### PR TITLE
chore: make KeyType comparable, so that we can retain the type safety when using them as map keys

### DIFF
--- a/backend/controller/state/controllerstate.go
+++ b/backend/controller/state/controllerstate.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/block/ftl/internal/channels"
 	"github.com/block/ftl/internal/eventstream"
+	"github.com/block/ftl/internal/model"
 	"github.com/block/ftl/internal/statemachine"
 )
 
@@ -13,8 +14,8 @@ type SchemaEvent interface {
 }
 
 type SchemaState struct {
-	deployments       map[string]*Deployment
-	activeDeployments map[string]bool
+	deployments       map[model.DeploymentKey]*Deployment
+	activeDeployments map[model.DeploymentKey]bool
 }
 
 func NewInMemorySchemaState(ctx context.Context) *statemachine.SingleQueryHandle[struct{}, SchemaState, SchemaEvent] {
@@ -23,8 +24,8 @@ func NewInMemorySchemaState(ctx context.Context) *statemachine.SingleQueryHandle
 		notifier:   notifier,
 		runningCtx: ctx,
 		state: SchemaState{
-			deployments:       map[string]*Deployment{},
-			activeDeployments: map[string]bool{},
+			deployments:       map[model.DeploymentKey]*Deployment{},
+			activeDeployments: map[model.DeploymentKey]bool{},
 		},
 	})
 
