### PR TITLE
fix: add a sharded task scheduler

### DIFF
--- a/backend/controller/scheduledtask/scheduledtask.go
+++ b/backend/controller/scheduledtask/scheduledtask.go
@@ -1,0 +1,174 @@
+// Package scheduledtask implements a task scheduler.
+package scheduledtask
+
+import (
+	"context"
+	"math/rand"
+	"reflect"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/alecthomas/atomic"
+	"github.com/jpillora/backoff"
+	"github.com/serialx/hashring"
+
+	"github.com/TBD54566975/ftl/backend/common/log"
+	"github.com/TBD54566975/ftl/backend/common/model"
+	"github.com/TBD54566975/ftl/backend/common/slices"
+	"github.com/TBD54566975/ftl/backend/controller/dal"
+)
+
+type descriptor struct {
+	next        time.Time
+	name        string
+	retry       backoff.Backoff
+	job         Job
+	singlyHomed bool
+}
+
+// A Job is a function that is scheduled to run periodically.
+//
+// The Job itself controls its schedule by returning the next time it should
+// run.
+type Job func(ctx context.Context) (time.Duration, error)
+
+// Scheduler is a task scheduler for the controller.
+//
+// Each job runs in its own goroutine.
+//
+// The scheduler uses a consistent hash ring to attempt to ensure that jobs are
+// only run on a single controller at a time. This is not guaranteed, however,
+// as the hash ring is only updated periodically and controllers may have
+// inconsistent views of the hash ring.
+type Scheduler struct {
+	getControllers func(ctx context.Context, all bool) ([]dal.Controller, error)
+	key            model.ControllerKey
+	jobs           chan *descriptor
+
+	hashring atomic.Value[*hashring.HashRing]
+}
+
+// New creates a new [Scheduler].
+func New(ctx context.Context, id model.ControllerKey, getControllers func(ctx context.Context, all bool) ([]dal.Controller, error)) *Scheduler {
+	s := &Scheduler{getControllers: getControllers, key: id, jobs: make(chan *descriptor)}
+	_ = s.updateHashring(ctx)
+	go s.syncHashRing(ctx)
+	go s.run(ctx)
+	return s
+}
+
+// Singleton schedules a job to attempt to run on only a single controller.
+//
+// This is not guaranteed, however, as controllers may have inconsistent views
+// of the hash ring.
+func (s *Scheduler) Singleton(retry backoff.Backoff, job Job) {
+	s.schedule(retry, job, true)
+}
+
+// Parallel schedules a job to run on every controller.
+func (s *Scheduler) Parallel(retry backoff.Backoff, job Job) {
+	s.schedule(retry, job, false)
+}
+
+func (s *Scheduler) schedule(retry backoff.Backoff, job Job, singlyHomed bool) {
+	name := runtime.FuncForPC(reflect.ValueOf(job).Pointer()).Name()
+	name = name[strings.LastIndex(name, ".")+1:]
+	name = strings.TrimSuffix(name, "-fm")
+	s.jobs <- &descriptor{
+		name:        name,
+		retry:       retry,
+		job:         job,
+		singlyHomed: singlyHomed,
+		next:        time.Now().Add(time.Millisecond * time.Duration(rand.Int63n(2000))), //nolint:gosec
+	}
+}
+
+func (s *Scheduler) run(ctx context.Context) {
+	logger := log.FromContext(ctx).Scope("cron")
+	// List of jobs to run.
+	// For singleton jobs running on a different host, this can include jobs
+	// scheduled in the past. These are skipped on each run.
+	jobs := []*descriptor{}
+	for {
+		next := time.Now().Add(time.Second)
+		// Find the next job to run.
+		if len(jobs) > 0 {
+			sort.Slice(jobs, func(i, j int) bool { return jobs[i].next.Before(jobs[j].next) })
+			for _, job := range jobs {
+				if job.next.IsZero() {
+					continue
+				}
+				next = job.next
+				break
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+
+		case <-time.After(time.Until(next)):
+			// Jobs to reschedule on the next run.
+			for i, job := range jobs {
+				if job.next.After(time.Now()) {
+					continue
+				}
+				job := job
+				hashring := s.hashring.Load()
+
+				// If the job is singly homed, check that we are the active controller.
+				if job.singlyHomed {
+					if node, ok := hashring.GetNode(job.name); !ok || node != s.key.String() {
+						job.next = time.Time{}
+						continue
+					}
+				}
+				jobs[i] = nil // Zero out scheduled jobs.
+				logger.Scope(job.name).Tracef("Running cron job")
+				go func() {
+					if delay, err := job.job(ctx); err != nil {
+						logger.Scope(job.name).Warnf("%s", err)
+						job.next = time.Now().Add(job.retry.Duration())
+					} else {
+						// Reschedule the job.
+						job.retry.Reset()
+						job.next = time.Now().Add(delay)
+					}
+					s.jobs <- job
+				}()
+			}
+			jobs = slices.Filter(jobs, func(job *descriptor) bool { return job != nil })
+
+		case job := <-s.jobs:
+			jobs = append(jobs, job)
+		}
+	}
+}
+
+// Synchronise the hash ring with the active controllers.
+func (s *Scheduler) syncHashRing(ctx context.Context) {
+	logger := log.FromContext(ctx).Scope("cron")
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case <-time.After(time.Second * 5):
+			if err := s.updateHashring(ctx); err != nil {
+				logger.Warnf("Failed to get controllers: %s", err)
+			}
+		}
+	}
+}
+
+func (s *Scheduler) updateHashring(ctx context.Context) error {
+	controllers, err := s.getControllers(ctx, false)
+	if err != nil {
+		return err
+	}
+	hashring := hashring.New(slices.Map(controllers, func(c dal.Controller) string { return c.Key.String() }))
+	s.hashring.Store(hashring)
+	return nil
+}

