### PR TITLE
feat: add changeset cleanup states

### DIFF
--- a/backend/provisioner/deployment.go
+++ b/backend/provisioner/deployment.go
@@ -73,6 +73,7 @@ func (t *Task) Start(ctx context.Context) error {
 }
 
 func (t *Task) Progress(ctx context.Context) error {
+	logger := log.FromContext(ctx)
 	if t.state != TaskStateRunning {
 		return fmt.Errorf("task state is not running: %s", t.state)
 	}
@@ -99,6 +100,7 @@ func (t *Task) Progress(ctx context.Context) error {
 			t.state = TaskStateDone
 			events := succ.Success.Events
 
+			logger.Infof("Received %d events for module %s with task %s", len(events), t.module, t.binding.ID)
 			for _, eventpb := range events {
 				event, err := schema.EventFromProto(eventpb)
 				if err != nil {

--- a/backend/provisioner/runner_scaling_provisioner.go
+++ b/backend/provisioner/runner_scaling_provisioner.go
@@ -62,7 +62,6 @@ func provisionRunner(scaling scaling.RunnerScaling) InMemResourceProvisionerFn {
 			}
 		}
 		if err := scaling.StartDeployment(ctx, module.Name, deployment.String(), module, cron, http); err != nil {
-			logger.Infof("failed to start deployment: %v", err)
 			return nil, fmt.Errorf("failed to start deployment: %w", err)
 		}
 		endpoint, err := scaling.GetEndpointForDeployment(ctx, module.Name, deployment.String())

--- a/backend/schemaservice/changesetstate_test.go
+++ b/backend/schemaservice/changesetstate_test.go
@@ -149,8 +149,28 @@ func TestChangesetState(t *testing.T) {
 		csd := changeset(t, view)
 		assert.Equal(t, schema.ChangesetStateCommitted, csd.State)
 		assert.Equal(t, 1, len(view.GetCanonicalDeployments()))
-
 	})
+
+	t.Run("test archive first changeset", func(t *testing.T) {
+		err = state.Publish(ctx, &schema.ChangesetDrainedEvent{
+			Key: changesetKey,
+		})
+		assert.NoError(t, err)
+		view, err = state.View(ctx)
+		assert.NoError(t, err)
+		csd := changeset(t, view)
+		assert.Equal(t, schema.ChangesetStateDrained, csd.State)
+		assert.Equal(t, 1, len(view.GetChangesets()))
+
+		err = state.Publish(ctx, &schema.ChangesetDeProvisionedEvent{
+			Key: changesetKey,
+		})
+		assert.NoError(t, err)
+		view, err = state.View(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(view.GetChangesets()))
+	})
+
 }
 
 func changeset(t *testing.T, view schemaservice.SchemaState) *schema.Changeset {


### PR DESCRIPTION
This is currently a bit of a no-op, but this adds the relevant states and get the provisioner to move the changset through the states. 

Significant additional work/tests etc are required.