### PR TITLE
fix: handle refs without module

### DIFF
--- a/common/schema/typeresolver_test.go
+++ b/common/schema/typeresolver_test.go
@@ -34,7 +34,7 @@ func TestTypeResolver(t *testing.T) {
 	err = scopes.Add(optional.None[*Module](), otherModule.Name, otherModule)
 	assert.NoError(t, err)
 
-	// Resolving "HTTPRequest" should return builtin.HttpRequest
+	// Resolving "HttpRequest" should return builtin.HttpRequest
 	httpRequest := scopes.Resolve(Ref{Name: "HttpRequest"})
 	assert.Equal(t, httpRequest.Module.MustGet().Name, "builtin")
 
@@ -42,11 +42,11 @@ func TestTypeResolver(t *testing.T) {
 	scopes = scopes.Push()
 	assert.NoError(t, scopes.AddModuleDecls(module))
 
-	// Resolving "HTTPRequest" should return test.HttpRequest now that we've pushed the new scope
+	// Resolving "HttpRequest" should return test.HttpRequest now that we've pushed the new scope
 	httpRequest = scopes.Resolve(Ref{Name: "HttpRequest"})
 	assert.Equal(t, httpRequest.Module.MustGet().Name, "test")
 
-	// Resolving "external" should fail
+	// Resolving "External" should fail
 	external := scopes.Resolve(Ref{Name: "External"})
 	assert.Equal(t, external, nil)
 

--- a/common/schema/typeresolver_test.go
+++ b/common/schema/typeresolver_test.go
@@ -14,12 +14,41 @@ func TestTypeResolver(t *testing.T) {
 				t T
 			}
 			verb test(test.Request<String>) Empty
+
+			// This module has it's own definition of HttpRequest
+			data HttpRequest {
+			}
+		}
+	`)
+	assert.NoError(t, err)
+	otherModule, err := ParseModuleString("", `
+		module other {
+			data External {
+			}
 		}
 	`)
 	assert.NoError(t, err)
 	scopes := NewScopes()
 	err = scopes.Add(optional.None[*Module](), module.Name, module)
 	assert.NoError(t, err)
+	err = scopes.Add(optional.None[*Module](), otherModule.Name, otherModule)
+	assert.NoError(t, err)
+
+	// Resolving "HTTPRequest" should return builtin.HttpRequest
+	httpRequest := scopes.Resolve(Ref{Name: "HttpRequest"})
+	assert.Equal(t, httpRequest.Module.MustGet().Name, "builtin")
+
+	// Push a new scope for "test" module's decls
+	scopes = scopes.Push()
+	assert.NoError(t, scopes.AddModuleDecls(module))
+
+	// Resolving "HTTPRequest" should return test.HttpRequest now that we've pushed the new scope
+	httpRequest = scopes.Resolve(Ref{Name: "HttpRequest"})
+	assert.Equal(t, httpRequest.Module.MustGet().Name, "test")
+
+	// Resolving "external" should fail
+	external := scopes.Resolve(Ref{Name: "External"})
+	assert.Equal(t, external, nil)
 
 	// Resolve a builtin.
 	actualInt, _ := ResolveAs[*Int](scopes, Ref{Name: "Int"})

--- a/common/schema/validate_test.go
+++ b/common/schema/validate_test.go
@@ -104,8 +104,8 @@ func TestValidate(t *testing.T) {
 				}
 			`,
 			errs: []string{
-				"3:20: ingress verb a: request type Empty must be builtin.HttpRequest",
-				"3:27: ingress verb a: response type Empty must be builtin.HttpResponse",
+				"3:20: ingress verb a: request type builtin.Empty must be builtin.HttpRequest",
+				"3:27: ingress verb a: response type builtin.Empty must be builtin.HttpResponse",
 			}},
 		{name: "IngressBodyTypes",
 			schema: `
@@ -136,8 +136,8 @@ func TestValidate(t *testing.T) {
 				}
 			`,
 			errs: []string{
-				"11:22: ingress verb any: GET request type HttpRequest<Any, Unit, Unit> must have a body of unit not Any",
-				"11:52: ingress verb any: response type HttpResponse<Any, Any> must have a body of bytes, string, data structure, unit, float, int, bool, map, or array not Any",
+				"11:22: ingress verb any: GET request type builtin.HttpRequest<Any, Unit, Unit> must have a body of unit not Any",
+				"11:52: ingress verb any: response type builtin.HttpResponse<Any, Any> must have a body of bytes, string, data structure, unit, float, int, bool, map, or array not Any",
 				"16:31: ingress verb pathInvalid: cannot use path parameter \"invalid\" with request type String as it has multiple path parameters, expected Data or Map type",
 				"16:41: ingress verb pathInvalid: cannot use path parameter \"extra\" with request type String as it has multiple path parameters, expected Data or Map type",
 				"18:31: ingress verb pathMissing: request pathParameter type one.Path does not contain a field corresponding to the parameter \"missing\"",
@@ -152,7 +152,7 @@ func TestValidate(t *testing.T) {
 				}
 			`,
 			errs: []string{
-				"3:24: ingress verb bytes: GET request type HttpRequest<Bytes, Unit, Unit> must have a body of unit not Bytes",
+				"3:24: ingress verb bytes: GET request type builtin.HttpRequest<Bytes, Unit, Unit> must have a body of unit not Bytes",
 			}},
 		{name: "Array",
 			schema: `
@@ -222,8 +222,8 @@ func TestValidate(t *testing.T) {
 				}
 			`,
 			errs: []string{
-				`4:21: duplicate config "FTL_ENDPOINT", first defined at 3:20`,
-				`5:21: duplicate config "FTL_ENDPOINT", first defined at 3:20`,
+				`4:21: duplicate declaration of "FTL_ENDPOINT" at 3:20`,
+				`5:21: duplicate declaration of "FTL_ENDPOINT" at 3:20`,
 			},
 		},
 		{name: "DuplicateSecrets",
@@ -235,17 +235,9 @@ func TestValidate(t *testing.T) {
 				}
 			`,
 			errs: []string{
-				`4:6: duplicate secret "MY_SECRET", first defined at 3:6`,
-				`5:6: duplicate secret "MY_SECRET", first defined at 3:6`,
+				`4:6: duplicate declaration of "MY_SECRET" at 3:6`,
+				`5:6: duplicate declaration of "MY_SECRET" at 3:6`,
 			},
-		},
-		{name: "ConfigAndSecretsWithSameName",
-			schema: `
-				module one {
-					config FTL_ENDPOINT String
-					secret FTL_ENDPOINT String
-				}
-			`,
 		},
 		{name: "DuplicateDatabases",
 			schema: `
@@ -255,7 +247,7 @@ func TestValidate(t *testing.T) {
 				}
 			`,
 			errs: []string{
-				`4:6: duplicate database "MY_DB", first defined at 3:6`,
+				`4:6: duplicate declaration of "MY_DB" at 3:6`,
 			},
 		},
 		{name: "ValueEnumMismatchedVariantTypes",


### PR DESCRIPTION
See this PR instead: https://github.com/block/ftl/pull/3829



closes https://github.com/block/ftl/issues/3526
- When validating a module, push all module decls into scopes
    - This allows refs without a module value to match local decls (like how `builtins` decls work)
- Any decls with the same name are no longer allowed
    - We previously checked for decl name clashes only within the same type
    - If we allow name clashes then refs can't uniquely refer to those nodes
    - We previously had a test to allow configs and secrets with the same name, but that sounds like a mistake waiting to happen (setting a secret as a config means we won't treat it securely)
- Centralise Ref normalisation: Validation visits child nodes before validating parent nodes, removing the need for parent nodes to handle refs without a module value