### PR TITLE
chore: eventview implementation on top of raft

### DIFF
--- a/internal/raft/eventview.go
+++ b/internal/raft/eventview.go
@@ -1,0 +1,96 @@
+package raft
+
+import (
+	"context"
+	"encoding"
+	"fmt"
+	"io"
+
+	"github.com/block/ftl/internal/eventstream"
+)
+
+type UnitQuery struct{}
+
+type RaftStreamEvent[View encoding.BinaryMarshaler, VPtr Unmarshallable[View]] interface {
+	encoding.BinaryMarshaler
+	eventstream.Event[View]
+}
+
+type RaftEventView[V encoding.BinaryMarshaler, VPrt Unmarshallable[V], E RaftStreamEvent[V, VPrt]] struct {
+	shard *ShardHandle[E, UnitQuery, V]
+}
+
+func (s *RaftEventView[V, VPrt, E]) Publish(ctx context.Context, event E) error {
+	return s.shard.Propose(ctx, event)
+}
+
+func (s *RaftEventView[V, VPrt, E]) View(ctx context.Context) (V, error) {
+	var zero V
+
+	view, err := s.shard.Query(ctx, UnitQuery{})
+	if err != nil {
+		return zero, err
+	}
+
+	return view, nil
+}
+
+type eventStreamStateMachine[
+	V encoding.BinaryMarshaler,
+	VPrt Unmarshallable[V],
+	E RaftStreamEvent[V, VPrt],
+	EPtr Unmarshallable[E],
+] struct {
+	view V
+}
+
+func (s *eventStreamStateMachine[V, VPrt, E, EPtr]) Close() error {
+	return nil
+}
+
+func (s *eventStreamStateMachine[V, VPrt, E, EPtr]) Lookup(key UnitQuery) (V, error) {
+	return s.view, nil
+}
+
+func (s *eventStreamStateMachine[V, VPrt, E, EPtr]) Update(msg E) error {
+	v, err := msg.Handle(s.view)
+	if err != nil {
+		return fmt.Errorf("failed to handle event: %w", err)
+	}
+	s.view = v
+	return nil
+}
+
+func (s *eventStreamStateMachine[V, VPrt, E, EPtr]) Save(writer io.Writer) error {
+	bytes, err := s.view.MarshalBinary()
+	if err != nil {
+		return fmt.Errorf("failed to marshal view: %w", err)
+	}
+	_, err = writer.Write(bytes)
+	if err != nil {
+		return fmt.Errorf("failed to write view: %w", err)
+	}
+	return nil
+}
+
+func (s *eventStreamStateMachine[V, VPrt, E, EPtr]) Recover(reader io.Reader) error {
+	bytes, err := io.ReadAll(reader)
+	if err != nil {
+		return fmt.Errorf("failed to read view: %w", err)
+	}
+	if err := (VPrt)(&s.view).UnmarshalBinary(bytes); err != nil {
+		return fmt.Errorf("failed to unmarshal view: %w", err)
+	}
+	return nil
+}
+
+func NewRaftEventStream[
+	V encoding.BinaryMarshaler,
+	VPtr Unmarshallable[V],
+	E RaftStreamEvent[V, VPtr],
+	EPtr Unmarshallable[E],
+](ctx context.Context, cluster *Cluster, shardID uint64) eventstream.EventView[V, E] {
+	sm := &eventStreamStateMachine[V, VPtr, E, EPtr]{}
+	shard := AddShard[UnitQuery, V, E, EPtr](ctx, cluster, shardID, sm)
+	return &RaftEventView[V, VPtr, E]{shard: shard}
+}

--- a/internal/raft/eventview_test.go
+++ b/internal/raft/eventview_test.go
@@ -1,0 +1,71 @@
+package raft_test
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"github.com/alecthomas/assert/v2"
+	"github.com/block/ftl/internal/raft"
+	"golang.org/x/sync/errgroup"
+)
+
+type IntStreamEvent struct {
+	Value int
+}
+
+func (e IntStreamEvent) Handle(view IntSumView) (IntSumView, error) {
+	return IntSumView{Sum: view.Sum + e.Value}, nil
+}
+
+func (e IntStreamEvent) MarshalBinary() ([]byte, error) {
+	return binary.BigEndian.AppendUint64([]byte{}, uint64(e.Value)), nil
+}
+
+func (e *IntStreamEvent) UnmarshalBinary(data []byte) error {
+	e.Value = int(binary.BigEndian.Uint64(data))
+	return nil
+}
+
+type IntSumView struct {
+	Sum int
+}
+
+func (v IntSumView) MarshalBinary() ([]byte, error) {
+	return binary.BigEndian.AppendUint64([]byte{}, uint64(v.Sum)), nil
+}
+
+func (v *IntSumView) UnmarshalBinary(data []byte) error {
+	v.Sum = int(binary.BigEndian.Uint64(data))
+	return nil
+}
+
+func TestEventStream(t *testing.T) {
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(60*time.Second))
+	defer cancel()
+
+	members := []string{"localhost:51001", "localhost:51002"}
+
+	cluster1 := testCluster(t, members, 1, members[0])
+	stream1 := raft.NewRaftEventStream[IntSumView, *IntSumView, IntStreamEvent](ctx, cluster1, 1)
+	cluster2 := testCluster(t, members, 2, members[1])
+	stream2 := raft.NewRaftEventStream[IntSumView, *IntSumView, IntStreamEvent](ctx, cluster2, 1)
+
+	eg, wctx := errgroup.WithContext(ctx)
+	eg.Go(func() error { return cluster1.Start(wctx) })
+	eg.Go(func() error { return cluster2.Start(wctx) })
+	assert.NoError(t, eg.Wait())
+	defer cluster1.Stop()
+	defer cluster2.Stop()
+
+	assert.NoError(t, stream1.Publish(ctx, IntStreamEvent{Value: 1}))
+
+	view, err := stream1.View(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, IntSumView{Sum: 1}, view)
+
+	view, err = stream2.View(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, IntSumView{Sum: 1}, view)
+}


### PR DESCRIPTION
Implements the View part of EventStream on top of Raft.

Subscribing to events is not supported, as Raft protocol is not designed for that.

We should add notifications on view changes to the API as a followup, though.