--- a/backend/controller/scheduledtask/scheduledtask_test.go
+++ b/backend/controller/scheduledtask/scheduledtask_test.go
@@ -1,0 +1,59 @@
+package scheduledtask
+
+import (
+	"context"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/alecthomas/assert/v2"
+	"github.com/jpillora/backoff"
+
+	"github.com/TBD54566975/ftl/backend/common/log"
+	"github.com/TBD54566975/ftl/backend/common/model"
+	"github.com/TBD54566975/ftl/backend/common/slices"
+	"github.com/TBD54566975/ftl/backend/controller/dal"
+)
+
+func TestCron(t *testing.T) {
+	t.Parallel()
+	ctx := log.ContextWithLogger(context.Background(), log.Configure(os.Stderr, log.Config{Level: log.Info}))
+	ctx, cancel := context.WithCancel(ctx)
+	t.Cleanup(cancel)
+
+	var singletonCount atomic.Int64
+	var multiCount atomic.Int64
+
+	type controller struct {
+		controller dal.Controller
+		cron       *Scheduler
+	}
+
+	controllers := []*controller{
+		{controller: dal.Controller{Key: model.NewControllerKey()}},
+		{controller: dal.Controller{Key: model.NewControllerKey()}},
+		{controller: dal.Controller{Key: model.NewControllerKey()}},
+		{controller: dal.Controller{Key: model.NewControllerKey()}},
+	}
+
+	for _, c := range controllers {
+		c := c
+		c.cron = New(ctx, c.controller.Key, func(ctx context.Context, all bool) ([]dal.Controller, error) {
+			return slices.Map(controllers, func(c *controller) dal.Controller { return c.controller }), nil
+		})
+		c.cron.Singleton(backoff.Backoff{}, func(ctx context.Context) (time.Duration, error) {
+			singletonCount.Add(1)
+			return time.Second, nil
+		})
+		c.cron.Parallel(backoff.Backoff{}, func(ctx context.Context) (time.Duration, error) {
+			multiCount.Add(1)
+			return time.Second, nil
+		})
+	}
+
+	time.Sleep(time.Second * 6)
+
+	assert.True(t, singletonCount.Load() >= 5 && singletonCount.Load() < 10, "expected singletonCount to be >= 5 but was %d", singletonCount.Load())
+	assert.True(t, multiCount.Load() >= 20 && multiCount.Load() < 30, "expected multiCount to be >= 20 but was %d", multiCount.Load())
+}

--- a/go.mod
+++ b/go.mod
@@ -101,6 +101,7 @@ require (
 	github.com/lib/pq v1.10.9 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
+	github.com/serialx/hashring v0.0.0-20200727003509-22c0c7ab6b1b
 	github.com/swaggest/refl v1.3.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.21.0 // indirect
 	golang.design/x/reflect v0.0.0-20220504060917-02c43be63f3b

--- a/go.sum
+++ b/go.sum
@@ -212,6 +212,8 @@ github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6Ng
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
 github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
+github.com/serialx/hashring v0.0.0-20200727003509-22c0c7ab6b1b h1:h+3JX2VoWTFuyQEo87pStk/a99dzIO1mM9KxIyLPGTU=
+github.com/serialx/hashring v0.0.0-20200727003509-22c0c7ab6b1b/go.mod h1:/yeG0My1xr/u+HZrFQ1tOQQQQrOawfyMUH13ai5brBc=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=


### PR DESCRIPTION
This ensures that for all tasks that require it, they will only run on a single controller, and will be distributed across the controllers.

This is implemented on top of a hash ring that is periodically synced from the registered controllers in the DB.