### PR TITLE
fix: disallow modules to use reserved names

### DIFF
--- a/cmd/ftl/cmd_new.go
+++ b/cmd/ftl/cmd_new.go
@@ -90,7 +90,7 @@ func validateModule(dir string, name string) (string, string, error) {
 	if name == "" {
 		name = filepath.Base(dir)
 	}
-	if !schema.ValidateName(name) {
+	if !schema.ValidateModuleName(name) {
 		return "", "", fmt.Errorf("module name %q is invalid", name)
 	}
 	path := filepath.Join(dir, name)

--- a/cmd/ftl/cmd_new.go
+++ b/cmd/ftl/cmd_new.go
@@ -3,10 +3,8 @@ package main
 import (
 	"context"
 	"fmt"
-	"go/token"
 	"os"
 	"path/filepath"
-	"regexp"
 	"time"
 
 	"github.com/alecthomas/kong"
@@ -30,11 +28,6 @@ func (i newCmd) Run(ctx context.Context, ktctx *kong.Context, config projectconf
 	name, path, err := validateModule(i.Dir, i.Name)
 	if err != nil {
 		return err
-	}
-
-	// Validate the module name with custom validation
-	if !isValidModuleName(name) {
-		return fmt.Errorf("module name %q must be a valid Go module name and not a reserved keyword", name)
 	}
 
 	logger := log.FromContext(ctx)
@@ -64,6 +57,7 @@ func (i newCmd) Run(ctx context.Context, ktctx *kong.Context, config projectconf
 	if err != nil {
 		return fmt.Errorf("could not acquire file lock: %w", err)
 	}
+	logger.Infof("acquired file lock for %s", config.WatchModulesLockPath())
 	defer release() //nolint:errcheck
 
 	err = plugin.CreateModule(ctx, config, moduleConfig, flags)
@@ -108,15 +102,4 @@ func validateModule(dir string, name string) (string, string, error) {
 		return "", "", fmt.Errorf("module directory %s already exists", path)
 	}
 	return name, absPath, nil
-}
-
-func isValidModuleName(name string) bool {
-	validNamePattern := regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_]*$`)
-	if !validNamePattern.MatchString(name) {
-		return false
-	}
-	if token.Lookup(name).IsKeyword() {
-		return false
-	}
-	return true
 }

--- a/common/schema/validate.go
+++ b/common/schema/validate.go
@@ -3,6 +3,7 @@ package schema
 
 import (
 	"fmt"
+	"go/token"
 	"net/http"
 	"reflect"
 	"regexp"
@@ -242,6 +243,9 @@ var validNameRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
 // ValidateName validates an FTL name.
 func ValidateName(name string) bool {
+	if token.Lookup(name).IsKeyword() {
+		return false
+	}
 	return validNameRe.MatchString(name)
 }
 

--- a/common/schema/validate.go
+++ b/common/schema/validate.go
@@ -243,10 +243,15 @@ var validNameRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
 // ValidateName validates an FTL name.
 func ValidateName(name string) bool {
+	return validNameRe.MatchString(name)
+}
+
+// ValidateName validates an FTL name.
+func ValidateModuleName(name string) bool {
 	if token.Lookup(name).IsKeyword() {
 		return false
 	}
-	return validNameRe.MatchString(name)
+	return ValidateName(name)
 }
 
 // Validate performs the subset of semantic validation possible on a single module.
@@ -257,7 +262,7 @@ func (m *Module) Validate() error {
 
 	scopes := NewScopes()
 
-	if !ValidateName(m.Name) {
+	if !ValidateModuleName(m.Name) {
 		merr = append(merr, errorf(m, "module name %q is invalid", m.Name))
 	}
 	if m.Builtin && m.Name != "builtin" {

--- a/common/schema/validate.go
+++ b/common/schema/validate.go
@@ -246,7 +246,7 @@ func ValidateName(name string) bool {
 	return validNameRe.MatchString(name)
 }
 
-// ValidateName validates an FTL name.
+// ValidateModuleName validates an FTL module name.
 func ValidateModuleName(name string) bool {
 	if token.Lookup(name).IsKeyword() {
 		return false

--- a/common/schema/validate_test.go
+++ b/common/schema/validate_test.go
@@ -389,6 +389,13 @@ func TestValidate(t *testing.T) {
 				data subWithClashingDeadLetterFailed {}
 				verb subWithClashingDeadLetter(test.eventA) Unit
 					+subscribe topicA from=beginning deadletter
+
+				//some reserved names
+				verb func(Unit) Unit
+				verb switch(Unit) Unit
+				verb select(Unit) Unit
+				verb map(Unit) Unit
+				verb package(Unit) Unit
 			}
 			`,
 			errs: []string{
@@ -398,6 +405,11 @@ func TestValidate(t *testing.T) {
 				"22:6: verb emptyCantSubscribe: request type Unit differs from subscription's event type test.eventB",
 				"29:6: dead letter topic test.subWithExistingDeadLetterFailed must have the same event type (builtin.FailedEvent<test.eventB>) as the subscription request type (builtin.FailedEvent<test.eventA>)",
 				"33:6: expected test.subWithClashingDeadLetterFailed to be a dead letter topic but was already declared at 31:5",
+				`35:5: verb name "func" is invalid`,
+				`37:5: verb name "switch" is invalid`,
+				`38:5: verb name "select" is invalid`,
+				`39:5: verb name "map" is invalid`,
+				`40:5: verb name "package" is invalid`,
 				`7:5: invalid name: must consist of only letters, numbers and underscores, and start with a lowercase letter.`,
 			},
 		},

--- a/common/schema/validate_test.go
+++ b/common/schema/validate_test.go
@@ -389,13 +389,6 @@ func TestValidate(t *testing.T) {
 				data subWithClashingDeadLetterFailed {}
 				verb subWithClashingDeadLetter(test.eventA) Unit
 					+subscribe topicA from=beginning deadletter
-
-				//some reserved names
-				verb func(Unit) Unit
-				verb switch(Unit) Unit
-				verb select(Unit) Unit
-				verb map(Unit) Unit
-				verb package(Unit) Unit
 			}
 			`,
 			errs: []string{
@@ -405,11 +398,6 @@ func TestValidate(t *testing.T) {
 				"22:6: verb emptyCantSubscribe: request type Unit differs from subscription's event type test.eventB",
 				"29:6: dead letter topic test.subWithExistingDeadLetterFailed must have the same event type (builtin.FailedEvent<test.eventB>) as the subscription request type (builtin.FailedEvent<test.eventA>)",
 				"33:6: expected test.subWithClashingDeadLetterFailed to be a dead letter topic but was already declared at 31:5",
-				`35:5: verb name "func" is invalid`,
-				`37:5: verb name "switch" is invalid`,
-				`38:5: verb name "select" is invalid`,
-				`39:5: verb name "map" is invalid`,
-				`40:5: verb name "package" is invalid`,
 				`7:5: invalid name: must consist of only letters, numbers and underscores, and start with a lowercase letter.`,
 			},
 		},
@@ -487,6 +475,16 @@ func TestValidate(t *testing.T) {
 		`,
 			errs: []string{
 				`9:6: verb can not subscribe to multiple topics`,
+			},
+		},
+		{
+			name: "ModuleNameCantBeGoKeyword",
+			schema: `
+			module map {
+			}
+		`,
+			errs: []string{
+				`2:4: module name "map" is invalid`,
 			},
 		},
 	}


### PR DESCRIPTION
We can't compile go modules if module names use reserved go keywords.
Previously we checked for this in `ftl new` but modules can be manually renamed.