### PR TITLE
fix: runner logger includes key attribute

### DIFF
--- a/backend/runner/runner.go
+++ b/backend/runner/runner.go
@@ -88,7 +88,16 @@ func Start(ctx context.Context, config Config, storage *artefacts.OCIArtefactSer
 	}
 	pid := os.Getpid()
 
-	logger := log.FromContext(ctx).Attrs(map[string]string{"runner": config.Key.String()})
+	client := rpc.Dial(ftlv1connect.NewVerbServiceClient, config.ControllerEndpoint.String(), log.Error)
+	ctx = rpc.ContextWithClient(ctx, client)
+
+	runnerKey := config.Key
+	if runnerKey.IsZero() {
+		runnerKey = key.NewRunnerKey(config.Bind.Hostname(), config.Bind.Port())
+	}
+
+	logger := log.FromContext(ctx).Attrs(map[string]string{"runner": runnerKey.String()})
+	ctx = log.ContextWithLogger(ctx, logger)
 	logger.Debugf("Starting FTL Runner")
 
 	err = manageDeploymentDirectory(logger, config)
@@ -104,10 +113,6 @@ func Start(ctx context.Context, config Config, storage *artefacts.OCIArtefactSer
 	controllerClient := rpc.Dial(ftlv1connect.NewControllerServiceClient, config.ControllerEndpoint.String(), log.Error)
 	schemaClient := rpc.Dial(ftlv1connect.NewSchemaServiceClient, config.SchemaEndpoint.String(), log.Error)
 
-	runnerKey := config.Key
-	if runnerKey.IsZero() {
-		runnerKey = key.NewRunnerKey(config.Bind.Hostname(), config.Bind.Port())
-	}
 	labels, err := structpb.NewStruct(map[string]any{
 		"hostname": hostname,
 		"pid":      pid,

--- a/backend/runner/runner.go
+++ b/backend/runner/runner.go
@@ -88,9 +88,6 @@ func Start(ctx context.Context, config Config, storage *artefacts.OCIArtefactSer
 	}
 	pid := os.Getpid()
 
-	client := rpc.Dial(ftlv1connect.NewVerbServiceClient, config.ControllerEndpoint.String(), log.Error)
-	ctx = rpc.ContextWithClient(ctx, client)
-
 	runnerKey := config.Key
 	if runnerKey.IsZero() {
 		runnerKey = key.NewRunnerKey(config.Bind.Hostname(), config.Bind.Port())


### PR DESCRIPTION
Fixes these 2 issues:
- Logger was being created with runner key before the runner key was defaulted to a value
- Logger with runner key attributes was not saved to context, so it was not being used in later logs

Old logs via kubectl:
```
{"level":"debug","message":"Starting FTL Runner","time":"2025-02-03T02:39:51.92719858Z"}
// Initial logs have a runner key of "rnr-"
{"level":"debug","attributes":{"runner":"rnr-"},"message":"Starting FTL Runner","time":"2025-02-03T02:39:51.92719858Z"}
{"level":"debug","attributes":{"runner":"rnr-"},"message":"Deployment directory: deployments","time":"2025-02-03T02:39:51.927242169Z"}
{"level":"debug","attributes":{"runner":"rnr-"},"message":"Using FTL endpoint: http://10.0.1.244:8892","time":"2025-02-03T02:39:51.927341253Z"}
{"level":"debug","attributes":{"runner":"rnr-"},"message":"Listening on http://0.0.0.0:8893","time":"2025-02-03T02:39:51.92735112Z"}
// Later logs have no runner key
{"level":"debug","attributes":{"deployment":"dpl-alice-2tqy1uhvilocc8cj"},"message":"Downloading deployments/alice/dpl-alice-2tqy1uhvilocc8cj/main","time":"2025-02-03T02:39:51.990414946Z"}
{"level":"debug","attributes":{"deployment":"dpl-alice-2tqy1uhvilocc8cj"},"message":"Downloading deployments/alice/dpl-alice-2tqy1uhvilocc8cj/launch","time":"2025-02-03T02:39:52.253427345Z"}
```