### PR TITLE
fix: close consumer group

### DIFF
--- a/backend/runner/pubsub/consumer.go
+++ b/backend/runner/pubsub/consumer.go
@@ -126,6 +126,7 @@ func (c *consumer) subscribe(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			c.group.Close()
 			return
 		default:
 		}

--- a/backend/runner/pubsub/testdata/go/publisher/publisher.go
+++ b/backend/runner/pubsub/testdata/go/publisher/publisher.go
@@ -8,6 +8,11 @@ import (
 	// Import the FTL SDK.
 )
 
+type PubSubEvent struct {
+	Time     time.Time
+	Haystack string
+}
+
 type PartitionMapper struct{}
 
 var _ ftl.TopicPartitionMap[PubSubEvent] = PartitionMapper{}
@@ -21,10 +26,8 @@ type TestTopic = ftl.TopicHandle[PubSubEvent, PartitionMapper]
 
 type LocalTopic = ftl.TopicHandle[PubSubEvent, PartitionMapper]
 
-type PubSubEvent struct {
-	Time     time.Time
-	Haystack string
-}
+//ftl:export
+type SlowTopic = ftl.TopicHandle[PubSubEvent, PartitionMapper]
 
 //ftl:verb
 func PublishTen(ctx context.Context, topic TestTopic) error {
@@ -86,4 +89,14 @@ func PublishOneToTopic2(ctx context.Context, req PublishOneToTopic2Request, topi
 func Local(ctx context.Context, event PubSubEvent) error {
 	ftl.LoggerFromContext(ctx).Infof("Consume local: %v", event.Time)
 	return nil
+}
+
+//ftl:verb
+func PublishSlow(ctx context.Context, topic SlowTopic) error {
+	logger := ftl.LoggerFromContext(ctx)
+	t := time.Now()
+	logger.Infof("Publishing to slowTopic: %v", t)
+	return topic.Publish(ctx, PubSubEvent{
+		Time: t,
+	})
 }

--- a/backend/runner/pubsub/testdata/go/publisher/types.ftl.go
+++ b/backend/runner/pubsub/testdata/go/publisher/types.ftl.go
@@ -2,10 +2,10 @@
 package publisher
 
 import (
-	"context"
-	"github.com/block/ftl/common/reflection"
-	"github.com/block/ftl/go-runtime/ftl"
-	"github.com/block/ftl/go-runtime/server"
+    "context"
+    "github.com/block/ftl/common/reflection"
+    "github.com/block/ftl/go-runtime/ftl"
+    "github.com/block/ftl/go-runtime/server"
 )
 
 type LocalClient func(context.Context, PubSubEvent) error
@@ -14,6 +14,8 @@ type PublishOneClient func(context.Context) error
 
 type PublishOneToTopic2Client func(context.Context, PublishOneToTopic2Request) error
 
+type PublishSlowClient func(context.Context) error
+
 type PublishTenClient func(context.Context) error
 
 type PublishTenLocalClient func(context.Context) error
@@ -21,22 +23,26 @@ type PublishTenLocalClient func(context.Context) error
 func init() {
 	reflection.Register(
 		reflection.ProvideResourcesForVerb(
-			Local,
+            Local,
 		),
 		reflection.ProvideResourcesForVerb(
-			PublishOne,
+            PublishOne,
 			server.TopicHandle[PubSubEvent, PartitionMapper]("publisher", "testTopic"),
 		),
 		reflection.ProvideResourcesForVerb(
-			PublishOneToTopic2,
+            PublishOneToTopic2,
 			server.TopicHandle[PubSubEvent, ftl.SinglePartitionMap[PubSubEvent]]("publisher", "topic2"),
 		),
 		reflection.ProvideResourcesForVerb(
-			PublishTen,
+            PublishSlow,
+			server.TopicHandle[PubSubEvent, PartitionMapper]("publisher", "slowTopic"),
+		),
+		reflection.ProvideResourcesForVerb(
+            PublishTen,
 			server.TopicHandle[PubSubEvent, PartitionMapper]("publisher", "testTopic"),
 		),
 		reflection.ProvideResourcesForVerb(
-			PublishTenLocal,
+            PublishTenLocal,
 			server.TopicHandle[PubSubEvent, PartitionMapper]("publisher", "localTopic"),
 		),
 	)

--- a/backend/runner/pubsub/testdata/go/subscriber/subscriber.go
+++ b/backend/runner/pubsub/testdata/go/subscriber/subscriber.go
@@ -3,6 +3,7 @@ package subscriber
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"ftl/publisher"
@@ -37,4 +38,17 @@ func PublishToExternalModule(ctx context.Context) error {
 	// Get around compile-time checks
 	externalTopic := ftl.TopicHandle[publisher.PubSubEvent, ftl.SinglePartitionMap[publisher.PubSubEvent]]{Ref: reflection.Ref{Module: "publisher", Name: "testTopic"}.ToSchema()}
 	return externalTopic.Publish(ctx, publisher.PubSubEvent{Time: time.Now()})
+}
+
+//ftl:verb
+//ftl:subscribe publisher.slowTopic from=beginning
+func ConsumeSlow(ctx context.Context, req publisher.PubSubEvent) error {
+	versionDescription := "This deployment is TheFirstDeployment"
+	if strings.Contains(versionDescription, "TheFirstDeployment") {
+		ftl.LoggerFromContext(ctx).Infof("ConsumeSlow first deployment (will sleep 5s): %v", req.Time)
+		time.Sleep(5 * time.Second)
+		return nil
+	}
+	ftl.LoggerFromContext(ctx).Infof("ConsumeSlow second deployment (immediate): %v", req.Time)
+	return nil
 }

--- a/backend/runner/pubsub/testdata/go/subscriber/types.ftl.go
+++ b/backend/runner/pubsub/testdata/go/subscriber/types.ftl.go
@@ -13,6 +13,8 @@ type ConsumeButFailAndRetryClient func(context.Context, ftlpublisher.PubSubEvent
 
 type ConsumeFromLatestClient func(context.Context, ftlpublisher.PubSubEvent) error
 
+type ConsumeSlowClient func(context.Context, ftlpublisher.PubSubEvent) error
+
 type PublishToExternalModuleClient func(context.Context) error
 
 func init() {
@@ -25,6 +27,9 @@ func init() {
 		),
 		reflection.ProvideResourcesForVerb(
 			ConsumeFromLatest,
+		),
+		reflection.ProvideResourcesForVerb(
+			ConsumeSlow,
 		),
 		reflection.ProvideResourcesForVerb(
 			PublishToExternalModule,

--- a/internal/integration/harness.go
+++ b/internal/integration/harness.go
@@ -45,7 +45,7 @@ import (
 
 const dumpPath = "/tmp/ftl-kube-report"
 
-var redPandaBrokers = []string{"127.0.0.1:19092"}
+var RedPandaBrokers = []string{"127.0.0.1:19092"}
 
 func (i TestContext) integrationTestTimeout() time.Duration {
 	timeout := optional.Zero(os.Getenv("FTL_INTEGRATION_TEST_TIMEOUT")).Default("5s")
@@ -415,7 +415,7 @@ func run(t *testing.T, actionsOrOptions ...ActionOrOption) {
 				err = exec.CommandWithEnv(ctx, log.Debug, rootDir, envars, "docker", "compose", "-f", "internal/dev/docker-compose.redpanda.yml", "-p", "ftl", "up", "-d", "--wait").RunBuffered(ctx)
 				assert.NoError(t, err)
 
-				client, err := sarama.NewClient(redPandaBrokers, sarama.NewConfig())
+				client, err := sarama.NewClient(RedPandaBrokers, sarama.NewConfig())
 				assert.NoError(t, err)
 				defer client.Close()
 


### PR DESCRIPTION
closes https://github.com/block/ftl/issues/3472
- Rebalance after old deployment is killed is faster
- Added integration test that checks to make sure slow consumers are not affected by rebalances (the call will fail due to rebalance and then try again after rebalance)