### PR TITLE
fix: stop readline eating exit messages

### DIFF
--- a/frontend/cli/cmd_dev.go
+++ b/frontend/cli/cmd_dev.go
@@ -54,7 +54,6 @@ func (d *devCmd) Run(
 	verbClient ftlv1connect.VerbServiceClient,
 ) error {
 	startTime := time.Now()
-	logger := log.FromContext(ctx)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	if len(d.Build.Dirs) == 0 {
@@ -145,7 +144,6 @@ func (d *devCmd) Run(
 
 	err = g.Wait()
 	if err != nil {
-		logger.Errorf(err, "error during dev")
 		return fmt.Errorf("error during dev: %w", err)
 	}
 	return nil

--- a/frontend/cli/cmd_serve.go
+++ b/frontend/cli/cmd_serve.go
@@ -128,7 +128,7 @@ func (s *serveCommonConfig) run(
 		_, err := controllerClient.Ping(ctx, connect.NewRequest(&ftlv1.PingRequest{}))
 		if err == nil {
 			// The controller is already running, bail out.
-			return fmt.Errorf("controller is already running")
+			return errors.New(ftlRunningErrorMsg)
 		}
 		if err := runInBackground(logger); err != nil {
 			return err
@@ -152,7 +152,7 @@ func (s *serveCommonConfig) run(
 	_, err := controllerClient.Ping(ctx, connect.NewRequest(&ftlv1.PingRequest{}))
 	if err == nil {
 		// The controller is already running, bail out.
-		return fmt.Errorf("controller is already running")
+		return errors.New(ftlRunningErrorMsg)
 	}
 	if s.Provisioners > 0 {
 		logger.Debugf("Starting FTL with %d controller(s) and %d provisioner(s)", s.Controllers, s.Provisioners)


### PR DESCRIPTION
The interactive console could eat error messages on exit