### PR TITLE
[started] close kafka consumer when runner exits

### DIFF
--- a/internal/integration/actions.go
+++ b/internal/integration/actions.go
@@ -24,6 +24,7 @@ import (
 	_ "github.com/jackc/pgx/v5/stdlib" // SQL driver
 	"github.com/kballard/go-shellquote"
 	"github.com/otiai10/copy"
+	"github.com/puzpuzpuz/xsync/v3"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/block/scaffolder"
@@ -304,6 +305,19 @@ func Sleep(duration time.Duration) Action {
 	return func(t testing.TB, ic TestContext) {
 		Infof("Sleeping for %s", duration)
 		time.Sleep(duration)
+	}
+}
+
+func WithoutRetries(action Action) Action {
+	attempted := xsync.NewCounter()
+	return func(t testing.TB, ic TestContext) {
+		attempted.Add(1)
+		if attempted.Value() > 1 {
+			// t.Fatal("action does not support retries")
+			panic("action does not support retries")
+		}
+		// assert.Equal(t, attempted.Value(), 1, "action does not support retries; see original attempt's failure")
+		action(t, ic)
 	}
 }
 

--- a/internal/integration/harness.go
+++ b/internal/integration/harness.go
@@ -45,7 +45,7 @@ import (
 
 const dumpPath = "/tmp/ftl-kube-report"
 
-var redPandaBrokers = []string{"127.0.0.1:19092"}
+var RedPandaBrokers = []string{"127.0.0.1:19092"}
 
 func (i TestContext) integrationTestTimeout() time.Duration {
 	timeout := optional.Zero(os.Getenv("FTL_INTEGRATION_TEST_TIMEOUT")).Default("5s")
@@ -415,7 +415,7 @@ func run(t *testing.T, actionsOrOptions ...ActionOrOption) {
 				err = exec.CommandWithEnv(ctx, log.Debug, rootDir, envars, "docker", "compose", "-f", "internal/dev/docker-compose.redpanda.yml", "-p", "ftl", "up", "-d", "--wait").RunBuffered(ctx)
 				assert.NoError(t, err)
 
-				client, err := sarama.NewClient(redPandaBrokers, sarama.NewConfig())
+				client, err := sarama.NewClient(RedPandaBrokers, sarama.NewConfig())
 				assert.NoError(t, err)
 				defer client.Close()
 


### PR DESCRIPTION
closes https://github.com/TBD54566975/ftl/issues/3473
- Added integration test to see if runner exits the consumer group when ending
- ... but we don't pass the test yet
- ... `ftl kill` is not currently killing runners.
- Adding a signal handler in consumer doesn't work, because other signal handler calls `os.Exit()` without giving enough time for consumer to fully close.