### PR TITLE
refactor: move go2proto configuration from flags to comment directives

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -111,7 +111,7 @@ build-generate:
 
 # Generate testdata for go2proto. This should be run after any changes to go2proto.
 build-go2proto-testdata:
-  @mk cmd/go2proto/testdata/go2proto.to.go cmd/go2proto/testdata/testdatapb/model.proto : cmd/go2proto/*.go cmd/go2proto/testdata/model.go -- go2proto -m -o ./cmd/go2proto/testdata/testdatapb/model.proto -O 'go_package="github.com/block/ftl/cmd/go2proto/testdata/testdatapb"' xyz.block.ftl.go2proto.test ./cmd/go2proto/testdata.Root && bin/gofmt -w cmd/go2proto/testdata/go2proto.to.go
+  @mk cmd/go2proto/testdata/go2proto.to.go cmd/go2proto/testdata/testdatapb/model.proto : cmd/go2proto/*.go cmd/go2proto/testdata/model.go -- go2proto -m -o ./cmd/go2proto/testdata/testdatapb/model.proto ./cmd/go2proto/testdata.Root && bin/gofmt -w cmd/go2proto/testdata/go2proto.to.go
   @mk cmd/go2proto/testdata/testdatapb/model.pb.go : cmd/go2proto/testdata/testdatapb/model.proto -- '(cd ./cmd/go2proto/testdata/testdatapb && protoc --go_out=paths=source_relative:. model.proto) && go build ./cmd/go2proto/testdata'
 
 # Build command-line tools
@@ -234,10 +234,7 @@ build-protos: go2proto
 # Generate .proto files from .go types.
 go2proto:
   @mk "{{SCHEMA_OUT}}" common/schema/go2proto.to.go : cmd/go2proto common/schema -- \
-    "go2proto -m -o \"{{SCHEMA_OUT}}\" \
-    -O 'go_package=\"github.com/block/ftl/common/protos/xyz/block/ftl/schema/v1;schemapb\"' \
-    -O 'java_multiple_files=true' \
-    xyz.block.ftl.schema.v1 {{GO_SCHEMA_ROOTS}} && buf format -w && buf lint && bin/gofmt -w common/schema/go2proto.to.go"
+    "go2proto -m -o \"{{SCHEMA_OUT}}\" {{GO_SCHEMA_ROOTS}} && buf format -w && buf lint && bin/gofmt -w common/schema/go2proto.to.go"
 
 # Unconditionally rebuild protos
 build-protos-unconditionally: go2proto lint-protos pnpm-install

--- a/cmd/go2proto/pbtmpl.go
+++ b/cmd/go2proto/pbtmpl.go
@@ -65,14 +65,16 @@ message {{ .Name }} {
 `))
 
 type RenderContext struct {
+	Directives
 	Config
 	File
 }
 
-func render(out *os.File, config Config, file File) error {
+func render(out *os.File, directives Directives, config Config, file File) error {
 	err := tmpl.Execute(out, RenderContext{
-		Config: config,
-		File:   file,
+		Directives: directives,
+		Config:     config,
+		File:       file,
 	})
 	if err != nil {
 		return fmt.Errorf("template error: %w", err)

--- a/cmd/go2proto/testdata/model.go
+++ b/cmd/go2proto/testdata/model.go
@@ -1,3 +1,5 @@
+//protobuf:package xyz.block.ftl.go2proto.test
+//protobuf:option go_package="github.com/block/ftl/cmd/go2proto/testdata/testdatapb"
 package testdata
 
 import (

--- a/cmd/go2proto/toprototmpl.go
+++ b/cmd/go2proto/toprototmpl.go
@@ -157,17 +157,16 @@ func {{ .Name }}ToProto(value {{ .Name }}) *destpb.{{ .Name }} {
 		`))
 
 type Go2ProtoContext struct {
+	Directives
 	Config
 	File
 }
 
-func renderToProto(out *os.File, config Config, file File) error {
-	if config.Options["go_package"] == "" {
-		return fmt.Errorf("go_package must be set in the protobuf options")
-	}
+func renderToProto(out *os.File, directives Directives, config Config, file File) error {
 	err := go2protoTmpl.Execute(out, Go2ProtoContext{
-		Config: config,
-		File:   file,
+		Directives: directives,
+		Config:     config,
+		File:       file,
 	})
 	if err != nil {
 		return fmt.Errorf("template error: %w", err)

--- a/common/schema/schema.go
+++ b/common/schema/schema.go
@@ -1,3 +1,6 @@
+//protobuf:package xyz.block.ftl.schema.v1
+//protobuf:option go_package="github.com/block/ftl/common/protos/xyz/block/ftl/schema/v1;schemapb"
+//protobuf:option java_multiple_files=true
 package schema
 
 import (


### PR DESCRIPTION
This makes the source files more self-contained, which is nice, but is also a step towards being able to support multiple packages - when we import a Go package with directives, we will know that it is a protobuf package, and we won't generate types for it in the current package.

Next I'll move the definition of the "roots" into code.