### PR TITLE
refactor: simplify the common case of ranging over a channel w/ cancellation

### DIFF
--- a/backend/controller/deployment_logs.go
+++ b/backend/controller/deployment_logs.go
@@ -3,11 +3,11 @@ package controller
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/alecthomas/types/optional"
 
 	"github.com/block/ftl/backend/timeline"
+	"github.com/block/ftl/internal/channels"
 	"github.com/block/ftl/internal/log"
 	"github.com/block/ftl/internal/model"
 )
@@ -41,46 +41,40 @@ func (d *deploymentLogsSink) Log(entry log.Entry) error {
 }
 
 func (d *deploymentLogsSink) processLogs(ctx context.Context, timelineClient *timeline.Client) {
-	for {
-		select {
-		case entry := <-d.logQueue:
-			var deployment model.DeploymentKey
-			depStr, ok := entry.Attributes["deployment"]
-			if !ok {
-				continue
-			}
-
-			dep, err := model.ParseDeploymentKey(depStr)
-			if err != nil {
-				continue
-			}
-			deployment = dep
-
-			var request optional.Option[model.RequestKey]
-			if reqStr, ok := entry.Attributes["request"]; ok {
-				req, err := model.ParseRequestKey(reqStr)
-				if err == nil {
-					request = optional.Some(req)
-				}
-			}
-
-			var errorStr optional.Option[string]
-			if entry.Error != nil {
-				errorStr = optional.Some(entry.Error.Error())
-			}
-
-			timelineClient.Publish(ctx, &timeline.Log{
-				RequestKey:    request,
-				DeploymentKey: deployment,
-				Time:          entry.Time,
-				Level:         int32(entry.Level.Severity()),
-				Attributes:    entry.Attributes,
-				Message:       entry.Message,
-				Error:         errorStr,
-			})
-		case <-ctx.Done():
-			return
-		case <-time.After(1 * time.Second):
+	for entry := range channels.IterContext(ctx, d.logQueue) {
+		var deployment model.DeploymentKey
+		depStr, ok := entry.Attributes["deployment"]
+		if !ok {
+			continue
 		}
+
+		dep, err := model.ParseDeploymentKey(depStr)
+		if err != nil {
+			continue
+		}
+		deployment = dep
+
+		var request optional.Option[model.RequestKey]
+		if reqStr, ok := entry.Attributes["request"]; ok {
+			req, err := model.ParseRequestKey(reqStr)
+			if err == nil {
+				request = optional.Some(req)
+			}
+		}
+
+		var errorStr optional.Option[string]
+		if entry.Error != nil {
+			errorStr = optional.Some(entry.Error.Error())
+		}
+
+		timelineClient.Publish(ctx, &timeline.Log{
+			RequestKey:    request,
+			DeploymentKey: deployment,
+			Time:          entry.Time,
+			Level:         int32(entry.Level.Severity()),
+			Attributes:    entry.Attributes,
+			Message:       entry.Message,
+			Error:         errorStr,
+		})
 	}
 }

--- a/go-runtime/ftl/ftltest/pubsub.go
+++ b/go-runtime/ftl/ftltest/pubsub.go
@@ -14,6 +14,7 @@ import (
 	"github.com/block/ftl/common/schema"
 	"github.com/block/ftl/common/slices"
 	"github.com/block/ftl/go-runtime/ftl"
+	"github.com/block/ftl/internal/channels"
 	"github.com/block/ftl/internal/log"
 )
 
@@ -95,13 +96,8 @@ func (f *fakePubSub) watchPubSub(ctx context.Context) {
 	f.globalTopic.Subscribe(events)
 	go func() {
 		defer f.globalTopic.Unsubscribe(events)
-		for {
-			select {
-			case e := <-events:
-				f.handlePubSubEvent(ctx, e)
-			case <-ctx.Done():
-				return
-			}
+		for e := range channels.IterContext(ctx, events) {
+			f.handlePubSubEvent(ctx, e)
 		}
 	}()
 }

--- a/internal/buildengine/terminal.go
+++ b/internal/buildengine/terminal.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/alecthomas/types/pubsub"
 
+	"github.com/block/ftl/internal/channels"
 	"github.com/block/ftl/internal/terminal"
 )
 
@@ -14,36 +15,31 @@ func updateTerminalWithEngineEvents(ctx context.Context, topic *pubsub.Topic[Eng
 
 	go func() {
 		defer topic.Unsubscribe(events)
-		for {
-			select {
-			case event := <-events:
-				switch event := event.(type) {
-				case EngineStarted:
-				case EngineEnded:
+		for event := range channels.IterContext(ctx, events) {
+			switch event := event.(type) {
+			case EngineStarted:
+			case EngineEnded:
 
-				case ModuleAdded:
-					terminal.UpdateModuleState(ctx, event.Module, terminal.BuildStateWaiting)
-				case ModuleRemoved:
-					terminal.UpdateModuleState(ctx, event.Module, terminal.BuildStateTerminated)
+			case ModuleAdded:
+				terminal.UpdateModuleState(ctx, event.Module, terminal.BuildStateWaiting)
+			case ModuleRemoved:
+				terminal.UpdateModuleState(ctx, event.Module, terminal.BuildStateTerminated)
 
-				case ModuleBuildWaiting:
-					terminal.UpdateModuleState(ctx, event.Config.Module, terminal.BuildStateWaiting)
-				case ModuleBuildStarted:
-					terminal.UpdateModuleState(ctx, event.Config.Module, terminal.BuildStateBuilding)
-				case ModuleBuildSuccess:
-					terminal.UpdateModuleState(ctx, event.Config.Module, terminal.BuildStateBuilt)
-				case ModuleBuildFailed:
-					terminal.UpdateModuleState(ctx, event.Config.Module, terminal.BuildStateFailed)
+			case ModuleBuildWaiting:
+				terminal.UpdateModuleState(ctx, event.Config.Module, terminal.BuildStateWaiting)
+			case ModuleBuildStarted:
+				terminal.UpdateModuleState(ctx, event.Config.Module, terminal.BuildStateBuilding)
+			case ModuleBuildSuccess:
+				terminal.UpdateModuleState(ctx, event.Config.Module, terminal.BuildStateBuilt)
+			case ModuleBuildFailed:
+				terminal.UpdateModuleState(ctx, event.Config.Module, terminal.BuildStateFailed)
 
-				case ModuleDeployStarted:
-					terminal.UpdateModuleState(ctx, event.Module, terminal.BuildStateDeploying)
-				case ModuleDeploySuccess:
-					terminal.UpdateModuleState(ctx, event.Module, terminal.BuildStateDeployed)
-				case ModuleDeployFailed:
-					terminal.UpdateModuleState(ctx, event.Module, terminal.BuildStateFailed)
-				}
-			case <-ctx.Done():
-				return
+			case ModuleDeployStarted:
+				terminal.UpdateModuleState(ctx, event.Module, terminal.BuildStateDeploying)
+			case ModuleDeploySuccess:
+				terminal.UpdateModuleState(ctx, event.Module, terminal.BuildStateDeployed)
+			case ModuleDeployFailed:
+				terminal.UpdateModuleState(ctx, event.Module, terminal.BuildStateFailed)
 			}
 		}
 	}()

--- a/internal/channels/itercontext.go
+++ b/internal/channels/itercontext.go
@@ -1,0 +1,27 @@
+package channels
+
+import (
+	"context"
+	"iter"
+)
+
+// IterContext returns an iterator that iterates over the channel until the channel is closed or the context cancelled.
+//
+// Check ctx.Err() != nil to detect if the context was cancelled.
+func IterContext[T any](ctx context.Context, ch <-chan T) iter.Seq[T] {
+	return func(yield func(T) bool) {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case v, ok := <-ch:
+				if !ok {
+					return
+				}
+				if !yield(v) {
+					return
+				}
+			}
+		}
+	}
+}

--- a/internal/routing/verb_routing.go
+++ b/internal/routing/verb_routing.go
@@ -15,6 +15,7 @@ import (
 	"github.com/block/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
 	"github.com/block/ftl/backend/timeline"
 	"github.com/block/ftl/common/schema"
+	"github.com/block/ftl/internal/channels"
 	"github.com/block/ftl/internal/log"
 	"github.com/block/ftl/internal/model"
 	"github.com/block/ftl/internal/rpc"
@@ -90,13 +91,8 @@ func NewVerbRouterFromTable(ctx context.Context, routeTable *RouteTable, timelin
 	}
 	routeUpdates := svc.routingTable.Subscribe()
 	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case module := <-routeUpdates:
-				svc.moduleClients.Delete(module)
-			}
+		for module := range channels.IterContext(ctx, routeUpdates) {
+			svc.moduleClients.Delete(module)
 		}
 	}()
 	return svc


### PR DESCRIPTION
Simplifies this:

```go
for {
  select {
    case <-ctx.Done():
      return
    case msg := <-events:
      // DO STUFF
  }
}
```

To this:

```go
for msg := range channels.IterContext(ctx, events) {
  // DO STUFF
}
```