### PR TITLE
fix: silence unwanted runner terminated errors

### DIFF
--- a/backend/runner/runner.go
+++ b/backend/runner/runner.go
@@ -79,7 +79,7 @@ type Config struct {
 
 func Start(ctx context.Context, config Config, storage *artefacts.OCIArtefactService) error {
 	ctx, doneFunc := context.WithCancelCause(ctx)
-	defer doneFunc(fmt.Errorf("runner terminated"))
+	defer doneFunc(context.Canceled)
 	hostname, err := os.Hostname()
 	if err != nil {
 		observability.Runner.StartupFailed(ctx)

--- a/backend/runner/runner.go
+++ b/backend/runner/runner.go
@@ -79,7 +79,7 @@ type Config struct {
 
 func Start(ctx context.Context, config Config, storage *artefacts.OCIArtefactService) error {
 	ctx, doneFunc := context.WithCancelCause(ctx)
-	defer doneFunc(context.Canceled)
+	defer doneFunc(fmt.Errorf("runner terminated: %w", context.Canceled))
 	hostname, err := os.Hostname()
 	if err != nil {
 		observability.Runner.StartupFailed(ctx)


### PR DESCRIPTION
Fixes https://github.com/block/ftl/issues/4229
Some more info:
- The old runner is terminated properly, but there seems to be some race where the context cancellation cause is propagated places sometimes.
    - eg: `https://github.com/block/ftl/blob/main/backend/runner/runner.go#L385`
- We had checks in place to ignore the errors if they were context cancelled errors, but we have moved away from using context cancelled errors.