### PR TITLE
chore: separate runner state from schema state

### DIFF
--- a/backend/controller/schemaservice.go
+++ b/backend/controller/schemaservice.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (s *Service) GetSchema(ctx context.Context, c *connect.Request[ftlv1.GetSchemaRequest]) (*connect.Response[ftlv1.GetSchemaResponse], error) {
-	view, err := s.controllerState.View(ctx)
+	view, err := s.schemaState.View(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get controller state: %w", err)
 	}
@@ -38,7 +38,7 @@ func (s *Service) UpdateDeploymentRuntime(ctx context.Context, req *connect.Requ
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid deployment key: %w", err))
 	}
-	view, err := s.controllerState.View(ctx)
+	view, err := s.schemaState.View(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get controller state: %w", err)
 	}
@@ -52,7 +52,7 @@ func (s *Service) UpdateDeploymentRuntime(ctx context.Context, req *connect.Requ
 	}
 	event := schema.ModuleRuntimeEventFromProto(req.Msg.Event)
 	module.Runtime.ApplyEvent(event)
-	err = s.controllerState.Publish(ctx, &state.DeploymentSchemaUpdatedEvent{
+	err = s.schemaState.Publish(ctx, &state.DeploymentSchemaUpdatedEvent{
 		Key:    deployment,
 		Schema: module,
 	})

--- a/backend/controller/state/controllerstate.go
+++ b/backend/controller/state/controllerstate.go
@@ -2,64 +2,47 @@ package state
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/block/ftl/common/reflect"
 	"github.com/block/ftl/internal/channels"
+	"github.com/block/ftl/internal/eventstream"
 	"github.com/block/ftl/internal/statemachine"
 )
 
-type State struct {
-	deployments         map[string]*Deployment
-	activeDeployments   map[string]bool
-	runners             map[string]*Runner
-	runnersByDeployment map[string][]*Runner
+type SchemaEvent interface {
+	Handle(view SchemaState) (SchemaState, error)
 }
 
-type ControllerEvent interface {
-	Handle(view State) (State, error)
+type SchemaState struct {
+	deployments       map[string]*Deployment
+	activeDeployments map[string]bool
 }
 
-type controllerStateMachine struct {
-	state State
-
-	notifier   *channels.Notifier
-	runningCtx context.Context
-}
-
-var _ statemachine.Listenable[struct{}, State, ControllerEvent] = &controllerStateMachine{}
-
-func (c *controllerStateMachine) Lookup(key struct{}) (State, error) {
-	return reflect.DeepCopy(c.state), nil
-}
-
-func (c *controllerStateMachine) Publish(msg ControllerEvent) error {
-	var err error
-	c.state, err = msg.Handle(c.state)
-	if err != nil {
-		return fmt.Errorf("update: %w", err)
-	}
-	// Notify all subscribers using broadcaster
-	c.notifier.Notify(c.runningCtx)
-	return nil
-}
-
-func (c *controllerStateMachine) Subscribe(ctx context.Context) (<-chan struct{}, error) {
-	return c.notifier.Subscribe(), nil
-}
-
-func NewInMemoryState(ctx context.Context) *statemachine.SingleQueryHandle[struct{}, State, ControllerEvent] {
+func NewInMemorySchemaState(ctx context.Context) *statemachine.SingleQueryHandle[struct{}, SchemaState, SchemaEvent] {
 	notifier := channels.NewNotifier(ctx)
 	handle := statemachine.NewLocalHandle(&controllerStateMachine{
 		notifier:   notifier,
 		runningCtx: ctx,
-		state: State{
-			deployments:         map[string]*Deployment{},
-			activeDeployments:   map[string]bool{},
-			runners:             map[string]*Runner{},
-			runnersByDeployment: map[string][]*Runner{},
+		state: SchemaState{
+			deployments:       map[string]*Deployment{},
+			activeDeployments: map[string]bool{},
 		},
 	})
 
 	return statemachine.NewSingleQueryHandle(handle, struct{}{})
+}
+
+type RunnerState struct {
+	runners             map[string]*Runner
+	runnersByDeployment map[string][]*Runner
+}
+
+type RunnerEvent interface {
+	Handle(view RunnerState) (RunnerState, error)
+}
+
+func NewInMemoryRunnerState(ctx context.Context) eventstream.EventStream[RunnerState, RunnerEvent] {
+	return eventstream.NewInMemory[RunnerState, RunnerEvent](RunnerState{
+		runners:             map[string]*Runner{},
+		runnersByDeployment: map[string][]*Runner{},
+	})
 }

--- a/backend/controller/state/controllerstate_test.go
+++ b/backend/controller/state/controllerstate_test.go
@@ -16,7 +16,7 @@ import (
 func TestRunnerState(t *testing.T) {
 	ctx := log.ContextWithNewDefaultLogger(context.Background())
 
-	cs := state.NewInMemoryState(ctx)
+	cs := state.NewInMemoryRunnerState(ctx)
 	view, err := cs.View(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(view.Runners()))
@@ -68,7 +68,7 @@ func TestRunnerState(t *testing.T) {
 
 func TestDeploymentState(t *testing.T) {
 	ctx := log.ContextWithNewDefaultLogger(context.Background())
-	cs := state.NewInMemoryState(ctx)
+	cs := state.NewInMemorySchemaState(ctx)
 	view, err := cs.View(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(view.GetDeployments()))

--- a/backend/controller/state/deployments.go
+++ b/backend/controller/state/deployments.go
@@ -23,7 +23,7 @@ type Deployment struct {
 	Language    string
 }
 
-func (r *State) GetDeployment(deployment model.DeploymentKey) (*Deployment, error) {
+func (r *SchemaState) GetDeployment(deployment model.DeploymentKey) (*Deployment, error) {
 	d, ok := r.deployments[deployment.String()]
 	if !ok {
 		return nil, fmt.Errorf("deployment %s not found", deployment)
@@ -31,11 +31,11 @@ func (r *State) GetDeployment(deployment model.DeploymentKey) (*Deployment, erro
 	return d, nil
 }
 
-func (r *State) GetDeployments() map[string]*Deployment {
+func (r *SchemaState) GetDeployments() map[string]*Deployment {
 	return r.deployments
 }
 
-func (r *State) GetActiveDeployments() map[string]*Deployment {
+func (r *SchemaState) GetActiveDeployments() map[string]*Deployment {
 	deployments := map[string]*Deployment{}
 	for key, active := range r.activeDeployments {
 		if active {
@@ -45,16 +45,16 @@ func (r *State) GetActiveDeployments() map[string]*Deployment {
 	return deployments
 }
 
-func (r *State) GetActiveDeploymentSchemas() []*schema.Module {
+func (r *SchemaState) GetActiveDeploymentSchemas() []*schema.Module {
 	rows := r.GetActiveDeployments()
 	return slices.Map(maps.Values(rows), func(in *Deployment) *schema.Module { return in.Schema })
 }
 
-var _ ControllerEvent = (*DeploymentCreatedEvent)(nil)
-var _ ControllerEvent = (*DeploymentActivatedEvent)(nil)
-var _ ControllerEvent = (*DeploymentDeactivatedEvent)(nil)
-var _ ControllerEvent = (*DeploymentSchemaUpdatedEvent)(nil)
-var _ ControllerEvent = (*DeploymentReplicasUpdatedEvent)(nil)
+var _ SchemaEvent = (*DeploymentCreatedEvent)(nil)
+var _ SchemaEvent = (*DeploymentActivatedEvent)(nil)
+var _ SchemaEvent = (*DeploymentDeactivatedEvent)(nil)
+var _ SchemaEvent = (*DeploymentSchemaUpdatedEvent)(nil)
+var _ SchemaEvent = (*DeploymentReplicasUpdatedEvent)(nil)
 
 type DeploymentCreatedEvent struct {
 	Key       model.DeploymentKey
@@ -65,7 +65,7 @@ type DeploymentCreatedEvent struct {
 	Language  string
 }
 
-func (r *DeploymentCreatedEvent) Handle(t State) (State, error) {
+func (r *DeploymentCreatedEvent) Handle(t SchemaState) (SchemaState, error) {
 	if existing := t.deployments[r.Key.String()]; existing != nil {
 		return t, nil
 	}
@@ -93,7 +93,7 @@ type DeploymentSchemaUpdatedEvent struct {
 	Schema *schema.Module
 }
 
-func (r *DeploymentSchemaUpdatedEvent) Handle(t State) (State, error) {
+func (r *DeploymentSchemaUpdatedEvent) Handle(t SchemaState) (SchemaState, error) {
 	existing, ok := t.deployments[r.Key.String()]
 	if !ok {
 		return t, fmt.Errorf("deployment %s not found", r.Key)
@@ -107,7 +107,7 @@ type DeploymentReplicasUpdatedEvent struct {
 	Replicas int
 }
 
-func (r *DeploymentReplicasUpdatedEvent) Handle(t State) (State, error) {
+func (r *DeploymentReplicasUpdatedEvent) Handle(t SchemaState) (SchemaState, error) {
 	existing, ok := t.deployments[r.Key.String()]
 	if !ok {
 		return t, fmt.Errorf("deployment %s not found", r.Key)
@@ -129,7 +129,7 @@ type DeploymentActivatedEvent struct {
 	MinReplicas int
 }
 
-func (r *DeploymentActivatedEvent) Handle(t State) (State, error) {
+func (r *DeploymentActivatedEvent) Handle(t SchemaState) (SchemaState, error) {
 	existing, ok := t.deployments[r.Key.String()]
 	if !ok {
 		return t, fmt.Errorf("deployment %s not found", r.Key)
@@ -146,7 +146,7 @@ type DeploymentDeactivatedEvent struct {
 	ModuleRemoved bool
 }
 
-func (r *DeploymentDeactivatedEvent) Handle(t State) (State, error) {
+func (r *DeploymentDeactivatedEvent) Handle(t SchemaState) (SchemaState, error) {
 	existing, ok := t.deployments[r.Key.String()]
 	if !ok {
 		return t, fmt.Errorf("deployment %s not found", r.Key)

--- a/backend/controller/state/eventextractor.go
+++ b/backend/controller/state/eventextractor.go
@@ -3,8 +3,8 @@ package state
 import "github.com/alecthomas/types/tuple"
 
 // EventExtractor calculates controller events from changes to the state.
-func EventExtractor(diff tuple.Pair[State, State]) []ControllerEvent {
-	var events []ControllerEvent
+func EventExtractor(diff tuple.Pair[SchemaState, SchemaState]) []SchemaEvent {
+	var events []SchemaEvent
 
 	previous := diff.A
 	current := diff.B

--- a/backend/controller/state/eventextractor_test.go
+++ b/backend/controller/state/eventextractor_test.go
@@ -15,14 +15,14 @@ func TestEventExtractor(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		previous State
-		current  State
-		want     []ControllerEvent
+		previous SchemaState
+		current  SchemaState
+		want     []SchemaEvent
 	}{
 		{
 			name:     "new deployment creates deployment event",
-			previous: State{},
-			current: State{
+			previous: SchemaState{},
+			current: SchemaState{
 				deployments: map[string]*Deployment{
 					"dpl-test-sjkfislfjslfas": {
 						Module:    "test",
@@ -33,7 +33,7 @@ func TestEventExtractor(t *testing.T) {
 					},
 				},
 			},
-			want: []ControllerEvent{
+			want: []SchemaEvent{
 				&DeploymentCreatedEvent{
 					Module:    "test",
 					Key:       deploymentKey(t, "dpl-test-sjkfislfjslfas"),
@@ -45,7 +45,7 @@ func TestEventExtractor(t *testing.T) {
 		},
 		{
 			name: "schema update creates schema updated event",
-			previous: State{
+			previous: SchemaState{
 				deployments: map[string]*Deployment{
 					"dpl-test-sjkfislfjslfas": {
 						Module:    "test",
@@ -56,7 +56,7 @@ func TestEventExtractor(t *testing.T) {
 					},
 				},
 			},
-			current: State{
+			current: SchemaState{
 				deployments: map[string]*Deployment{
 					"dpl-test-sjkfislfjslfas": {
 						Module: "test",
@@ -65,7 +65,7 @@ func TestEventExtractor(t *testing.T) {
 					},
 				},
 			},
-			want: []ControllerEvent{
+			want: []SchemaEvent{
 				&DeploymentSchemaUpdatedEvent{
 					Key:    deploymentKey(t, "dpl-test-sjkfislfjslfas"),
 					Schema: &schema.Module{Name: "test", Metadata: []schema.Metadata{&schema.MetadataArtefact{}}},
@@ -74,7 +74,7 @@ func TestEventExtractor(t *testing.T) {
 		},
 		{
 			name: "deactivated deployment creates deactivation event",
-			previous: State{
+			previous: SchemaState{
 				deployments: map[string]*Deployment{
 					"dpl-test-sjkfislfjslfas": {
 						Module: "test",
@@ -85,7 +85,7 @@ func TestEventExtractor(t *testing.T) {
 					"dpl-test-sjkfislfjslfas": true,
 				},
 			},
-			current: State{
+			current: SchemaState{
 				deployments: map[string]*Deployment{
 					"dpl-test-sjkfislfjslfas": {
 						Module: "test",
@@ -94,7 +94,7 @@ func TestEventExtractor(t *testing.T) {
 				},
 				activeDeployments: map[string]bool{},
 			},
-			want: []ControllerEvent{
+			want: []SchemaEvent{
 				&DeploymentDeactivatedEvent{
 					Key:           deploymentKey(t, "dpl-test-sjkfislfjslfas"),
 					ModuleRemoved: false,
@@ -102,7 +102,7 @@ func TestEventExtractor(t *testing.T) {
 			},
 		}, {
 			name: "removing an active deployment creates module removed event",
-			previous: State{
+			previous: SchemaState{
 				deployments: map[string]*Deployment{
 					"dpl-test-sjkfislfjslfaa": {
 						Module: "test",
@@ -113,10 +113,10 @@ func TestEventExtractor(t *testing.T) {
 					"dpl-test-sjkfislfjslfaa": true,
 				},
 			},
-			current: State{
+			current: SchemaState{
 				deployments: map[string]*Deployment{},
 			},
-			want: []ControllerEvent{
+			want: []SchemaEvent{
 				&DeploymentDeactivatedEvent{
 					Key:           deploymentKey(t, "dpl-test-sjkfislfjslfaa"),
 					ModuleRemoved: true,

--- a/backend/controller/state/runners.go
+++ b/backend/controller/state/runners.go
@@ -18,7 +18,7 @@ type Runner struct {
 	Deployment model.DeploymentKey
 }
 
-func (r *State) Runner(s string) optional.Option[Runner] {
+func (r *RunnerState) Runner(s string) optional.Option[Runner] {
 	result, ok := r.runners[s]
 	if ok {
 		return optional.Ptr(result)
@@ -26,7 +26,7 @@ func (r *State) Runner(s string) optional.Option[Runner] {
 	return optional.None[Runner]()
 }
 
-func (r *State) Runners() []Runner {
+func (r *RunnerState) Runners() []Runner {
 	var ret []Runner
 	for _, v := range r.runners {
 		ret = append(ret, *v)
@@ -34,7 +34,7 @@ func (r *State) Runners() []Runner {
 	return ret
 }
 
-func (r *State) RunnersForDeployment(deployment string) []Runner {
+func (r *RunnerState) RunnersForDeployment(deployment string) []Runner {
 	var ret []Runner
 	for _, v := range r.runnersByDeployment[deployment] {
 		ret = append(ret, *v)
@@ -42,9 +42,9 @@ func (r *State) RunnersForDeployment(deployment string) []Runner {
 	return ret
 }
 
-var _ ControllerEvent = (*RunnerRegisteredEvent)(nil)
+var _ RunnerEvent = (*RunnerRegisteredEvent)(nil)
 var _ eventstream.VerboseMessage = (*RunnerRegisteredEvent)(nil)
-var _ ControllerEvent = (*RunnerDeletedEvent)(nil)
+var _ RunnerEvent = (*RunnerDeletedEvent)(nil)
 
 type RunnerRegisteredEvent struct {
 	Key        model.RunnerKey
@@ -58,7 +58,7 @@ func (r *RunnerRegisteredEvent) VerboseMessage() {
 	// Stops this message being logged every second
 }
 
-func (r *RunnerRegisteredEvent) Handle(t State) (State, error) {
+func (r *RunnerRegisteredEvent) Handle(t RunnerState) (RunnerState, error) {
 	if existing := t.runners[r.Key.String()]; existing != nil {
 		existing.LastSeen = r.Time
 		return t, nil
@@ -80,7 +80,7 @@ type RunnerDeletedEvent struct {
 	Key model.RunnerKey
 }
 
-func (r *RunnerDeletedEvent) Handle(t State) (State, error) {
+func (r *RunnerDeletedEvent) Handle(t RunnerState) (RunnerState, error) {
 	existing := t.runners[r.Key.String()]
 	if existing != nil {
 		delete(t.runners, r.Key.String())

--- a/backend/controller/state/statemachine.go
+++ b/backend/controller/state/statemachine.go
@@ -1,0 +1,38 @@
+package state
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/block/ftl/common/reflect"
+	"github.com/block/ftl/internal/channels"
+	"github.com/block/ftl/internal/statemachine"
+)
+
+type controllerStateMachine struct {
+	state SchemaState
+
+	notifier   *channels.Notifier
+	runningCtx context.Context
+}
+
+var _ statemachine.Listenable[struct{}, SchemaState, SchemaEvent] = &controllerStateMachine{}
+
+func (c *controllerStateMachine) Lookup(key struct{}) (SchemaState, error) {
+	return reflect.DeepCopy(c.state), nil
+}
+
+func (c *controllerStateMachine) Publish(msg SchemaEvent) error {
+	var err error
+	c.state, err = msg.Handle(c.state)
+	if err != nil {
+		return fmt.Errorf("update: %w", err)
+	}
+	// Notify all subscribers using broadcaster
+	c.notifier.Notify(c.runningCtx)
+	return nil
+}
+
+func (c *controllerStateMachine) Subscribe(ctx context.Context) (<-chan struct{}, error) {
+	return c.notifier.Subscribe(), nil
+}

--- a/backend/protos/xyz/block/ftl/v1/mixins.go
+++ b/backend/protos/xyz/block/ftl/v1/mixins.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 
 	"github.com/alecthomas/types/optional"
-
 	"github.com/block/ftl/backend/controller/state"
 )
 

--- a/backend/protos/xyz/block/ftl/v1/mixins.go
+++ b/backend/protos/xyz/block/ftl/v1/mixins.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/alecthomas/types/optional"
+
 	"github.com/block/ftl/backend/controller/state"
 )
 


### PR DESCRIPTION
Eventually, we will want to include runner state in the runtime of schemas. However, for now, separate the schema state from runner state so we can move the schema state management into a separate service without explicitly including runners in its API