### PR TITLE
feat: `ftl new` and `ftl init` updates

### DIFF
--- a/backend/provisioner/registry.go
+++ b/backend/provisioner/registry.go
@@ -92,7 +92,7 @@ func provisionerIDToProvisioner(ctx context.Context, id string, controller ftlv1
 	default:
 		plugin, _, err := plugin.Spawn(
 			ctx,
-			log.Debug,
+			log.FromContext(ctx).GetLevel(),
 			"ftl-provisioner-"+id,
 			".",
 			"ftl-provisioner-"+id,

--- a/docs/content/docs/getting-started/quick-start/index.md
+++ b/docs/content/docs/getting-started/quick-start/index.md
@@ -67,13 +67,11 @@ The [FTL VSCode extension](https://marketplace.visualstudio.com/items?itemName=F
 Once FTL is installed, initialize an FTL project:
 
 ```
-mkdir myproject
+ftl init myproject
 cd myproject
-ftl init myproject .
 ```
 
-This will create an `ftl-project.toml` file, a git repository, and a `bin/` directory with Hermit tooling. The Hermit tooling
-includes the current version of FTL, and language support for go and JVM based languages.
+This will create a new `myproject` directory containing an `ftl-project.toml` file, a git repository, and a `bin/` directory with Hermit tooling. The Hermit tooling includes the current version of FTL, and language support for go and JVM based languages.
 
 ### Create a new module
 

--- a/frontend/cli/cmd_init.go
+++ b/frontend/cli/cmd_init.go
@@ -28,7 +28,7 @@ var userHermitPackages string
 
 type initCmd struct {
 	Name        string   `arg:"" help:"Name of the project."`
-	Dir         string   `arg:"" optional:"" help:"Directory to initialize the project in. If not specified, creates a new directory with the project name." default:"."`
+	Dir         string   `arg:"" optional:"" help:"Directory to initialize the project in. If not specified, creates a new directory with the project name."`
 	Hermit      bool     `help:"Include Hermit language-specific toolchain binaries." negatable:"" default:"true"`
 	ModuleDirs  []string `help:"Child directories of existing modules."`
 	ModuleRoots []string `help:"Root directories of existing modules."`
@@ -39,9 +39,9 @@ type initCmd struct {
 func (i initCmd) Help() string {
 	return `
 Examples:
-  ftl init my-app        # Creates a new folder named "my-app" and initializes it
-  ftl init my-app .      # Initializes the current directory as "my-app"
-  ftl init my-app custom # Creates a folder named "custom" and initializes it as "my-app"`
+  ftl init myproject        # Creates a new folder named "myproject" and initializes it
+  ftl init myproject .      # Initializes the current directory as "myproject"
+  ftl init myproject custom # Creates a folder named "custom" and initializes it as "myproject"`
 }
 
 func (i initCmd) Run(
@@ -50,12 +50,13 @@ func (i initCmd) Run(
 	configRegistry *providers.Registry[configuration.Configuration],
 	secretsRegistry *providers.Registry[configuration.Secrets],
 ) error {
-	if i.Dir == "." && !strings.Contains(i.Name, "/") {
+	// If the directory is not specified, use the project name as the directory name.
+	if i.Dir == "" {
 		i.Dir = i.Name
 	}
 
 	logger.Debugf("Initializing FTL project in %s", i.Dir)
-	if err := os.MkdirAll(i.Dir, 0755); err != nil {
+	if err := os.MkdirAll(i.Dir, 0750); err != nil {
 		return fmt.Errorf("failed to create directory: %w", err)
 	}
 
@@ -117,6 +118,13 @@ func (i initCmd) Run(
 			}
 		}
 	}
+
+	fmt.Printf("Successfully created FTL project '%s' in %s\n\n", i.Name, i.Dir)
+	fmt.Printf("To get started:\n")
+	if i.Dir != "." {
+		fmt.Printf("  cd %s\n", i.Dir)
+	}
+	fmt.Printf("  ftl dev\n")
 	return nil
 }
 

--- a/frontend/cli/cmd_new.go
+++ b/frontend/cli/cmd_new.go
@@ -76,6 +76,8 @@ func (i newCmd) Run(ctx context.Context, ktctx *kong.Context, config projectconf
 		}
 	}
 	_ = plugin.Kill() //nolint:errcheck
+
+	fmt.Printf("Successfully created %s module %q in %s\n", i.Language, name, path)
 	return nil
 }
 

--- a/jvm-runtime/jvm_hot_reload_test.go
+++ b/jvm-runtime/jvm_hot_reload_test.go
@@ -21,7 +21,7 @@ func TestLifecycleJVM(t *testing.T) {
 		in.WithDevMode(),
 		in.GitInit(),
 		in.Exec("rm", "ftl-project.toml"),
-		in.Exec("ftl", "init", "test"),
+		in.Exec("ftl", "init", "test", "."),
 		in.IfLanguage("java", in.Exec("ftl", "new", "java", "echo")),
 		in.IfLanguage("kotlin", in.Exec("ftl", "new", "kotlin", "echo")),
 		in.WaitWithTimeout("echo", time.Minute),


### PR DESCRIPTION
Fixes #3924

Automatically create project folder and update help:
```
Usage: ftl init <name> [<dir>] [flags]

Initialize a new FTL project.

Examples:

    ftl init myproject        # Creates a new folder named "myproject" and initializes it
    ftl init myproject .      # Initializes the current directory as "myproject"
    ftl init myproject custom # Creates a folder named "custom" and initializes it as "myproject"
```

Creating a new ftl project will provide some help to the user as well:

```
ftl init myproject

Successfully created FTL project 'myproject' in myproject

To get started:
  cd myproject
  ftl dev
```

And update docs site:
![Screenshot 2025-01-07 at 2 51 23 PM](https://github.com/user-attachments/assets/1f0c70c2-2d7d-4399-ac5b-f23a567c13a8)