### PR TITLE
chore: temporarily disable rust proto generation

### DIFF
--- a/backend/protos/buf.gen.yaml
+++ b/backend/protos/buf.gen.yaml
@@ -16,7 +16,7 @@ plugins:
     out: ../../python-runtime/ftl/src/ftl/protos
     opt:
       - pyi_out=../../python-runtime/ftl/src/ftl/protos
-  - plugin: prost
-    out: ../../sqlc-gen-ftl/src/protos
-    opt:
-      - bytes=.
+#  - plugin: prost
+#    out: ../../sqlc-gen-ftl/src/protos
+#    opt:
+#      - bytes=.


### PR DESCRIPTION
This seems to be causing build stability issues.