### PR TITLE
fix: formatting of go compiler errors

### DIFF
--- a/backend/protos/xyz/block/ftl/language/v1/mixins.go
+++ b/backend/protos/xyz/block/ftl/language/v1/mixins.go
@@ -33,16 +33,17 @@ func ErrorString(err *Error) string {
 	return err.Msg
 }
 
-// ErrorListString formats all errors in a languagepb.ErrorList, one per line
+// ErrorListString formats all errors in a languagepb.ErrorList using builderrors.Error formatting
 func ErrorListString(errList *ErrorList) string {
 	if errList == nil || len(errList.Errors) == 0 {
 		return ""
 	}
-	result := make([]string, len(errList.Errors))
-	for i, err := range errList.Errors {
-		result[i] = ErrorString(err)
+	errs := ErrorsFromProto(errList)
+	result := make([]string, len(errs))
+	for i, err := range errs {
+		result[i] = err.Error()
 	}
-	return strings.Join(result, "\n")
+	return strings.Join(result, ": ")
 }
 
 // positionString formats a languagepb.Position similar to builderrors.Position

--- a/cmd/go2proto/testdata/go2proto.to.go
+++ b/cmd/go2proto/testdata/go2proto.to.go
@@ -8,8 +8,8 @@ import "google.golang.org/protobuf/proto"
 import "google.golang.org/protobuf/types/known/timestamppb"
 import "google.golang.org/protobuf/types/known/durationpb"
 
-import "github.com/block/ftl/internal/key"
 import "net/url"
+import "github.com/block/ftl/internal/key"
 
 var _ fmt.Stringer
 var _ = timestamppb.Timestamp{}

--- a/examples/go/echo/types.ftl.go
+++ b/examples/go/echo/types.ftl.go
@@ -2,10 +2,10 @@
 package echo
 
 import (
-	"context"
-	ftltime "ftl/time"
-	"github.com/block/ftl/common/reflection"
-	"github.com/block/ftl/go-runtime/server"
+    "context"
+    "github.com/block/ftl/common/reflection"
+    "github.com/block/ftl/go-runtime/server"
+    ftltime "ftl/time"
 )
 
 type EchoClient func(context.Context, EchoRequest) (EchoResponse, error)
@@ -13,8 +13,8 @@ type EchoClient func(context.Context, EchoRequest) (EchoResponse, error)
 func init() {
 	reflection.Register(
 		reflection.ProvideResourcesForVerb(
-			Echo,
-			server.VerbClient[ftltime.TimeClient, ftltime.TimeRequest, ftltime.TimeResponse](),
+            Echo,
+            server.VerbClient[ftltime.TimeClient, ftltime.TimeRequest, ftltime.TimeResponse](),
 			server.Config[string]("echo", "default"),
 		),
 	)

--- a/go-runtime/compile/build.go
+++ b/go-runtime/compile/build.go
@@ -554,7 +554,9 @@ func compile(ctx context.Context, mainDir string, buildEnv []string, devMode boo
 	buildEnv = append(buildEnv, "GODEBUG=http2client=0")
 	err := exec.CommandWithEnv(ctx, log.Debug, mainDir, buildEnv, "go", args...).RunStderrError(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to compile: %w", err)
+		// Clean up Go compiler error format to be single line
+		errStr := strings.ReplaceAll(err.Error(), "\n", " ")
+		return fmt.Errorf("failed to compile: %s", errStr)
 	}
 	return nil
 }


### PR DESCRIPTION
Compiler errors can have newlines in them, which seems to break our terminal formatting. Removing those newlines.

BEFORE:
![Screenshot 2025-01-15 at 9 50 00 AM](https://github.com/user-attachments/assets/f2739828-729e-4625-9593-621ca5722b27)

AFTER:
![Screenshot 2025-01-15 at 9 49 15 AM](https://github.com/user-attachments/assets/aed7c061-7f5e-40c6-a6cb-6c9e593166a0)
