### PR TITLE
fix: wait for dev endpoint to be available before runner is ready

### DIFF
--- a/backend/runner/runner.go
+++ b/backend/runner/runner.go
@@ -397,6 +397,11 @@ func (s *Service) deploy(ctx context.Context, key model.DeploymentKey, module *s
 				logger.Errorf(err, "could not create FTL dev Config")
 			}
 		}
+		err = rpc.Wait(ctx, backoff.Backoff{}, time.Second*10, client)
+		if err != nil {
+			observability.Deployment.Failure(ctx, optional.Some(key.String()))
+			return fmt.Errorf("failed to ping dev endpoint: %w", err)
+		}
 	} else {
 		err := download.ArtefactsFromOCI(ctx, s.controllerClient, key, deploymentDir, s.storage)
 		if err != nil {


### PR DESCRIPTION
This became apparent when pubsub would immediately start trying to consume events once the runner claimed to be ready.