### PR TITLE
chore: log deployment finished as info

### DIFF
--- a/internal/buildengine/deploy.go
+++ b/internal/buildengine/deploy.go
@@ -112,7 +112,7 @@ func Deploy(ctx context.Context, projectConfig projectconfig.Config, module Modu
 		if err != nil {
 			return err
 		}
-		logger.Debugf("Deployment %s became ready", resp.Msg.DeploymentKey)
+		logger.Infof("Deployment %s became ready", resp.Msg.DeploymentKey)
 	}
 
 	return nil


### PR DESCRIPTION
closes https://github.com/block/ftl/issues/4062
We were logging the start of deployment at info level, but not the completion log.