### PR TITLE
fix: allow and warn for partition mismatches in dev

### DIFF
--- a/backend/provisioner/dev_provisioner.go
+++ b/backend/provisioner/dev_provisioner.go
@@ -237,7 +237,7 @@ func provisionTopic() InMemResourceProvisionerFn {
 			} else {
 				plural = "partitions"
 			}
-			return nil, fmt.Errorf("existing topic %s has %d %s instead of %d", topicID, len(topicMetas[0].Partitions), plural, partitions)
+			logger.Warnf("Using existing topic %s with %d %s instead of %d", topicID, len(topicMetas[0].Partitions), plural, partitions)
 		}
 
 		return &RuntimeEvent{


### PR DESCRIPTION
fixes https://github.com/block/ftl/issues/3909

We don't yet have a good solution for resetting topics to change the number of partitions. So warning is better for now and we can revisit it later.