@@ -32,8 +33,8 @@ func NewInMemorySchemaState(ctx context.Context) *statemachine.SingleQueryHandle
 }
 
 type RunnerState struct {
-	runners             map[string]*Runner
-	runnersByDeployment map[string][]*Runner
+	runners             map[model.RunnerKey]*Runner
+	runnersByDeployment map[model.DeploymentKey][]*Runner
 }
 
 type RunnerEvent interface {
@@ -42,7 +43,7 @@ type RunnerEvent interface {
 
 func NewInMemoryRunnerState(ctx context.Context) eventstream.EventStream[RunnerState, RunnerEvent] {
 	return eventstream.NewInMemory[RunnerState, RunnerEvent](RunnerState{
-		runners:             map[string]*Runner{},
-		runnersByDeployment: map[string][]*Runner{},
+		runners:             map[model.RunnerKey]*Runner{},
+		runnersByDeployment: map[model.DeploymentKey][]*Runner{},
 	})
 }

--- a/backend/controller/state/controllerstate_test.go
+++ b/backend/controller/state/controllerstate_test.go
@@ -84,8 +84,8 @@ func TestDeploymentState(t *testing.T) {
 	view, err = cs.View(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(view.GetDeployments()))
-	assert.Equal(t, deploymentKey, view.GetDeployments()[deploymentKey.String()].Key)
-	assert.Equal(t, create, view.GetDeployments()[deploymentKey.String()].CreatedAt)
+	assert.Equal(t, deploymentKey, view.GetDeployments()[deploymentKey].Key)
+	assert.Equal(t, create, view.GetDeployments()[deploymentKey].CreatedAt)
 
 	activate := time.Now()
 	err = cs.Publish(ctx, &state.DeploymentActivatedEvent{
@@ -96,8 +96,8 @@ func TestDeploymentState(t *testing.T) {
 	assert.NoError(t, err)
 	view, err = cs.View(ctx)
 	assert.NoError(t, err)
-	assert.Equal(t, 1, view.GetDeployments()[deploymentKey.String()].MinReplicas)
-	assert.Equal(t, activate, view.GetDeployments()[deploymentKey.String()].ActivatedAt.MustGet())
+	assert.Equal(t, 1, view.GetDeployments()[deploymentKey].MinReplicas)
+	assert.Equal(t, activate, view.GetDeployments()[deploymentKey].ActivatedAt.MustGet())
 
 	err = cs.Publish(ctx, &state.DeploymentDeactivatedEvent{
 		Key: deploymentKey,
@@ -105,5 +105,5 @@ func TestDeploymentState(t *testing.T) {
 	assert.NoError(t, err)
 	view, err = cs.View(ctx)
 	assert.NoError(t, err)
-	assert.Equal(t, 0, view.GetDeployments()[deploymentKey.String()].MinReplicas)
+	assert.Equal(t, 0, view.GetDeployments()[deploymentKey].MinReplicas)
 }

--- a/backend/controller/state/deployments.go
+++ b/backend/controller/state/deployments.go
@@ -24,19 +24,19 @@ type Deployment struct {
 }
 
 func (r *SchemaState) GetDeployment(deployment model.DeploymentKey) (*Deployment, error) {
-	d, ok := r.deployments[deployment.String()]
+	d, ok := r.deployments[deployment]
 	if !ok {
 		return nil, fmt.Errorf("deployment %s not found", deployment)
 	}
 	return d, nil
 }
 
-func (r *SchemaState) GetDeployments() map[string]*Deployment {
+func (r *SchemaState) GetDeployments() map[model.DeploymentKey]*Deployment {
 	return r.deployments
 }
 
-func (r *SchemaState) GetActiveDeployments() map[string]*Deployment {
-	deployments := map[string]*Deployment{}
+func (r *SchemaState) GetActiveDeployments() map[model.DeploymentKey]*Deployment {
+	deployments := map[model.DeploymentKey]*Deployment{}
 	for key, active := range r.activeDeployments {
 		if active {
 			deployments[key] = r.deployments[key]
@@ -66,7 +66,7 @@ type DeploymentCreatedEvent struct {
 }
 
 func (r *DeploymentCreatedEvent) Handle(t SchemaState) (SchemaState, error) {
-	if existing := t.deployments[r.Key.String()]; existing != nil {
+	if existing := t.deployments[r.Key]; existing != nil {
 		return t, nil
 	}
 	n := Deployment{
@@ -84,7 +84,7 @@ func (r *DeploymentCreatedEvent) Handle(t SchemaState) (SchemaState, error) {
 			Executable: a.Executable,
 		}
 	}
-	t.deployments[r.Key.String()] = &n
+	t.deployments[r.Key] = &n
 	return t, nil
 }
 
@@ -94,7 +94,7 @@ type DeploymentSchemaUpdatedEvent struct {
 }
 
 func (r *DeploymentSchemaUpdatedEvent) Handle(t SchemaState) (SchemaState, error) {
-	existing, ok := t.deployments[r.Key.String()]
+	existing, ok := t.deployments[r.Key]
 	if !ok {
 		return t, fmt.Errorf("deployment %s not found", r.Key)
 	}
@@ -108,7 +108,7 @@ type DeploymentReplicasUpdatedEvent struct {
 }
 
 func (r *DeploymentReplicasUpdatedEvent) Handle(t SchemaState) (SchemaState, error) {
-	existing, ok := t.deployments[r.Key.String()]
+	existing, ok := t.deployments[r.Key]
 	if !ok {
 		return t, fmt.Errorf("deployment %s not found", r.Key)
 	}
@@ -130,14 +130,14 @@ type DeploymentActivatedEvent struct {
 }
 
 func (r *DeploymentActivatedEvent) Handle(t SchemaState) (SchemaState, error) {
-	existing, ok := t.deployments[r.Key.String()]
+	existing, ok := t.deployments[r.Key]
 	if !ok {
 		return t, fmt.Errorf("deployment %s not found", r.Key)
 
 	}
 	existing.ActivatedAt = optional.Some(r.ActivatedAt)
 	existing.MinReplicas = r.MinReplicas
-	t.activeDeployments[r.Key.String()] = true
+	t.activeDeployments[r.Key] = true
 	return t, nil
 }
 
@@ -147,12 +147,12 @@ type DeploymentDeactivatedEvent struct {
 }
 
 func (r *DeploymentDeactivatedEvent) Handle(t SchemaState) (SchemaState, error) {
-	existing, ok := t.deployments[r.Key.String()]
+	existing, ok := t.deployments[r.Key]
 	if !ok {
 		return t, fmt.Errorf("deployment %s not found", r.Key)
 
 	}
 	existing.MinReplicas = 0
-	delete(t.activeDeployments, r.Key.String())
+	delete(t.activeDeployments, r.Key)
 	return t, nil
 }

--- a/backend/controller/state/eventextractor.go
+++ b/backend/controller/state/eventextractor.go
@@ -17,7 +17,7 @@ func EventExtractor(diff tuple.Pair[SchemaState, SchemaState]) iter.Seq[SchemaEv
 
 	previousAll := previous.GetDeployments()
 	for _, deployment := range current.GetDeployments() {
-		pd, ok := previousAll[deployment.Key.String()]
+		pd, ok := previousAll[deployment.Key]
 		if !ok {
 			events = append(events, &DeploymentCreatedEvent{
 				Module:    deployment.Module,
@@ -41,7 +41,7 @@ func EventExtractor(diff tuple.Pair[SchemaState, SchemaState]) iter.Seq[SchemaEv
 		currentModules[deployment.Module] = true
 	}
 	for _, deployment := range previous.GetActiveDeployments() {
-		if _, ok := currentActive[deployment.Key.String()]; !ok {
+		if _, ok := currentActive[deployment.Key]; !ok {
 			_, ok2 := currentModules[deployment.Module]
 			events = append(events, &DeploymentDeactivatedEvent{
 				Key:           deployment.Key,

--- a/backend/controller/state/eventextractor_test.go
+++ b/backend/controller/state/eventextractor_test.go
@@ -24,8 +24,8 @@ func TestEventExtractor(t *testing.T) {
 			name:     "new deployment creates deployment event",
 			previous: SchemaState{},
 			current: SchemaState{
-				deployments: map[string]*Deployment{
-					"dpl-test-sjkfislfjslfas": {
+				deployments: map[model.DeploymentKey]*Deployment{
+					deploymentKey(t, "dpl-test-sjkfislfjslfas"): {
 						Module:    "test",
 						Key:       deploymentKey(t, "dpl-test-sjkfislfjslfas"),
 						CreatedAt: now,
@@ -47,8 +47,8 @@ func TestEventExtractor(t *testing.T) {
 		{
 			name: "schema update creates schema updated event",
 			previous: SchemaState{
-				deployments: map[string]*Deployment{
-					"dpl-test-sjkfislfjslfas": {
+				deployments: map[model.DeploymentKey]*Deployment{
+					deploymentKey(t, "dpl-test-sjkfislfjslfas"): {
 						Module:    "test",
 						Key:       deploymentKey(t, "dpl-test-sjkfislfjslfas"),
 						CreatedAt: now,
@@ -58,8 +58,8 @@ func TestEventExtractor(t *testing.T) {
 				},
 			},
 			current: SchemaState{
-				deployments: map[string]*Deployment{
-					"dpl-test-sjkfislfjslfas": {
+				deployments: map[model.DeploymentKey]*Deployment{
+					deploymentKey(t, "dpl-test-sjkfislfjslfas"): {
 						Module: "test",
 						Key:    deploymentKey(t, "dpl-test-sjkfislfjslfas"),
 						Schema: &schema.Module{Name: "test", Metadata: []schema.Metadata{&schema.MetadataArtefact{}}},
@@ -76,24 +76,24 @@ func TestEventExtractor(t *testing.T) {
 		{
 			name: "deactivated deployment creates deactivation event",
 			previous: SchemaState{
-				deployments: map[string]*Deployment{
-					"dpl-test-sjkfislfjslfas": {
+				deployments: map[model.DeploymentKey]*Deployment{
+					deploymentKey(t, "dpl-test-sjkfislfjslfas"): {
 						Module: "test",
 						Key:    deploymentKey(t, "dpl-test-sjkfislfjslfas"),
 					},
 				},
-				activeDeployments: map[string]bool{
-					"dpl-test-sjkfislfjslfas": true,
+				activeDeployments: map[model.DeploymentKey]bool{
+					deploymentKey(t, "dpl-test-sjkfislfjslfas"): true,
 				},
 			},
 			current: SchemaState{
-				deployments: map[string]*Deployment{
-					"dpl-test-sjkfislfjslfas": {
+				deployments: map[model.DeploymentKey]*Deployment{
+					deploymentKey(t, "dpl-test-sjkfislfjslfas"): {
 						Module: "test",
 						Key:    deploymentKey(t, "dpl-test-sjkfislfjslfas"),
 					},
 				},
-				activeDeployments: map[string]bool{},
+				activeDeployments: map[model.DeploymentKey]bool{},
 			},
 			want: []SchemaEvent{
 				&DeploymentDeactivatedEvent{
@@ -104,18 +104,18 @@ func TestEventExtractor(t *testing.T) {
 		}, {
 			name: "removing an active deployment creates module removed event",
 			previous: SchemaState{
-				deployments: map[string]*Deployment{
-					"dpl-test-sjkfislfjslfaa": {
+				deployments: map[model.DeploymentKey]*Deployment{
+					deploymentKey(t, "dpl-test-sjkfislfjslfaa"): {
 						Module: "test",
 						Key:    deploymentKey(t, "dpl-test-sjkfislfjslfaa"),
 					},
 				},
-				activeDeployments: map[string]bool{
-					"dpl-test-sjkfislfjslfaa": true,
+				activeDeployments: map[model.DeploymentKey]bool{
+					deploymentKey(t, "dpl-test-sjkfislfjslfaa"): true,
 				},
 			},
 			current: SchemaState{
-				deployments: map[string]*Deployment{},
+				deployments: map[model.DeploymentKey]*Deployment{},
 			},
 			want: []SchemaEvent{
 				&DeploymentDeactivatedEvent{

--- a/backend/controller/state/runners.go
+++ b/backend/controller/state/runners.go
@@ -18,7 +18,7 @@ type Runner struct {
 	Deployment model.DeploymentKey
 }
 
-func (r *RunnerState) Runner(s string) optional.Option[Runner] {
+func (r *RunnerState) Runner(s model.RunnerKey) optional.Option[Runner] {
 	result, ok := r.runners[s]
 	if ok {
 		return optional.Ptr(result)
@@ -34,7 +34,7 @@ func (r *RunnerState) Runners() []Runner {
 	return ret
 }
 
-func (r *RunnerState) RunnersForDeployment(deployment string) []Runner {
+func (r *RunnerState) RunnersForDeployment(deployment model.DeploymentKey) []Runner {
 	var ret []Runner
 	for _, v := range r.runnersByDeployment[deployment] {
 		ret = append(ret, *v)
@@ -59,7 +59,7 @@ func (r *RunnerRegisteredEvent) VerboseMessage() {
 }
 
 func (r *RunnerRegisteredEvent) Handle(t RunnerState) (RunnerState, error) {
-	if existing := t.runners[r.Key.String()]; existing != nil {
+	if existing := t.runners[r.Key]; existing != nil {
 		existing.LastSeen = r.Time
 		return t, nil
 	}
@@ -71,8 +71,8 @@ func (r *RunnerRegisteredEvent) Handle(t RunnerState) (RunnerState, error) {
 		Module:     r.Module,
 		Deployment: r.Deployment,
 	}
-	t.runners[r.Key.String()] = &n
-	t.runnersByDeployment[r.Deployment.String()] = append(t.runnersByDeployment[r.Deployment.String()], &n)
+	t.runners[r.Key] = &n
+	t.runnersByDeployment[r.Deployment] = append(t.runnersByDeployment[r.Deployment], &n)
 	return t, nil
 }
 
@@ -81,9 +81,9 @@ type RunnerDeletedEvent struct {
 }
 
 func (r *RunnerDeletedEvent) Handle(t RunnerState) (RunnerState, error) {
-	existing := t.runners[r.Key.String()]
+	existing := t.runners[r.Key]
 	if existing != nil {
-		delete(t.runners, r.Key.String())
+		delete(t.runners, r.Key)
 	}
 	return t, nil
 }

--- a/internal/model/deployment_key_test.go
+++ b/internal/model/deployment_key_test.go
@@ -17,22 +17,21 @@ func TestDeploymentKey(t *testing.T) {
 		{key: NewDeploymentKey("time"),
 			expected: DeploymentKey{
 				Payload: DeploymentPayload{Module: "time"},
-				Suffix:  []byte("\x01\x94\xfd\xc2\xfa/\xfc\xc0A\xd3"),
+				Suffix:  "17snepfuemu5iab",
 			},
 		},
 		{key: NewDeploymentKey("time"),
 			expected: DeploymentKey{
 				Payload: DeploymentPayload{Module: "time"},
-				Suffix:  []byte("\xff\x12\x04[s\xc8nO\xf9_"),
+				Suffix:  "5g5cadeqxpqe574v",
 			},
 		},
 		{str: "-0011223344", expectedErr: `expected prefix "dpl" for key "-0011223344"`},
 		{key: NewDeploymentKey("module-with-hyphens"), expected: DeploymentKey{
 			Payload: DeploymentPayload{Module: "module-with-hyphens"},
-			Suffix:  []byte("\xf6b\xa5\xee\xe8*\xbd\xf4J-"),
+			Suffix:  "59gwlv6lkyexwxf1",
 		},
 		},
-		// {str: "-", decodeErr: true},
 	} {
 		keyStr := test.str
 		if keyStr == "" {

--- a/internal/model/runner_key_test.go
+++ b/internal/model/runner_key_test.go
@@ -27,7 +27,7 @@ func TestRunnerKey(t *testing.T) {
 		{key: NewRunnerKey("0.0.0.0", "8080"),
 			expected: RunnerKey{
 				Payload: RunnerPayload{HostPortMixin{Hostname: optional.Some("0.0.0.0"), Port: "8080"}},
-				Suffix:  []byte("\x01\x94\xfd\xc2\xfa/\xfc\xc0A\xd3"),
+				Suffix:  "17snepfuemu5iab",
 			},
 			expectedStr: "rnr-0.0.0.0-8080-17snepfuemu5iab"},
 		{key: NewRunnerKey("example-host-with-hyphens", "0"),
@@ -39,7 +39,7 @@ func TestRunnerKey(t *testing.T) {
 		{key: NewRunnerKey("rnr-hostwithprefixandfakeport-80", "80"),
 			expected: RunnerKey{
 				Payload: RunnerPayload{HostPortMixin{Hostname: optional.Some("rnr-hostwithprefixandfakeport-80"), Port: "80"}},
-				Suffix:  []byte("\xb1\r9FQ\x85\x0fԡx"),
+				Suffix:  "3s5h946y6kylrxx4",
 			},
 			expectedStr: "rnr-rnr-hostwithprefixandfakeport-80-80-3s5h946y6kylrxx4"},
 


### PR DESCRIPTION
Unfortunately `[]byte` is not `comparable` in go, so I had to convert that to string.