### PR TITLE
fix: cleanly leaving the raft cluster

### DIFF
--- a/internal/raft/cluster.go
+++ b/internal/raft/cluster.go
@@ -6,12 +6,13 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/block/ftl/internal/log"
 	"github.com/jpillora/backoff"
 	"github.com/lni/dragonboat/v4"
 	"github.com/lni/dragonboat/v4/client"
 	"github.com/lni/dragonboat/v4/config"
 	"github.com/lni/dragonboat/v4/statemachine"
+
+	"github.com/block/ftl/internal/log"
 )
 
 type RaftConfig struct {

--- a/internal/raft/eventview_test.go
+++ b/internal/raft/eventview_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/alecthomas/assert/v2"
 	"github.com/block/ftl/internal/local"
+	"github.com/block/ftl/internal/log"
 	"github.com/block/ftl/internal/raft"
 	"golang.org/x/sync/errgroup"
 )
@@ -43,7 +44,8 @@ func (v *IntSumView) UnmarshalBinary(data []byte) error {
 }
 
 func TestEventView(t *testing.T) {
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(60*time.Second))
+	ctx := log.ContextWithNewDefaultLogger(context.Background())
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(60*time.Second))
 	defer cancel()
 
 	members, err := local.FreeTCPAddresses(2)


### PR DESCRIPTION
Dragonboat returns shard not ready errors if there is a leader election in progress. This catches those and retries