### PR TITLE
fix: missing language in the deployment runtime status

### DIFF
--- a/backend/controller/controller.go
+++ b/backend/controller/controller.go
@@ -309,8 +309,9 @@ func (s *Service) Status(ctx context.Context, req *connect.Request[ftlv1.StatusR
 	for key, deployment := range status {
 		deployments = append(deployments, &ftlv1.StatusResponse_Deployment{
 			Key:         key.String(),
+			Language:    deployment.Runtime.Base.Language,
 			Name:        deployment.Name,
-			MinReplicas: deployment.GetRuntime().GetScaling().GetMinReplicas(),
+			MinReplicas: deployment.Runtime.Scaling.MinReplicas,
 			Replicas:    replicas[key.String()],
 			Schema:      deployment.ToProto(),
 		})


### PR DESCRIPTION
BEFORE:
![Screenshot 2025-01-23 at 11 06 07 AM](https://github.com/user-attachments/assets/9bdd4607-45ef-45e1-ba9c-45e307de8b68)

`ftl status`
```json
{
  "key": "dpl-echo-1b4ika76nibqepu0",
  "name": "echo",
  "minReplicas": 1,
  "replicas": 1
},
```

AFTER:
![Screenshot 2025-01-23 at 11 07 11 AM](https://github.com/user-attachments/assets/91a69e0d-b1f1-4265-8072-3c3a3c149f8e)

`ftl status`
```json
{
  "key": "dpl-echo-ylcjj355jm6dja",
  "language": "go",
  "name": "echo",
  "minReplicas": 1,
  "replicas": 1
},
```