### PR TITLE
docs: flesh out the types documentation

### DIFF
--- a/docs/content/docs/help/glossary.md
+++ b/docs/content/docs/help/glossary.md
@@ -18,30 +18,30 @@ top = false
 
 A Verb is a remotely callable function that takes an input and returns an output.
 
-```go
-func(context.Context, In) (Out, error)
+```
+F(I) -> O
 ```
 
 ##### Sink
 
 A Sink is a function that takes an input and returns nothing.
 
-```go
-func(context.Context, In) error
+```
+F(I)
 ```
 
 ##### Source
 
 A Source is a function that takes no input and returns an output.
 
-```go
-func(context.Context) (Out, error)
+```
+F() -> O
 ```
 
 ##### Empty
 
 An Empty function is one that takes neither input or output.
 
-```go
-func(context.Context) error
+```
+F()
 ```


### PR DESCRIPTION
Added a table for basic types, and sections for the more complex types such as sum types. Each section includes examples in the three main supported languages.

Note: there are some TODOs

<img width="1320" alt="image" src="https://github.com/user-attachments/assets/1894b215-0207-4e5e-9f02-780b0e1b9eab" />
