### PR TITLE
chore: extract statemachines and state machine handles to a separate package

### DIFF
--- a/cmd/raft-tester/main.go
+++ b/cmd/raft-tester/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/block/ftl/internal/log"
 	"github.com/block/ftl/internal/raft"
+	sm "github.com/block/ftl/internal/statemachine"
 )
 
 var cli struct {
@@ -57,7 +58,7 @@ func (j *joinCmd) Run() error {
 	return run(ctx, shard)
 }
 
-func run(ctx context.Context, shard *raft.ShardHandle[IntEvent, int64, int64]) error {
+func run(ctx context.Context, shard sm.StateMachineHandle[int64, int64, IntEvent]) error {
 	messages := make(chan int)
 
 	wg, ctx := errgroup.WithContext(ctx)
@@ -85,7 +86,7 @@ func run(ctx context.Context, shard *raft.ShardHandle[IntEvent, int64, int64]) e
 		for {
 			select {
 			case msg := <-messages:
-				err := shard.Propose(ctx, IntEvent(msg))
+				err := shard.Update(ctx, IntEvent(msg))
 				if err != nil {
 					return fmt.Errorf("failed to propose event: %w", err)
 				}

--- a/cmd/raft-tester/statemachine.go
+++ b/cmd/raft-tester/statemachine.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/block/ftl/internal/raft"
+	sm "github.com/block/ftl/internal/statemachine"
 )
 
 type IntStateMachine struct {
@@ -23,7 +23,7 @@ func (i IntEvent) MarshalBinary() ([]byte, error) { //nolint:unparam
 	return binary.BigEndian.AppendUint64([]byte{}, uint64(i)), nil
 }
 
-var _ raft.StateMachine[int64, int64, IntEvent, *IntEvent] = &IntStateMachine{}
+var _ sm.SnapshottingStateMachine[int64, int64, IntEvent] = &IntStateMachine{}
 
 func (s IntStateMachine) Lookup(key int64) (int64, error) {
 	return s.sum, nil

--- a/internal/raft/statemachine.go
+++ b/internal/raft/statemachine.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"io"
 
-	sm "github.com/block/ftl/internal/statemachine"
 	"github.com/lni/dragonboat/v4/statemachine"
+
+	sm "github.com/block/ftl/internal/statemachine"
 )
 
 // stateMachineShim is a shim to convert a typed StateMachine to a dragonboat statemachine.IStateMachine.

--- a/internal/statemachine/statemachine.go
+++ b/internal/statemachine/statemachine.go
@@ -1,0 +1,48 @@
+package statemachine
+
+import (
+	"context"
+	"encoding"
+	"io"
+)
+
+// StateMachine updates an underlying state based on events.
+// It can be queried for the current state.
+//
+// Q is the query type.
+// R is the query response type.
+// E is the event type.
+type StateMachine[Q any, R any, E any] interface {
+	// Query the state of the state machine.
+	Lookup(key Q) (R, error)
+	// Update the state of the state machine.
+	Update(msg E) error
+}
+
+// Unmarshallable is a type that can be unmarshalled from a binary representation.
+type Unmarshallable[T any] interface {
+	*T
+	encoding.BinaryUnmarshaler
+}
+
+// Marshallable is a type that can be marshalled to a binary representation.
+type Marshallable encoding.BinaryMarshaler
+
+// SnapshottingStateMachine adds snapshotting capabilities to a StateMachine.
+type SnapshottingStateMachine[Q any, R any, E any] interface {
+	StateMachine[Q, R, E]
+
+	// Save the state of the state machine to a snapshot.
+	Save(writer io.Writer) error
+	// Recover the state of the state machine from a snapshot.
+	Recover(reader io.Reader) error
+	// Close the state machine.
+	Close() error
+}
+
+// StateMachineHandle is a handle to update and query a state machine.
+type StateMachineHandle[Q any, R any, E any] interface {
+	Update(ctx context.Context, msg E) error
+	Query(ctx context.Context, query Q) (R, error)
+	Changes(ctx context.Context, query Q) (chan R, error)
+}


### PR DESCRIPTION
This will make it easier to replace raft based implementations with in memory versions for testing