### PR TITLE
chore: drop some log messages to trace

### DIFF
--- a/backend/controller/controller.go
+++ b/backend/controller/controller.go
@@ -1111,7 +1111,7 @@ func (s *Service) watchModuleChanges(ctx context.Context, sendChange func(respon
 			return err
 		}
 	}
-	logger.Debugf("Seeded %d deployments", initialCount)
+	logger.Tracef("Seeded %d deployments", initialCount)
 
 	for {
 		select {

--- a/backend/provisioner/runner_scaling_provisioner.go
+++ b/backend/provisioner/runner_scaling_provisioner.go
@@ -75,7 +75,7 @@ func provisionRunner(scaling scaling.RunnerScaling) InMemResourceProvisionerFn {
 			if err == nil {
 				break
 			}
-			logger.Debugf("waiting for runner to be ready: %v", err)
+			logger.Tracef("waiting for runner to be ready: %v", err)
 			select {
 			case <-ctx.Done():
 				return nil, fmt.Errorf("context cancelled %w", ctx.Err())

--- a/internal/rpc/context.go
+++ b/internal/rpc/context.go
@@ -96,7 +96,7 @@ func requestKeyFromContextValue(value any) (optional.Option[model.RequestKey], e
 func DefaultClientOptions(level log.Level) []connect.ClientOption {
 	interceptors := []connect.Interceptor{
 		PanicInterceptor(),
-		MetadataInterceptor(log.Debug),
+		MetadataInterceptor(log.Trace),
 		connectOtelInterceptor(),
 		CustomOtelInterceptor(),
 	}

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -283,7 +283,7 @@ func RetryStreamingServerStream[Req, Resp any](
 	handler func(ctx context.Context, resp *Resp) error,
 	errorRetryCallback func(err error) bool,
 ) {
-	logLevel := log.Debug
+	logLevel := log.Trace
 	errored := false
 	logger := log.FromContext(ctx)
 	for {
@@ -298,7 +298,7 @@ func RetryStreamingServerStream[Req, Resp any](
 						break
 					}
 					if errored {
-						logger.Debugf("Server stream recovered")
+						logger.Tracef("Server stream recovered")
 						errored = false
 					}
 					select {
@@ -351,7 +351,7 @@ func RetryStreamingServerStream[Req, Resp any](
 // logLevelForError indicates the log.Level to use for the specified error
 func logLevelForError(err error) log.Level {
 	if err != nil && errors.Is(err, syscall.ECONNREFUSED) {
-		return log.Debug
+		return log.Trace
 	}
 	return log.Warn
 }

--- a/internal/schema/schemaeventsource/schemaeventsource.go
+++ b/internal/schema/schemaeventsource/schemaeventsource.go
@@ -204,7 +204,7 @@ func New(ctx context.Context, client ftlv1connect.SchemaServiceClient) EventSour
 			out.Publish(event)
 
 		case ftlv1.DeploymentChangeType_DEPLOYMENT_CHANGE_TYPE_ADDED, ftlv1.DeploymentChangeType_DEPLOYMENT_CHANGE_TYPE_CHANGED:
-			logger.Debugf("Module %s upserted", sch.Name)
+			logger.Tracef("Module %s upserted", sch.Name)
 			event := EventUpsert{
 				Deployment: someDeploymentKey,
 				Module:     sch,

--- a/jvm-runtime/plugin/common/jvmcommon.go
+++ b/jvm-runtime/plugin/common/jvmcommon.go
@@ -89,7 +89,6 @@ func New(scaffoldFiles *zip.Reader) *Service {
 }
 
 func (s *Service) Ping(ctx context.Context, req *connect.Request[ftlv1.PingRequest]) (*connect.Response[ftlv1.PingResponse], error) {
-	log.FromContext(ctx).Debugf("Received Ping")
 	return connect.NewResponse(&ftlv1.PingResponse{}), nil
 }
 


### PR DESCRIPTION
This drops the level of some of the most noisy / less informative debug messages to trace.