### PR TITLE
feat: Aat/foreground console

### DIFF
--- a/cmd/ftl/cmd_serve.go
+++ b/cmd/ftl/cmd_serve.go
@@ -33,6 +33,7 @@ import (
 	"github.com/block/ftl/backend/provisioner/scaling/localscaling"
 	"github.com/block/ftl/backend/timeline"
 	"github.com/block/ftl/common/schema"
+	consolefrontend "github.com/block/ftl/frontend/console"
 	"github.com/block/ftl/internal/bind"
 	"github.com/block/ftl/internal/channels"
 	"github.com/block/ftl/internal/configuration"
@@ -270,15 +271,16 @@ func (s *serveCommonConfig) run(
 	}
 
 	if !s.NoConsole {
-		if err := console.PrepareServer(); err != nil {
+		if err := consolefrontend.PrepareServer(ctx); err != nil {
+			return fmt.Errorf("failed to prepare console server: %w", err)
 		}
 		wg.Go(func() error {
 			// Deliberately start Console in the foreground.
 			err := console.Start(ctx, s.Console, schemaEventSourceFactory(), controllerClient, timelineClient, adminClient, routing.NewVerbRouter(ctx, schemaEventSourceFactory(), timelineClient), buildEngineClient)
 			if err != nil {
-				return fmt.Errorf("console failed: %w", err)
+				return fmt.Errorf("failed to start console server: %w", err)
 			}
-			return err
+			return nil
 		})
 	}
 

--- a/frontend/console/local.go
+++ b/frontend/console/local.go
@@ -24,6 +24,10 @@ import (
 var proxyURL, _ = url.Parse("http://localhost:5173") //nolint:errcheck
 var proxy = httputil.NewSingleHostReverseProxy(proxyURL)
 
+func PrepareServer() error {
+	return nil
+}
+
 func Server(ctx context.Context, timestamp time.Time, allowOrigin *url.URL) (http.Handler, error) {
 	gitRoot, ok := internal.GitRoot(os.Getenv("FTL_DIR")).Get()
 	if !ok {

--- a/frontend/console/release.go
+++ b/frontend/console/release.go
@@ -22,6 +22,10 @@ import (
 //go:embed all:dist
 var build embed.FS
 
+func PrepareServer() error {
+	return nil
+}
+
 func Server(ctx context.Context, timestamp time.Time, allowOrigin *url.URL) (http.Handler, error) {
 	dir, err := fs.Sub(build, "dist")
 	if err != nil {

--- a/frontend/console/release.go
+++ b/frontend/console/release.go
@@ -22,7 +22,7 @@ import (
 //go:embed all:dist
 var build embed.FS
 
-func PrepareServer() error {
+func PrepareServer(ctx context.Context) error {
 	return nil
 }
 


### PR DESCRIPTION
Previously the console would build (if needed) while we were deploying modules. This would cause the console to not become available until all modules were deployed in some cases which made using the console to debug quite challenging. Now we synchronously build the console code first, then async start the server.

![Screenshot 2025-01-28 at 11 10 23 AM](https://github.com/user-attachments/assets/b0585859-3867-4ee2-9674-675dfe2d2e07)
