### PR TITLE
chore(rollup): update rollup config to fix warnings

### DIFF
--- a/frontend/console/package.json
+++ b/frontend/console/package.json
@@ -11,6 +11,7 @@
   },
   "scripts": {
     "build": "tsc && vite build",
+    "build:analyze": "ANALYZE=true vite build",
     "build:css-types": "tcm --c -p  'src/**/*.css' .",
     "copy:css": "node ./scripts/copy-css.cjs",
     "dev": "vite",
@@ -94,6 +95,7 @@
     "lint-staged": "15.4.1",
     "postcss": "8.5.1",
     "postcss-nesting": "13.0.1",
+    "rollup-plugin-visualizer": "^5.14.0",
     "storybook": "^8.2.7",
     "storybook-dark-mode": "^4.0.2",
     "typed-css-modules": "0.9.1",

--- a/frontend/console/vite.config.ts
+++ b/frontend/console/vite.config.ts
@@ -1,8 +1,18 @@
 import react from '@vitejs/plugin-react'
+import { visualizer } from 'rollup-plugin-visualizer'
 import { defineConfig } from 'vite'
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    process.env.ANALYZE === 'true' &&
+      visualizer({
+        open: true, // Automatically open the visualization in your browser
+        gzipSize: true, // Show gzipped sizes
+        brotliSize: true, // Show brotli sizes
+        filename: 'dist/stats.html', // Output file
+      }),
+  ].filter(Boolean),
   css: {
     modules: {
       localsConvention: 'camelCaseOnly',
@@ -11,30 +21,37 @@ export default defineConfig({
   build: {
     rollupOptions: {
       output: {
-        manualChunks: {
-          'vendor-react': ['react', 'react-dom', 'react-router-dom'],
-          'vendor-ui': ['@headlessui/react', '@tanstack/react-query'],
-          'vendor-json-schema-faker': ['json-schema-faker'],
-          'vendor-json-schema-library': ['json-schema-library'],
-          'vendor-yaml': ['yaml'],
-          'vendor-fuse': ['fuse.js'],
-          'vendor-codemirror': [
-            '@codemirror/autocomplete',
-            '@codemirror/commands',
-            '@codemirror/lang-json',
-            '@codemirror/language',
-            '@codemirror/lint',
-            '@codemirror/state',
-            '@codemirror/view',
-          ],
-          'vendor-protos': [
-            './src/protos/xyz/block/ftl/console/v1/console_pb',
-            './src/protos/xyz/block/ftl/console/v1/console_connect',
-            './src/protos/xyz/block/ftl/schema/v1/schema_pb',
-            './src/protos/xyz/block/ftl/timeline/v1/event_pb',
-            './src/protos/xyz/block/ftl/timeline/v1/timeline_pb',
-            './src/protos/xyz/block/ftl/timeline/v1/timeline_connect',
-          ],
+        manualChunks(id) {
+          if (id.includes('node_modules/lodash')) {
+            return 'vendor-lodash'
+          }
+          if (id.includes('node_modules/react/') || id.includes('node_modules/react-dom') || id.includes('node_modules/react-router-dom')) {
+            return 'vendor-react'
+          }
+          if (id.includes('node_modules/@headlessui/react') || id.includes('node_modules/@tanstack/react-query')) {
+            return 'vendor-ui'
+          }
+          if (id.includes('node_modules/json-schema-faker')) {
+            return 'vendor-json-schema-faker'
+          }
+          if (id.includes('node_modules/json-schema-library')) {
+            return 'vendor-json-schema-library'
+          }
+          if (id.includes('node_modules/yaml')) {
+            return 'vendor-yaml'
+          }
+          if (id.includes('node_modules/fuse.js')) {
+            return 'vendor-fuse'
+          }
+          if (id.includes('node_modules/reactflow') || id.includes('node_modules/@reactflow')) {
+            return 'vendor-reactflow'
+          }
+          if (id.includes('node_modules/@codemirror')) {
+            return 'vendor-codemirror'
+          }
+          if (id.includes('/protos/xyz/block/ftl/')) {
+            return 'vendor-protos'
+          }
         },
       },
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,9 @@ importers:
       postcss-nesting:
         specifier: 13.0.1
         version: 13.0.1(postcss@8.5.1)
+      rollup-plugin-visualizer:
+        specifier: ^5.14.0
+        version: 5.14.0(rollup@4.31.0)
       storybook:
         specifier: ^8.2.7
         version: 8.5.0(prettier@2.8.8)
@@ -4756,6 +4759,19 @@ packages:
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
+  rollup-plugin-visualizer@5.14.0:
+    resolution: {integrity: sha512-VlDXneTDaKsHIw8yzJAFWtrzguoJ/LnQ+lMpoVfYJ3jJF4Ihe5oYLAqLklIK/35lgUY+1yEzCkHyZ1j4A5w5fA==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      rolldown: 1.x
+      rollup: 2.x || 3.x || 4.x
+    peerDependenciesMeta:
+      rolldown:
+        optional: true
+      rollup:
+        optional: true
 
   rollup@4.31.0:
     resolution: {integrity: sha512-9cCE8P4rZLx9+PjoyqHLs31V9a9Vpvfo4qNcs6JCiGWYhw2gijSetFbH6SSy1whnkgcefnUwr8sad7tgqsGvnw==}
@@ -10509,6 +10525,15 @@ snapshots:
   reusify@1.0.4: {}
 
   rfdc@1.4.1: {}
+
+  rollup-plugin-visualizer@5.14.0(rollup@4.31.0):
+    dependencies:
+      open: 8.4.2
+      picomatch: 4.0.2
+      source-map: 0.7.4
+      yargs: 17.7.2
+    optionalDependencies:
+      rollup: 4.31.0
 
   rollup@4.31.0:
     dependencies:


### PR DESCRIPTION
- add new `build:analyze` script to console for rollup visualizations

BEFORE (9.38s with warnings):
```
vite v6.0.11 building for production...
✓ 5440 modules transformed.
dist/index.html                                       1.36 kB │ gzip:   0.55 kB
dist/assets/favicon-jjzVXmZJ.ico                     15.41 kB
dist/assets/index-CB5hp2DV.css                       64.74 kB │ gzip:  10.95 kB
dist/assets/vendor-fuse-DPyu62bB.js                  15.77 kB │ gzip:   5.40 kB
dist/assets/vendor-react-D8uXf6-9.js                 87.16 kB │ gzip:  29.84 kB
dist/assets/vendor-json-schema-library-c1NQVLVx.js   95.20 kB │ gzip:  27.38 kB
dist/assets/vendor-yaml-DPZo3Gqr.js                 105.03 kB │ gzip:  32.43 kB
dist/assets/vendor-protos-DP8__gRb.js               168.87 kB │ gzip:  27.59 kB
dist/assets/vendor-ui-DO6raoTH.js                   180.65 kB │ gzip:  57.52 kB
dist/assets/vendor-json-schema-faker-THA4HSpH.js    272.65 kB │ gzip:  88.86 kB
dist/assets/vendor-codemirror-_pve6hc8.js           371.77 kB │ gzip: 120.86 kB
dist/assets/index-DZVGi2No.js                       766.72 kB │ gzip: 257.87 kB

(!) Some chunks are larger than 500 kB after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
✓ built in 9.38s
```

AFTER (7.66s no warnings):
```
vite v6.0.11 building for production...
✓ 5440 modules transformed.
dist/index.html                                       1.62 kB │ gzip:   0.59 kB
dist/assets/favicon-jjzVXmZJ.ico                     15.41 kB
dist/assets/vendor-reactflow-B5DZHykP.css             7.32 kB │ gzip:   1.60 kB
dist/assets/index-DoivQ0Qf.css                       57.42 kB │ gzip:   9.50 kB
dist/assets/vendor-fuse-DPyu62bB.js                  15.77 kB │ gzip:   5.40 kB
dist/assets/vendor-lodash-CSMaoA2u.js                46.96 kB │ gzip:  17.02 kB
dist/assets/vendor-json-schema-library-DLv5Wwdf.js   95.21 kB │ gzip:  27.39 kB
dist/assets/vendor-yaml-DPZo3Gqr.js                 105.03 kB │ gzip:  32.43 kB
dist/assets/vendor-reactflow-Dni2oQuU.js            144.27 kB │ gzip:  47.09 kB
dist/assets/vendor-protos-DP8__gRb.js               168.87 kB │ gzip:  27.59 kB
dist/assets/vendor-ui-BH9npj9H.js                   179.92 kB │ gzip:  57.14 kB
dist/assets/vendor-react-BZWd4Tjq.js                261.41 kB │ gzip:  84.41 kB
dist/assets/vendor-json-schema-faker-DSnAX_B6.js    272.83 kB │ gzip:  88.90 kB
dist/assets/vendor-codemirror-_pve6hc8.js           371.77 kB │ gzip: 120.86 kB
dist/assets/index-BLqFm2PD.js                       401.17 kB │ gzip: 138.41 kB
✓ built in 7.66s
```
