### PR TITLE
fix: speed up pubsub provisioning

### DIFF
--- a/backend/runner/runner.go
+++ b/backend/runner/runner.go
@@ -350,7 +350,7 @@ func (s *Service) deploy(ctx context.Context, key model.DeploymentKey, module *s
 	pubSub, err := pubsub.New(module, key, s, s.timelineClient)
 	if err != nil {
 		observability.Deployment.Failure(ctx, optional.Some(key.String()))
-		return fmt.Errorf("failed to create pubsub service: %w", err)
+		return fmt.Errorf("failed to set up pubsub: %w", err)
 	}
 	s.pubSub = pubSub
 

--- a/internal/dev/redpanda.go
+++ b/internal/dev/redpanda.go
@@ -16,7 +16,7 @@ import (
 var redpandaDockerCompose string
 
 // use this lock while checking redPandaRunning status and running `docker compose up` if needed
-var redPandaLock *sync.Mutex = &sync.Mutex{}
+var redPandaLock = &sync.Mutex{}
 var redPandaRunning bool
 
 func SetUpRedPanda(ctx context.Context) error {


### PR DESCRIPTION
fixes: https://github.com/block/ftl/issues/3901
prerequisite: https://github.com/block/ftl/pull/3917

Wraps `docker compose up` with a lock and a cached success flag.