### PR TITLE
feat: Automatically join the raft cluster

### DIFF
--- a/cmd/raft-tester/statemachine.go
+++ b/cmd/raft-tester/statemachine.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/block/ftl/internal/raft"
+)
+
+type IntStateMachine struct {
+	sum int64
+}
+
+type IntEvent int64
+
+func (i *IntEvent) UnmarshalBinary(data []byte) error { //nolint:unparam
+	*i = IntEvent(binary.BigEndian.Uint64(data))
+	return nil
+}
+
+func (i IntEvent) MarshalBinary() ([]byte, error) { //nolint:unparam
+	return binary.BigEndian.AppendUint64([]byte{}, uint64(i)), nil
+}
+
+var _ raft.StateMachine[int64, int64, IntEvent, *IntEvent] = &IntStateMachine{}
+
+func (s IntStateMachine) Lookup(key int64) (int64, error) {
+	return s.sum, nil
+}
+
+func (s *IntStateMachine) Update(msg IntEvent) error {
+	s.sum += int64(msg)
+	return nil
+}
+
+func (s IntStateMachine) Close() error {
+	return nil
+}
+
+func (s IntStateMachine) Recover(reader io.Reader) error {
+	err := binary.Read(reader, binary.BigEndian, &s.sum)
+	if err != nil {
+		return fmt.Errorf("failed to recover from snapshot: %w", err)
+	}
+	return nil
+}
+
+func (s IntStateMachine) Save(writer io.Writer) error {
+	err := binary.Write(writer, binary.BigEndian, s.sum)
+	if err != nil {
+		return fmt.Errorf("failed to save snapshot: %w", err)
+	}
+	return nil
+}

--- a/internal/raft/cluster_test.go
+++ b/internal/raft/cluster_test.go
@@ -119,7 +119,9 @@ func TestJoiningExistingCluster(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.NoError(t, cluster3.Join(ctx))
-	defer cluster3.Stop(ctx) //nolint:errcheck
+	t.Cleanup(func() {
+		cluster3.Stop(ctx)
+	})
 
 	assert.NoError(t, shard3.Propose(ctx, IntEvent(1)))
 
@@ -137,7 +139,9 @@ func TestJoiningExistingCluster(t *testing.T) {
 	}))
 	assert.NoError(t, err)
 	assert.NoError(t, cluster4.Join(ctx))
-	defer cluster4.Stop(ctx) //nolint:errcheck
+	t.Cleanup(func() {
+		cluster4.Stop(ctx)
+	})
 
 	assert.NoError(t, shard4.Propose(ctx, IntEvent(1)))
 

--- a/internal/raft/eventview_test.go
+++ b/internal/raft/eventview_test.go
@@ -51,11 +51,11 @@ func TestEventView(t *testing.T) {
 	members, err := local.FreeTCPAddresses(2)
 	assert.NoError(t, err)
 
-	builder1 := testBuilder(t, members, 1, members[0].String())
+	builder1 := testBuilder(t, members, 1, members[0].String(), nil)
 	view1 := raft.AddEventView[IntSumView, *IntSumView, IntStreamEvent](ctx, builder1, 1)
 	cluster1 := builder1.Build(ctx)
 
-	builder2 := testBuilder(t, members, 2, members[1].String())
+	builder2 := testBuilder(t, members, 2, members[1].String(), nil)
 	view2 := raft.AddEventView[IntSumView, *IntSumView, IntStreamEvent](ctx, builder2, 1)
 	cluster2 := builder2.Build(ctx)
 

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -1,0 +1,24 @@
+package retry
+
+import (
+	"time"
+
+	"github.com/jpillora/backoff"
+)
+
+// RetryConfig is a Kong compatible configuration for creating backoff.Backoff instances.
+type RetryConfig struct {
+	Min    time.Duration `help:"Minimum retry interval" default:"100ms"`
+	Max    time.Duration `help:"Maximum retry interval" default:"10s"`
+	Factor float64       `help:"Factor to multiply the retry interval by" default:"2"`
+	Jitter bool          `help:"Whether to add jitter to the retry interval" default:"true"`
+}
+
+func (c *RetryConfig) Backoff() *backoff.Backoff {
+	return &backoff.Backoff{
+		Min:    c.Min,
+		Max:    c.Max,
+		Factor: c.Factor,
+		Jitter: c.Jitter,
+	}
+}


### PR DESCRIPTION
Changes `Join` to take a cluster control endpoint to send the add member request when joining as a new member.

Changes the raft tester to support joining.

Still, it seems that recovering from crashed nodes is not working properly, fixing that as a followup.