### PR TITLE
fix: console dropping some errors messages

### DIFF
--- a/frontend/cli/main.go
+++ b/frontend/cli/main.go
@@ -128,7 +128,6 @@ func main() {
 		sm := terminal.NewStatusManager(ctx)
 		csm.statusManager = optional.Some(sm)
 		ctx = sm.IntoContext(ctx)
-		defer sm.Close()
 	}
 	rpc.InitialiseClients(cli.Authenticators, cli.Insecure)
 
@@ -171,7 +170,14 @@ func main() {
 	ctx = bindContext(ctx, kctx)
 
 	err = kctx.Run(ctx)
-	kctx.FatalIfErrorf(err)
+
+	if sm, ok := csm.statusManager.Get(); ok {
+		sm.Close()
+	}
+
+	if err != nil {
+		kctx.FatalIfErrorf(err)
+	}
 }
 
 func createKongApplication(cli any, csm *currentStatusManager) *kong.Kong {


### PR DESCRIPTION
Fixes #3142

BEFORE:

```sh
ftl deploy --endpoint=http://localhost:4678/
info:time:build: Building module
info:time:build: Module built (1.48s)
info:time:deploy: Deploying module
✘[time]
```

AFTER:

```sh
ftl deploy --endpoint=http://localhost:4678/
info:time:build: Building module
info:time:build: Module built (1.61s)
info:time:deploy: Deploying module
ftl: error: failed to deploy: failed to get artefact diffs: unavailable: dial tcp 127.0.0.1:8893: connect: connection refused
```