### PR TITLE
chore: consistent capitalisation of FTL in poms

### DIFF
--- a/jvm-runtime/ftl-runtime/common/bom/pom.xml
+++ b/jvm-runtime/ftl-runtime/common/bom/pom.xml
@@ -9,7 +9,7 @@
         <version>1.0-SNAPSHOT</version>
     </parent>
     <artifactId>ftl-jvm-bom</artifactId>
-    <name>Ftl JVM BOM</name>
+    <name>FTL JVM BOM</name>
 
     <dependencyManagement>
         <dependencies>

--- a/jvm-runtime/ftl-runtime/common/build-parent/pom.xml
+++ b/jvm-runtime/ftl-runtime/common/build-parent/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <artifactId>ftl-build-parent</artifactId>
     <packaging>pom</packaging>
-    <name>Ftl JVM Build Parent POM</name>
+    <name>FTL JVM Build Parent POM</name>
     <description>This pom.xml can be used as a parent pom to inherit all required configuration to build a FTL app.</description>
     <properties>
         <ftl.version>1.0-SNAPSHOT</ftl.version>

--- a/jvm-runtime/ftl-runtime/common/deployment/pom.xml
+++ b/jvm-runtime/ftl-runtime/common/deployment/pom.xml
@@ -8,7 +8,7 @@
         <version>1.0-SNAPSHOT</version>
     </parent>
     <artifactId>ftl-jvm-runtime-deployment</artifactId>
-    <name>Ftl Java Runtime - Deployment</name>
+    <name>FTL Java Runtime - Deployment</name>
 
     <dependencies>
         <dependency>

--- a/jvm-runtime/ftl-runtime/common/runtime/pom.xml
+++ b/jvm-runtime/ftl-runtime/common/runtime/pom.xml
@@ -9,7 +9,7 @@
         <version>1.0-SNAPSHOT</version>
     </parent>
     <artifactId>ftl-jvm-runtime</artifactId>
-    <name>Ftl Java Runtime - Runtime</name>
+    <name>FTL Java Runtime - Runtime</name>
 
     <dependencies>
         <dependency>

--- a/jvm-runtime/ftl-runtime/java/build-parent/pom.xml
+++ b/jvm-runtime/ftl-runtime/java/build-parent/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <artifactId>ftl-build-parent-java</artifactId>
     <packaging>pom</packaging>
-    <name>Ftl Java Build Parent POM</name>
+    <name>FTL Java Build Parent POM</name>
     <description>This pom.xml can be used as a parent pom to inherit all required configuration to build a FTL Java app.</description>
 
     <dependencies>

--- a/jvm-runtime/ftl-runtime/java/deployment/pom.xml
+++ b/jvm-runtime/ftl-runtime/java/deployment/pom.xml
@@ -8,7 +8,7 @@
         <version>1.0-SNAPSHOT</version>
     </parent>
     <artifactId>ftl-java-runtime-deployment</artifactId>
-    <name>Ftl Java Runtime - Deployment</name>
+    <name>FTL Java Runtime - Deployment</name>
 
     <dependencies>
         <dependency>

--- a/jvm-runtime/ftl-runtime/java/runtime/pom.xml
+++ b/jvm-runtime/ftl-runtime/java/runtime/pom.xml
@@ -9,7 +9,7 @@
         <version>1.0-SNAPSHOT</version>
     </parent>
     <artifactId>ftl-java-runtime</artifactId>
-    <name>Ftl Java Runtime</name>
+    <name>FTL Java Runtime</name>
 
     <dependencies>
         <dependency>

--- a/jvm-runtime/ftl-runtime/kotlin/build-parent/pom.xml
+++ b/jvm-runtime/ftl-runtime/kotlin/build-parent/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <artifactId>ftl-build-parent-kotlin</artifactId>
     <packaging>pom</packaging>
-    <name>Ftl Kotlin Build Parent POM</name>
+    <name>FTL Kotlin Build Parent POM</name>
     <description>This pom.xml can be used as a parent pom to inherit all required configuration to build a FTL Kotlin
         app.
     </description>

--- a/jvm-runtime/ftl-runtime/kotlin/deployment/pom.xml
+++ b/jvm-runtime/ftl-runtime/kotlin/deployment/pom.xml
@@ -8,7 +8,7 @@
         <version>1.0-SNAPSHOT</version>
     </parent>
     <artifactId>ftl-kotlin-runtime-deployment</artifactId>
-    <name>Ftl Kotlin Runtime - Deployment</name>
+    <name>FTL Kotlin Runtime - Deployment</name>
 
     <dependencies>
         <dependency>

--- a/jvm-runtime/ftl-runtime/kotlin/runtime/pom.xml
+++ b/jvm-runtime/ftl-runtime/kotlin/runtime/pom.xml
@@ -9,7 +9,7 @@
         <version>1.0-SNAPSHOT</version>
     </parent>
     <artifactId>ftl-kotlin-runtime</artifactId>
-    <name>Ftl Kotlin Runtime</name>
+    <name>FTL Kotlin Runtime</name>
 
     <dependencies>
         <dependency>

--- a/jvm-runtime/ftl-runtime/pom.xml
+++ b/jvm-runtime/ftl-runtime/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>ftl-jvm-parent</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
-    <name>Ftl Java Runtime - Parent</name>
+    <name>FTL Java Runtime - Parent</name>
     <description>Towards a 𝝺-calculus for large-scale systems</description>
     <url>https://block.github.io/ftl/</url>
 

--- a/jvm-runtime/ftl-runtime/test-framework/pom.xml
+++ b/jvm-runtime/ftl-runtime/test-framework/pom.xml
@@ -8,7 +8,7 @@
         <version>1.0-SNAPSHOT</version>
     </parent>
     <artifactId>ftl-jvm-test-framework</artifactId>
-    <name>Ftl JVM Runtime - Test Framework</name>
+    <name>FTL JVM Runtime - Test Framework</name>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
Makes JVM names consistent
Old:
<img width="518" alt="Screenshot 2025-01-14 at 11 43 57 am" src="https://github.com/user-attachments/assets/ecc9026f-cf35-4af4-b38b-e7686993d19d" />
