### PR TITLE
feat: use infinite query for streaming endpoint

### DIFF
--- a/frontend/console/src/api/timeline/use-module-trace-events.ts
+++ b/frontend/console/src/api/timeline/use-module-trace-events.ts
@@ -1,4 +1,4 @@
-import { EventType } from '../../protos/xyz/block/ftl/timeline/v1/event_pb.ts'
+import { type Event, EventType } from '../../protos/xyz/block/ftl/timeline/v1/event_pb.ts'
 import type { GetTimelineRequest_Filter } from '../../protos/xyz/block/ftl/timeline/v1/timeline_pb.ts'
 import { eventTypesFilter, moduleFilter } from './timeline-filters.ts'
 import { useTimeline } from './use-timeline.ts'
@@ -8,7 +8,10 @@ export const useModuleTraceEvents = (module: string, verb?: string, filters: Get
   const allFilters = [...filters, moduleFilter(module, verb), eventTypesFilter(eventTypes)]
   const timelineQuery = useTimeline(true, allFilters, 500)
 
-  const data = timelineQuery.data?.filter((event) => event.entry.case === 'call' || event.entry.case === 'ingress') ?? []
+  const data = (timelineQuery.data?.pages ?? [])
+    .flatMap((page): Event[] => (Array.isArray(page) ? page : []))
+    .filter((event) => 'entry' in event && (event.entry.case === 'call' || event.entry.case === 'ingress'))
+
   return {
     ...timelineQuery,
     data,

--- a/frontend/console/src/features/timeline/Timeline.tsx
+++ b/frontend/console/src/features/timeline/Timeline.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from 'react'
+import { useContext, useEffect, useMemo, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { timeFilter, useTimeline } from '../../api/timeline/index.ts'
 import { Loader } from '../../components/Loader.tsx'
@@ -31,6 +31,7 @@ export const Timeline = ({ timeSettings, filters }: { timeSettings: TimeSettings
   const streamTimeline = timeSettings.isTailing && !timeSettings.isPaused
 
   const timeline = useTimeline(streamTimeline, eventFilters)
+  const entries = useMemo(() => (timeline.data?.pages ?? []).flatMap((page): Event[] => (Array.isArray(page) ? page : [])), [timeline.data?.pages])
 
   useEffect(() => {
     if (!isOpen) {
@@ -93,8 +94,6 @@ export const Timeline = ({ timeSettings, filters }: { timeSettings: TimeSettings
       </div>
     )
   }
-
-  const entries = timeline.data || []
 
   return (
     <div className='border border-gray-100 dark:border-slate-700 rounded m-2'>


### PR DESCRIPTION
This integrates [ tanstack infinite query ](https://tanstack.com/query/latest/docs/framework/react/guides/infinite-queries) to avoid reloading the entire timeline when new events arrive.