### PR TITLE
feat: Channel to listen to changes

### DIFF
--- a/internal/raft/cluster.go
+++ b/internal/raft/cluster.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"github.com/alecthomas/atomic"
 	"github.com/jpillora/backoff"
 	"github.com/lni/dragonboat/v4"
 	"github.com/lni/dragonboat/v4/client"
@@ -33,6 +34,9 @@ type RaftConfig struct {
 	ControlBind       *url.URL          `help:"Address to listen for control traffic. If empty, no control listener will be started."`
 	ShardReadyTimeout time.Duration     `help:"Timeout for shard to be ready" default:"5s"`
 	Retry             retry.RetryConfig `help:"Connection retry configuration" prefix:"retry-" embed:""`
+	ChangesInterval   time.Duration     `help:"Interval for changes to be checked" default:"10ms"`
+	ChangesTimeout    time.Duration     `help:"Timeout for changes to be checked" default:"1s"`
+
 	// Raft configuration
 	RTT                time.Duration `help:"Estimated average round trip time between nodes" default:"200ms"`
 	ElectionRTT        uint64        `help:"Election RTT as a multiple of RTT" default:"10"`
@@ -87,7 +91,9 @@ type Cluster struct {
 	shards        map[uint64]statemachine.CreateStateMachineFunc
 	controlClient *http.Client
 
-	closeControlService context.CancelFunc
+	// runningCtx is cancelled when the cluster is stopped.
+	runningCtx    context.Context
+	runningCancel context.CancelFunc
 }
 
 var _ raftpbconnect.RaftServiceHandler = (*Cluster)(nil)
@@ -121,6 +127,8 @@ type ShardHandle[E Event, Q any, R any] struct {
 	shardID uint64
 	cluster *Cluster
 	session *client.Session
+
+	lastKnownIndex atomic.Value[uint64]
 
 	mu sync.Mutex
 }
@@ -181,6 +189,70 @@ func (s *ShardHandle[E, Q, R]) Query(ctx context.Context, query Q) (R, error) {
 	}
 
 	return response, nil
+}
+
+// Changes returns a channel that will receive the result of the query when the
+// shard state changes.
+//
+// This can only be called when the cluster is running.
+//
+// Note, that this is not guaranteed to receive an event for every change, but
+// will always receive the latest state of the shard.
+func (s *ShardHandle[E, Q, R]) Changes(ctx context.Context, query Q) (chan R, error) {
+	if s.cluster.nh == nil {
+		panic("cluster not started")
+	}
+
+	result := make(chan R)
+	logger := log.FromContext(ctx).Scope("raft")
+
+	// get the last known index as the starting point
+	reader, err := s.cluster.nh.GetLogReader(s.shardID)
+	if err != nil {
+		logger.Errorf(err, "failed to get log reader")
+	}
+	_, last := reader.GetRange()
+	s.lastKnownIndex.Store(last)
+
+	go func() {
+		// poll, as dragoboat does not have a way to listen to changes directly
+		timer := time.NewTicker(s.cluster.config.ChangesInterval)
+		defer timer.Stop()
+
+		for {
+			select {
+			case <-s.cluster.runningCtx.Done():
+				logger.Infof("changes channel closed")
+				close(result)
+
+				return
+			case <-timer.C:
+				reader, err := s.cluster.nh.GetLogReader(s.shardID)
+				if err != nil {
+					logger.Errorf(err, "failed to get log reader")
+				} else {
+					_, last := reader.GetRange()
+					if last > s.lastKnownIndex.Load() {
+						logger.Debugf("changes detected, last known index: %d, new index: %d", s.lastKnownIndex.Load(), last)
+
+						s.lastKnownIndex.Store(last)
+
+						ctx, cancel := context.WithTimeout(ctx, s.cluster.config.ChangesTimeout)
+						res, err := s.Query(ctx, query)
+						cancel()
+
+						if err != nil {
+							logger.Errorf(err, "failed to query shard")
+						} else {
+							result <- res
+						}
+					}
+				}
+			}
+		}
+	}()
+
+	return result, nil
 }
 
 func (s *ShardHandle[E, Q, R]) verifyReady() {
@@ -263,6 +335,10 @@ func (c *Cluster) start(ctx context.Context, join bool) error {
 		}
 	}
 
