### PR TITLE
fix: improve help docs for config/secret --json flag

### DIFF
--- a/frontend/cli/cmd_config.go
+++ b/frontend/cli/cmd_config.go
@@ -98,7 +98,7 @@ func (s *configGetCmd) Run(ctx context.Context, adminClient admin.Client) error 
 }
 
 type configSetCmd struct {
-	JSON  bool              `help:"Assume input value is JSON."`
+	JSON  bool              `help:"Assume input value is JSON. Note: For string configs, the JSON value itself must be a string (e.g., '\"hello\"' or '\"{'key': 'value'}\"')."`
 	Ref   configuration.Ref `arg:"" help:"Configuration reference in the form [<module>.]<name>."`
 	Value *string           `arg:"" placeholder:"VALUE" help:"Configuration value (read from stdin if omitted)." optional:""`
 }

--- a/frontend/cli/cmd_secret.go
+++ b/frontend/cli/cmd_secret.go
@@ -89,8 +89,9 @@ func (s *secretGetCmd) Run(ctx context.Context, adminClient admin.Client) error 
 }
 
 type secretSetCmd struct {
-	JSON bool   `help:"Assume input value is JSON."`
-	Ref  cf.Ref `arg:"" help:"Secret reference in the form [<module>.]<name>."`
+	JSON  bool   `help:"Assume input value is JSON. Note: For string secrets, the JSON value itself must be a string (e.g., '\"hello\"' or '\"{'key': 'value'}\"')."`
+	Ref   cf.Ref `arg:"" help:"Secret reference in the form [<module>.]<name>."`
+	Value string `arg:"" placeholder:"VALUE" help:"Secret value (read from stdin if omitted)." optional:""`
 }
 
 func (s *secretSetCmd) Run(ctx context.Context, adminClient admin.Client) (err error) {


### PR DESCRIPTION
Fixes #3408

Adds more info to the `--json` flag for `ftl config/secret set` commands

```
Command flags:
  --json    Assume input value is JSON. Note: For string secrets, the JSON value
            itself must be a string (e.g., '"hello"' or '"{'key': 'value'}"').
```

and

```
Command flags:
  --json    Assume input value is JSON. Note: For string configs, the JSON value
            itself must be a string (e.g., '"hello"' or '"{'key': 'value'}"').
```