### PR TITLE
chore: use mvn clean install for JVM build

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -136,7 +136,7 @@ build-backend-tests:
   go test -run ^NONE -tags integration,infrastructure ./... > /dev/null
 
 build-jvm *args:
-  @mk {{JVM_RUNTIME_OUT}} : {{JVM_RUNTIME_IN}} -- mvn -f jvm-runtime/ftl-runtime install {{args}}
+  @mk {{JVM_RUNTIME_OUT}} : {{JVM_RUNTIME_IN}} -- mvn -f jvm-runtime/ftl-runtime clean install {{args}}
 
 # Builds all language plugins
 build-language-plugins: build-zips build-protos


### PR DESCRIPTION
Running the clean means that the clean plugin will be downloaded and cached, which should help with the rate limiting we are seeing.