### PR TITLE
chore: when closing a nodehost, self deregister from all shards

### DIFF
--- a/internal/raft/eventview_test.go
+++ b/internal/raft/eventview_test.go
@@ -63,8 +63,8 @@ func TestEventView(t *testing.T) {
 	eg.Go(func() error { return cluster1.Start(wctx) })
 	eg.Go(func() error { return cluster2.Start(wctx) })
 	assert.NoError(t, eg.Wait())
-	defer cluster1.Stop()
-	defer cluster2.Stop()
+	defer cluster1.Stop(ctx) //nolint:errcheck
+	defer cluster2.Stop(ctx) //nolint:errcheck
 
 	assert.NoError(t, view1.Publish(ctx, IntStreamEvent{Value: 1}))
 


### PR DESCRIPTION
Also, adds retries in the case of timeouts when an election is in progress