### PR TITLE
refactor: context.WithCancel() -> context.WithCancelCause()

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,7 +31,6 @@ linters:
     - gci
     - gofumpt
     - nlreturn
-    - forbidigo
     - cyclop
     - paralleltest
     - tagliatelle
@@ -80,6 +79,14 @@ linters-settings:
       - ifElseChain
   errcheck:
     check-blank: true
+  forbidigo:
+    exclude-godoc-examples: true
+    analyze-types: true
+    forbid:
+      - p: '^context.WithCancel$'
+        msg: 'use context.WithCancelCause instead of context.WithCancel'
+      - p: '^context.CancelFunc$'
+        msg: 'use context.WithCancelCause instead of context.WithCancel'
   depguard:
     rules:
       main:

--- a/backend/controller/scheduledtask/scheduledtask_test.go
+++ b/backend/controller/scheduledtask/scheduledtask_test.go
@@ -2,6 +2,7 @@ package scheduledtask
 
 import (
 	"context"
+	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -18,8 +19,8 @@ import (
 func TestScheduledTask(t *testing.T) {
 	t.Parallel()
 	ctx := log.ContextWithNewDefaultLogger(context.Background())
-	ctx, cancel := context.WithCancel(ctx)
-	t.Cleanup(cancel)
+	ctx, cancel := context.WithCancelCause(ctx)
+	t.Cleanup(func() { cancel(fmt.Errorf("test ended")) })
 
 	var singletonCount atomic.Int64
 	var multiCount atomic.Int64

--- a/backend/provisioner/scaling/localscaling/local_scaling.go
+++ b/backend/provisioner/scaling/localscaling/local_scaling.go
@@ -171,7 +171,7 @@ type deploymentInfo struct {
 	exits    int
 }
 type runnerInfo struct {
-	cancelFunc context.CancelFunc
+	cancelFunc context.CancelCauseFunc
 	port       int
 	host       string
 }
@@ -238,7 +238,7 @@ func (l *localScaling) reconcileRunners(ctx context.Context, deploymentRunners *
 			time.Sleep(time.Second * 5)
 			l.lock.Lock()
 			defer l.lock.Unlock()
-			runner.cancelFunc()
+			runner.cancelFunc(fmt.Errorf("runner terminated"))
 		}()
 		deploymentRunners.runner = optional.None[runnerInfo]()
 	}
@@ -320,7 +320,7 @@ func (l *localScaling) startRunner(ctx context.Context, deploymentKey key.Deploy
 
 	runnerCtx := log.ContextWithLogger(ctx, logger.Scope(simpleName).Module(info.module))
 
-	runnerCtx, cancel := context.WithCancel(runnerCtx)
+	runnerCtx, cancel := context.WithCancelCause(runnerCtx)
 	info.runner = optional.Some(runnerInfo{cancelFunc: cancel, port: bind.Port, host: "127.0.0.1"})
 
 	go func() {

--- a/backend/schemaservice/schemaservice.go
+++ b/backend/schemaservice/schemaservice.go
@@ -149,8 +149,8 @@ func (s *Service) GetDeployments(ctx context.Context, req *connect.Request[ftlv1
 func (s *Service) watchModuleChanges(ctx context.Context, sendChange func(response *ftlv1.PullSchemaResponse) error) error {
 	logger := log.FromContext(ctx)
 
-	uctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	uctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(fmt.Errorf("schemaservice: stopped watching for module changes"))
 	stateIter, err := s.State.StateIter(uctx)
 	if err != nil {
 		return fmt.Errorf("failed to get schema state iterator: %w", err)

--- a/cmd/ftl/cmd_build.go
+++ b/cmd/ftl/cmd_build.go
@@ -33,8 +33,8 @@ func (b *buildCmd) Run(
 	}
 
 	// Cancel build engine context to ensure all language plugins are killed.
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(fmt.Errorf("build stopped"))
 	engine, err := buildengine.New(
 		ctx,
 		controllerClient,

--- a/go-runtime/goplugin/service.go
+++ b/go-runtime/goplugin/service.go
@@ -227,8 +227,8 @@ func (s *Service) Build(ctx context.Context, req *connect.Request[langpb.BuildRe
 	defer s.updatesTopic.Unsubscribe(events)
 
 	// cancel context when stream ends so that watcher can be stopped
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(fmt.Errorf("build stream ended"))
 
 	buildCtx, err := buildContextFromProto(req.Msg.BuildContext)
 	if err != nil {

--- a/internal/buildengine/engine_test.go
+++ b/internal/buildengine/engine_test.go
@@ -2,6 +2,7 @@ package buildengine_test
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"path/filepath"
 	"testing"
@@ -19,8 +20,10 @@ func TestGraph(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	ctx, cancel := context.WithCancel(log.ContextWithNewDefaultLogger(context.Background()))
-	t.Cleanup(cancel)
+	ctx, cancel := context.WithCancelCause(log.ContextWithNewDefaultLogger(context.Background()))
+	t.Cleanup(func() {
+		cancel(fmt.Errorf("test complete"))
+	})
 	projConfig := projectconfig.Config{
 		Path: filepath.Join(t.TempDir(), "ftl-project.toml"),
 		Name: "test",

--- a/internal/buildengine/languageplugin/plugin.go
+++ b/internal/buildengine/languageplugin/plugin.go
@@ -113,7 +113,7 @@ func newPluginForTesting(ctx context.Context, client pluginClient) *LanguagePlug
 	}
 
 	var runCtx context.Context
-	runCtx, plugin.cancel = context.WithCancel(ctx)
+	runCtx, plugin.cancel = context.WithCancelCause(ctx)
 	go plugin.run(runCtx)
 	go plugin.watchForCmdError(runCtx)
 
@@ -134,7 +134,7 @@ type LanguagePlugin struct {
 	client pluginClient
 
 	// cancels the run() context
-	cancel context.CancelFunc
+	cancel context.CancelCauseFunc
 
 	// commands to execute
 	commands chan buildCommand
@@ -144,7 +144,7 @@ type LanguagePlugin struct {
 
 // Kill stops the plugin and cleans up any resources.
 func (p *LanguagePlugin) Kill() error {
-	p.cancel()
+	p.cancel(fmt.Errorf("killing language plugin"))
 	if err := p.client.kill(); err != nil {
 		return fmt.Errorf("failed to kill language plugin: %w", err)
 	}

--- a/internal/channels/itercontext_test.go
+++ b/internal/channels/itercontext_test.go
@@ -27,14 +27,14 @@ func TestIterContext(t *testing.T) {
 
 	t.Run("stops when context cancelled", func(t *testing.T) {
 		ch := make(chan int)
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancelCause(context.Background())
 
 		// Start goroutine to send values
 		go func() {
 			ch <- 1
 			ch <- 2
 			time.Sleep(10 * time.Millisecond) // Small delay to ensure cancel happens
-			cancel()                          // Cancel context before sending 3
+			cancel(nil)                       // Cancel context before sending 3
 			ch <- 3                           // This should not be received
 			close(ch)
 		}()

--- a/internal/pgproxy/pgproxy.go
+++ b/internal/pgproxy/pgproxy.go
@@ -77,8 +77,8 @@ func (p *PgProxy) Start(ctx context.Context, started chan<- Started) error {
 // It will block until the connection is closed.
 func HandleConnection(ctx context.Context, conn net.Conn, connectionFn DSNConstructor) {
 	defer conn.Close()
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(fmt.Errorf("pgproxy: connection closed"))
 
 	logger := log.FromContext(ctx)
 	logger.Debugf("new connection established: %s", conn.RemoteAddr())

--- a/internal/pgproxy/pgproxy_test.go
+++ b/internal/pgproxy/pgproxy_test.go
@@ -2,6 +2,7 @@ package pgproxy_test
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"testing"
 
@@ -24,8 +25,8 @@ func TestPgProxy(t *testing.T) {
 
 	frontend := pgproto3.NewFrontend(client, client)
 
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(fmt.Errorf("test complete"))
 	go pgproxy.HandleConnection(ctx, proxy, func(ctx context.Context, parameters map[string]string) (string, error) {
 		return dsn, nil
 	})

--- a/internal/terminal/interactive.go
+++ b/internal/terminal/interactive.go
@@ -176,7 +176,7 @@ func (r *interactiveConsole) run(ctx context.Context) error {
 var _ readline.Listener = &ExitListener{}
 
 type ExitListener struct {
-	cancel context.CancelFunc
+	cancel func()
 }
 
 func (e ExitListener) OnChange(line []rune, pos int, key rune) (newLine []rune, newPos int, ok bool) {


### PR DESCRIPTION
Why? Because error messages like `error: updates service failed: build updates
service stopped serving: context canceled` are not super useful.