### PR TITLE
chore: remove event field that is always true

### DIFF
--- a/backend/cron/service.go
+++ b/backend/cron/service.go
@@ -153,12 +153,6 @@ func updateCronJobs(ctx context.Context, cronJobs map[string][]cronJob, change s
 	logger := log.FromContext(ctx).Scope("cron")
 	switch change := change.(type) {
 	case schemaeventsource.EventRemove:
-		// We see the new state of the module before we see the removed deployment.
-		// We only want to actually remove if it was not replaced by a new deployment.
-		if !change.Deleted {
-			logger.Debugf("Not removing cron jobs for %s as module is still present", change.Deployment)
-			return nil
-		}
 		logger.Debugf("Removing cron jobs for module %s", change.Module.Name)
 		delete(cronJobs, change.Module.Name)
 

--- a/backend/ingress/view.go
+++ b/backend/ingress/view.go
@@ -21,10 +21,6 @@ func syncView(ctx context.Context, schemaEventSource schemaeventsource.EventSour
 	logger.Debugf("Starting routing sync from schema")
 	go func() {
 		for event := range channels.IterContext(ctx, schemaEventSource.Events()) {
-			if event, ok := event.(schemaeventsource.EventRemove); ok && !event.Deleted {
-				logger.Debugf("Not removing ingress for %s as it is not the current deployment", event.Deployment)
-				continue
-			}
 			state := extractIngressRoutingEntries(event.Schema())
 			out.Store(state)
 		}

--- a/internal/schema/schemaeventsource/schemaeventsource_test.go
+++ b/internal/schema/schemaeventsource/schemaeventsource_test.go
@@ -170,7 +170,7 @@ func TestSchemaEventSource(t *testing.T) {
 			ChangeType:    ftlv1.DeploymentChangeType_DEPLOYMENT_CHANGE_TYPE_REMOVED,
 			ModuleRemoved: true,
 		})
-		var expected Event = EventRemove{Module: echo1, Deleted: true}
+		var expected Event = EventRemove{Module: echo1}
 		actual := recv(t)
 		assertEqual(t, expected, actual)
 		assertEqual(t, &schema.Schema{Modules: []*schema.Module{time2}}, changes.View())


### PR DESCRIPTION
Can only be true because of 
```
if !resp.ModuleRemoved {
  return nil
}
```
guard