+	ctx, cancel := context.WithCancel(context.WithoutCancel(ctx))
+	c.runningCancel = cancel
+	c.runningCtx = ctx
+
 	if err := c.startControlServer(ctx); err != nil {
 		return err
 	}
@@ -299,9 +375,6 @@ func (c *Cluster) startShard(nh *dragonboat.NodeHost, shardID uint64, sm statema
 func (c *Cluster) startControlServer(ctx context.Context) error {
 	logger := log.FromContext(ctx).Scope("raft")
 
-	ctx, cancel := context.WithCancel(context.WithoutCancel(ctx))
-	c.closeControlService = cancel
-
 	if c.config.ControlBind == nil {
 		return nil
 	}
@@ -327,7 +400,7 @@ func (c *Cluster) Stop(ctx context.Context) {
 			c.removeShardMember(ctx, shardID, c.config.ReplicaID)
 		}
 		c.nh.Close()
-		c.closeControlService()
+		c.runningCancel()
 		c.nh = nil
 		c.shards = nil
 	}

--- a/internal/raft/eventview.go
+++ b/internal/raft/eventview.go
@@ -35,6 +35,15 @@ func (s *RaftEventView[V, VPrt, E]) View(ctx context.Context) (V, error) {
 	return view, nil
 }
 
+func (s *RaftEventView[V, VPrt, E]) Changes(ctx context.Context) (chan V, error) {
+	res, err := s.shard.Changes(ctx, UnitQuery{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get changes: %w", err)
+	}
+
+	return res, nil
+}
+
 type eventStreamStateMachine[
 	V encoding.BinaryMarshaler,
 	VPrt Unmarshallable[V],

--- a/internal/raft/eventview_test.go
+++ b/internal/raft/eventview_test.go
@@ -1,16 +1,12 @@
 package raft_test
 
 import (
-	"context"
 	"encoding/binary"
 	"testing"
-	"time"
 
 	"github.com/alecthomas/assert/v2"
-	"github.com/block/ftl/internal/local"
-	"github.com/block/ftl/internal/log"
+	"github.com/block/ftl/internal/eventstream"
 	"github.com/block/ftl/internal/raft"
-	"golang.org/x/sync/errgroup"
 )
 
 type IntStreamEvent struct {
@@ -44,37 +40,19 @@ func (v *IntSumView) UnmarshalBinary(data []byte) error {
 }
 
 func TestEventView(t *testing.T) {
-	ctx := log.ContextWithNewDefaultLogger(context.Background())
-	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(60*time.Second))
-	t.Cleanup(cancel)
+	ctx := testContext(t)
 
-	members, err := local.FreeTCPAddresses(2)
-	assert.NoError(t, err)
-
-	builder1 := testBuilder(t, members, 1, members[0].String(), nil)
-	view1 := raft.AddEventView[IntSumView, *IntSumView, IntStreamEvent](ctx, builder1, 1)
-	cluster1 := builder1.Build(ctx)
-
-	builder2 := testBuilder(t, members, 2, members[1].String(), nil)
-	view2 := raft.AddEventView[IntSumView, *IntSumView, IntStreamEvent](ctx, builder2, 1)
-	cluster2 := builder2.Build(ctx)
-
-	eg, wctx := errgroup.WithContext(ctx)
-	eg.Go(func() error { return cluster1.Start(wctx) })
-	eg.Go(func() error { return cluster2.Start(wctx) })
-	assert.NoError(t, eg.Wait())
-	t.Cleanup(func() {
-		cluster1.Stop(ctx)
-		cluster2.Stop(ctx)
+	_, views := startClusters(ctx, t, 2, func(b *raft.Builder) eventstream.EventView[IntSumView, IntStreamEvent] {
+		return raft.AddEventView[IntSumView, *IntSumView, IntStreamEvent](ctx, b, 1)
 	})
 
-	assert.NoError(t, view1.Publish(ctx, IntStreamEvent{Value: 1}))
+	assert.NoError(t, views[0].Publish(ctx, IntStreamEvent{Value: 1}))
 
-	view, err := view1.View(ctx)
+	view, err := views[0].View(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, IntSumView{Sum: 1}, view)
 
-	view, err = view2.View(ctx)
+	view, err = views[1].View(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, IntSumView{Sum: 1}, view)
 }


### PR DESCRIPTION
Unfortunately, it seems that polling for log id changes is the only way to listen to changes in dragonboat.