### PR TITLE
fix: make protoc-gen-prost work

### DIFF
--- a/backend/protos/buf.gen.yaml
+++ b/backend/protos/buf.gen.yaml
@@ -16,7 +16,7 @@ plugins:
     out: ../../python-runtime/ftl/src/ftl/protos
     opt:
       - pyi_out=../../python-runtime/ftl/src/ftl/protos
-#  - plugin: prost
-#    out: ../../sqlc-gen-ftl/src/protos
-#    opt:
-#      - bytes=.
+  - plugin: prost
+    out: ../../sqlc-gen-ftl/src/protos
+    opt:
+      - bytes=.

--- a/scripts/protoc-gen-prost
+++ b/scripts/protoc-gen-prost
@@ -2,12 +2,23 @@
 set -euo pipefail
 
 if [ ! "${HERMIT_ENV:-}" ]; then
-    # shellcheck disable=SC1091
-    . "$(dirname "$(dirname "$0")")/bin/activate-hermit"
+  # shellcheck disable=SC1091
+  . "$(dirname "$(dirname "$0")")/bin/activate-hermit" > /dev/null 2>&1
 fi
 
+
+function flockexec() {
+  file="$1"
+  shift
+  if [ "$(uname)" = "Darwin" ]; then
+    lockf -t 120 "$file" "$@"
+  else
+    flock -w 120 "$file" "$@"
+  fi
+}
+
 # Ensure the binary exists, install if it doesn't
-mk "${HERMIT_ENV}/.hermit/rust/bin/protoc-gen-prost" : -- cargo install protoc-gen-prost
+flockexec /tmp/protoc-gen-prost.lock mk "${HERMIT_ENV}/.hermit/rust/bin/protoc-gen-prost" : -- cargo install protoc-gen-prost 1>&2
 
 # Execute the binary with any passed arguments
 exec "${HERMIT_ENV}/.hermit/rust/bin/protoc-gen-prost" "$@"

--- a/scripts/update-roadmap-issues
+++ b/scripts/update-roadmap-issues
@@ -1,7 +1,8 @@
 #!/bin/bash
+set -euo pipefail
 
-label="$1"
-issue_number="$2"
+label="${1:-}"
+issue_number="${2:-}"
 if [ -z "$label" ] || [ -z "$issue_number" ]; then
   echo "Error: Both label and issue number must be provided."
   echo "Usage: $0 <label> <issue_number>"
@@ -130,7 +131,7 @@ EOF
 }
 
 update_issue() {
-  if test -z "$NOOP"; then
+  if test -z "${NOOP:-}"; then
     gh issue edit -F - "$issue_number"
   else
     cat


### PR DESCRIPTION
1. Redirect stdout to stderr so we don't break the protoc plugin protocol
2. Use a file lock to avoid multiple concurrent invocations of protoc-gen-prost running cargo install many times