### PR TITLE
refactor: temporarily disable 1Password secret provider

### DIFF
--- a/cmd/ftl/main.go
+++ b/cmd/ftl/main.go
@@ -277,8 +277,8 @@ func makeBindContext(logger *log.Logger, cancel context.CancelCauseFunc) termina
 		})
 		kctx.FatalIfErrorf(err)
 
-		err = kctx.BindToProvider(func(cli *CLI, projectConfig projectconfig.Config) (*providers.Registry[configuration.Secrets], error) {
-			return providers.NewDefaultSecretsRegistry(projectConfig, cli.Vault), nil
+		err = kctx.BindToProvider(func() (*providers.Registry[configuration.Secrets], error) {
+			return providers.NewDefaultSecretsRegistry(), nil
 		})
 		kctx.FatalIfErrorf(err)
 

--- a/go-runtime/ftl/ftltest/ftltest.go
+++ b/go-runtime/ftl/ftltest/ftltest.go
@@ -146,7 +146,7 @@ func WithProjectFile(path string) Option {
 				}
 			}
 
-			sm, err := cf.NewDefaultSecretsManagerFromConfig(ctx, providers.NewDefaultSecretsRegistry(projectConfig, ""), projectConfig)
+			sm, err := cf.NewDefaultSecretsManagerFromConfig(ctx, providers.NewDefaultSecretsRegistry(), projectConfig)
 			if err != nil {
 				return fmt.Errorf("could not set up secrets: %w", err)
 			}

--- a/internal/configuration/providers/registry.go
+++ b/internal/configuration/providers/registry.go
@@ -7,7 +7,6 @@ import (
 	"slices"
 
 	"github.com/block/ftl/internal/configuration"
-	"github.com/block/ftl/internal/projectconfig"
 )
 
 type Factory[R configuration.Role] func(ctx context.Context) (configuration.Provider[R], error)
@@ -21,11 +20,11 @@ func NewDefaultConfigRegistry() *Registry[configuration.Configuration] {
 }
 
 // NewDefaultSecretsRegistry creates a new registry with the default secrets providers.
-func NewDefaultSecretsRegistry(config projectconfig.Config, onePasswordVault string) *Registry[configuration.Secrets] {
+func NewDefaultSecretsRegistry() *Registry[configuration.Secrets] {
 	registry := NewRegistry[configuration.Secrets]()
 	registry.Register(NewEnvarFactory[configuration.Secrets]())
 	registry.Register(NewInlineFactory[configuration.Secrets]())
-	registry.Register(NewOnePasswordFactory(onePasswordVault, config.Name))
+	// registry.Register(NewOnePasswordFactory(onePasswordVault, config.Name))
 	registry.Register(NewKeychainFactory())
 	return registry
 }

--- a/internal/profiles/profiles_test.go
+++ b/internal/profiles/profiles_test.go
@@ -40,10 +40,8 @@ func TestProfile(t *testing.T) {
 	profile, err := project.Load(ctx, "local")
 	assert.NoError(t, err)
 
-	assert.Equal(t, profiles.Config{
-		Name:     "local",
-		Endpoint: must.Get(url.Parse("http://localhost:8892")),
-	}, profile.Config())
+	assert.Equal(t, "local", profile.Name())
+	assert.Equal(t, must.Get(url.Parse("http://localhost:8892")), profile.Endpoint())
 
 	assert.Equal(t, profiles.ProjectConfig{
 		Root:           root,


### PR DESCRIPTION
This will simplify factoring out `projectconfig`.