### PR TITLE
fix: runtime language was not being set in controller state

### DIFF
--- a/backend/controller/state/deployments.go
+++ b/backend/controller/state/deployments.go
@@ -69,6 +69,7 @@ func (r *DeploymentCreatedEvent) Handle(t State) (State, error) {
 		Schema:    r.Schema,
 		Module:    r.Module,
 		Artefacts: map[string]*DeploymentArtefact{},
+		Language:  r.Language,
 	}
 	for _, a := range r.Artefacts {
 		n.Artefacts[a.Digest.String()] = &DeploymentArtefact{


### PR DESCRIPTION
I noticed the console wasn't showing the runtime language for the deployment state.

BEFORE:
![Screenshot 2024-12-19 at 11 25 46 AM](https://github.com/user-attachments/assets/c899d862-b650-4fe6-b313-b3f74f94dea7)

AFTER:
![Screenshot 2024-12-19 at 11 25 05 AM](https://github.com/user-attachments/assets/8fa194f6-1393-4a11-987b-f1c6edc9d26f)
