### PR TITLE
fix: prevent discovery of modules while scaffolding modules

### DIFF
--- a/go-runtime/goplugin/service.go
+++ b/go-runtime/goplugin/service.go
@@ -238,7 +238,7 @@ func (s *Service) Build(ctx context.Context, req *connect.Request[langpb.BuildRe
 		return err
 	}
 
-	watcher := watch.NewWatcher(watchPatterns...)
+	watcher := watch.NewWatcher(optional.None[string](), watchPatterns...)
 
 	ongoingState := &compile.OngoingState{}
 

--- a/internal/buildengine/engine.go
+++ b/internal/buildengine/engine.go
@@ -145,7 +145,7 @@ func New(
 		projectConfig:    projectConfig,
 		moduleDirs:       moduleDirs,
 		moduleMetas:      xsync.NewMapOf[string, moduleMeta](),
-		watcher:          watch.NewWatcher("ftl.toml"),
+		watcher:          watch.NewWatcher(optional.Some(projectConfig.WatchModulesLockPath()), "ftl.toml"),
 		controllerSchema: xsync.NewMapOf[string, *schema.Module](),
 		schemaChanges:    pubsub.New[schemaeventsource.Event](),
 		pluginEvents:     make(chan languageplugin.PluginEvent, 128),

--- a/internal/projectconfig/projectconfig.go
+++ b/internal/projectconfig/projectconfig.go
@@ -218,3 +218,8 @@ func (c Config) SchemaPath(module string) string {
 func (c Config) SQLCGenFTLPath() string {
 	return filepath.Join(c.Root(), ".ftl", "resources", "sqlc-gen-ftl.wasm")
 }
+
+// WatchModulesLockPath returns the path to the lock file used to prevent scaffolding new modules while discovering modules.
+func (c Config) WatchModulesLockPath() string {
+	return filepath.Join(c.Root(), ".ftl", "modules.lock")
+}

--- a/internal/watch/watch_integration_test.go
+++ b/internal/watch/watch_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/alecthomas/assert/v2"
+	"github.com/alecthomas/types/optional"
 	"github.com/alecthomas/types/pubsub"
 
 	in "github.com/block/ftl/internal/integration"
@@ -23,7 +24,7 @@ func TestWatch(t *testing.T) {
 	var topic *pubsub.Topic[WatchEvent]
 	var one, two moduleconfig.UnvalidatedModuleConfig
 
-	w := NewWatcher("**/*.go", "go.mod", "go.sum")
+	w := NewWatcher(optional.None[string](), "**/*.go", "go.mod", "go.sum")
 	in.Run(t,
 		func(tb testing.TB, ic in.TestContext) {
 			events, topic = startWatching(ic, t, w, ic.WorkingDir())
@@ -68,7 +69,7 @@ func TestWatchWithBuildModifyingFiles(t *testing.T) {
 	var events chan WatchEvent
 	var topic *pubsub.Topic[WatchEvent]
 	var transaction ModifyFilesTransaction
-	w := NewWatcher("**/*.go", "go.mod", "go.sum")
+	w := NewWatcher(optional.None[string](), "**/*.go", "go.mod", "go.sum")
 
 	in.Run(t,
 		func(tb testing.TB, ic in.TestContext) {
@@ -104,7 +105,7 @@ func TestWatchWithBuildAndUserModifyingFiles(t *testing.T) {
 	var events chan WatchEvent
 	var topic *pubsub.Topic[WatchEvent]
 	var transaction ModifyFilesTransaction
-	w := NewWatcher("**/*.go", "go.mod", "go.sum")
+	w := NewWatcher(optional.None[string](), "**/*.go", "go.mod", "go.sum")
 
 	in.Run(t,
 		func(tb testing.TB, ic in.TestContext) {

--- a/jvm-runtime/plugin/common/jvmcommon.go
+++ b/jvm-runtime/plugin/common/jvmcommon.go
@@ -18,6 +18,7 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/alecthomas/atomic"
+	"github.com/alecthomas/types/optional"
 	"github.com/alecthomas/types/pubsub"
 	"github.com/beevik/etree"
 	"github.com/block/scaffolder"
@@ -222,7 +223,7 @@ func (s *Service) runDevMode(ctx context.Context, req *connect.Request[langpb.Bu
 	if err != nil {
 		return err
 	}
-	watcher := watch.NewWatcher(watchPatterns...)
+	watcher := watch.NewWatcher(optional.None[string](), watchPatterns...)
 	fileEvents := make(chan watch.WatchEventModuleChanged, 32)
 	if err := watchFiles(ctx, watcher, buildCtx, fileEvents); err != nil {
 		return err


### PR DESCRIPTION
fixes https://github.com/block/ftl/issues/4039

`watch` can now be configured to only discover modules while it has acquisition of a file lock.
This allows coordination with `ftl new` so that half scaffolded modules are not detected too quickly, causing build errors.
