### PR TITLE
fix: reused enum type schema extraction

### DIFF
--- a/go-runtime/schema/schema_integration_test.go
+++ b/go-runtime/schema/schema_integration_test.go
@@ -72,6 +72,11 @@ func testExtractModuleSchema(t *testing.T) {
 
   database postgres testDb
 
+  enum Animal {
+    Dog one.Dog
+    Lion one.Lion
+  }
+
   export enum BlobOrList {
     Blob String
     List [String]
@@ -100,6 +105,11 @@ func testExtractModuleSchema(t *testing.T) {
     Third = 5
   }
 
+  enum Pet {
+    Cat one.Cat
+    Dog one.Dog
+  }
+
   enum PrivateEnum {
     ExportedStruct one.ExportedStruct
     PrivateStruct one.PrivateStruct
@@ -119,12 +129,18 @@ func testExtractModuleSchema(t *testing.T) {
     ValueEnum one.ColorInt
   }
 
+  data Cat {
+  }
+
   data Config {
     field String
   }
 
   data DataWithType<T> {
     value T
+  }
+
+  data Dog {
   }
 
   export data ExportedData {
@@ -135,6 +151,9 @@ func testExtractModuleSchema(t *testing.T) {
   }
 
   data InlineStruct {
+  }
+
+  data Lion {
   }
 
   export data Nested {

--- a/go-runtime/schema/testdata/one/one.go
+++ b/go-runtime/schema/testdata/one/one.go
@@ -91,6 +91,21 @@ func (ValueEnum) tag() {}
 //ftl:enum
 type PrivateEnum interface{ privateEnum() }
 
+//ftl:enum
+type Animal interface{ animal() }
+type Lion struct{}
+type Dog struct{}
+
+func (Lion) animal() {}
+func (Dog) animal()  {}
+
+//ftl:enum
+type Pet interface{ pet() }
+type Cat struct{}
+
+func (Cat) pet() {}
+func (Dog) pet() {}
+
 //ftl:data export
 type ExportedStruct struct{}
 

--- a/go-runtime/schema/testdata/one/types.ftl.go
+++ b/go-runtime/schema/testdata/one/types.ftl.go
@@ -4,8 +4,8 @@ package one
 import (
 	"context"
 	ftlbuiltin "ftl/builtin"
-	"github.com/block/ftl/go-runtime/ftl"
 	"github.com/block/ftl/common/reflection"
+	"github.com/block/ftl/go-runtime/ftl"
 	"github.com/block/ftl/go-runtime/server"
 	stdtime "time"
 )
@@ -26,9 +26,17 @@ type VerbClient func(context.Context, Req) (Resp, error)
 
 func init() {
 	reflection.Register(
+		reflection.SumType[Animal](
+			*new(Dog),
+			*new(Lion),
+		),
 		reflection.SumType[BlobOrList](
 			*new(Blob),
 			*new(List),
+		),
+		reflection.SumType[Pet](
+			*new(Cat),
+			*new(Dog),
 		),
 		reflection.SumType[PrivateEnum](
 			*new(ExportedStruct),

--- a/go-runtime/schema/testdata/pubsub/types.ftl.go
+++ b/go-runtime/schema/testdata/pubsub/types.ftl.go
@@ -3,8 +3,8 @@ package pubsub
 
 import (
 	"context"
-	"github.com/block/ftl/go-runtime/ftl"
 	"github.com/block/ftl/common/reflection"
+	"github.com/block/ftl/go-runtime/ftl"
 	"github.com/block/ftl/go-runtime/server"
 )
 

--- a/go-runtime/schema/testdata/two/types.ftl.go
+++ b/go-runtime/schema/testdata/two/types.ftl.go
@@ -4,8 +4,8 @@ package two
 import (
 	"context"
 	ftlbuiltin "ftl/builtin"
-	"github.com/block/ftl/go-runtime/ftl"
 	"github.com/block/ftl/common/reflection"
+	"github.com/block/ftl/go-runtime/ftl"
 	lib "github.com/block/ftl/go-runtime/schema/testdata"
 	"github.com/block/ftl/go-runtime/server"
 	"github.com/jpillora/backoff"

--- a/python-runtime/compile/testdata/echo/uv.lock
+++ b/python-runtime/compile/testdata/echo/uv.lock
@@ -21,18 +21,18 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "protobuf", specifier = ">=5.29.1" }]
+requires-dist = [{ name = "protobuf", specifier = "==5.29.2" }]
 
 [[package]]
 name = "protobuf"
-version = "5.29.1"
+version = "5.29.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d2/4f/1639b7b1633d8fd55f216ba01e21bf2c43384ab25ef3ddb35d85a52033e8/protobuf-5.29.1.tar.gz", hash = "sha256:683be02ca21a6ffe80db6dd02c0b5b2892322c59ca57fd6c872d652cb80549cb", size = 424965 }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/73/4e6295c1420a9d20c9c351db3a36109b4c9aa601916cb7c6871e3196a1ca/protobuf-5.29.2.tar.gz", hash = "sha256:b2cc8e8bb7c9326996f0e160137b0861f1a82162502658df2951209d0cb0309e", size = 424901 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/c7/28669b04691a376cf7d0617d612f126aa0fff763d57df0142f9bf474c5b8/protobuf-5.29.1-cp310-abi3-win32.whl", hash = "sha256:22c1f539024241ee545cbcb00ee160ad1877975690b16656ff87dde107b5f110", size = 422706 },
-    { url = "https://files.pythonhosted.org/packages/e3/33/dc7a7712f457456b7e0b16420ab8ba1cc8686751d3f28392eb43d0029ab9/protobuf-5.29.1-cp310-abi3-win_amd64.whl", hash = "sha256:1fc55267f086dd4050d18ef839d7bd69300d0d08c2a53ca7df3920cc271a3c34", size = 434505 },
-    { url = "https://files.pythonhosted.org/packages/e5/39/44239fb1c6ec557e1731d996a5de89a9eb1ada7a92491fcf9c5d714052ed/protobuf-5.29.1-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:d473655e29c0c4bbf8b69e9a8fb54645bc289dead6d753b952e7aa660254ae18", size = 417822 },
-    { url = "https://files.pythonhosted.org/packages/fb/4a/ec56f101d38d4bef2959a9750209809242d86cf8b897db00f2f98bfa360e/protobuf-5.29.1-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:b5ba1d0e4c8a40ae0496d0e2ecfdbb82e1776928a205106d14ad6985a09ec155", size = 319572 },
-    { url = "https://files.pythonhosted.org/packages/04/52/c97c58a33b3d6c89a8138788576d372a90a6556f354799971c6b4d16d871/protobuf-5.29.1-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:8ee1461b3af56145aca2800e6a3e2f928108c749ba8feccc6f5dd0062c410c0d", size = 319671 },
-    { url = "https://files.pythonhosted.org/packages/3b/24/c8c49df8f6587719e1d400109b16c10c6902d0c9adddc8fff82840146f99/protobuf-5.29.1-py3-none-any.whl", hash = "sha256:32600ddb9c2a53dedc25b8581ea0f1fd8ea04956373c0c07577ce58d312522e0", size = 172547 },
+    { url = "https://files.pythonhosted.org/packages/f3/42/6db5387124708d619ffb990a846fb123bee546f52868039f8fa964c5bc54/protobuf-5.29.2-cp310-abi3-win32.whl", hash = "sha256:c12ba8249f5624300cf51c3d0bfe5be71a60c63e4dcf51ffe9a68771d958c851", size = 422697 },
+    { url = "https://files.pythonhosted.org/packages/6c/38/2fcc968b377b531882d6ab2ac99b10ca6d00108394f6ff57c2395fb7baff/protobuf-5.29.2-cp310-abi3-win_amd64.whl", hash = "sha256:842de6d9241134a973aab719ab42b008a18a90f9f07f06ba480df268f86432f9", size = 434495 },
+    { url = "https://files.pythonhosted.org/packages/cb/26/41debe0f6615fcb7e97672057524687ed86fcd85e3da3f031c30af8f0c51/protobuf-5.29.2-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:a0c53d78383c851bfa97eb42e3703aefdc96d2036a41482ffd55dc5f529466eb", size = 417812 },
+    { url = "https://files.pythonhosted.org/packages/e4/20/38fc33b60dcfb380507b99494aebe8c34b68b8ac7d32808c4cebda3f6f6b/protobuf-5.29.2-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:494229ecd8c9009dd71eda5fd57528395d1eacdf307dbece6c12ad0dd09e912e", size = 319562 },
+    { url = "https://files.pythonhosted.org/packages/90/4d/c3d61e698e0e41d926dbff6aa4e57428ab1a6fc3b5e1deaa6c9ec0fd45cf/protobuf-5.29.2-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:b6b0d416bbbb9d4fbf9d0561dbfc4e324fd522f61f7af0fe0f282ab67b22477e", size = 319662 },
+    { url = "https://files.pythonhosted.org/packages/f3/fd/c7924b4c2a1c61b8f4b64edd7a31ffacf63432135a2606f03a2f0d75a750/protobuf-5.29.2-py3-none-any.whl", hash = "sha256:fde4554c0e578a5a0bcc9a276339594848d1e89f9ea47b4427c80e5d72f90181", size = 172539 },
 ]


### PR DESCRIPTION
Fixes #2857

This `go` code...
![Screenshot 2025-01-03 at 10 08 02 AM](https://github.com/user-attachments/assets/720e2777-27e1-45ec-9c5b-d0a220b1d260)

Extracts to this schema now
![Screenshot 2025-01-03 at 10 07 46 AM](https://github.com/user-attachments/assets/d49325cf-2a86-4db5-878b-54001c2b8494)
