### PR TITLE
fix: cleanup changesets

### DIFF
--- a/backend/provisioner/deployment.go
+++ b/backend/provisioner/deployment.go
@@ -100,7 +100,7 @@ func (t *Task) Progress(ctx context.Context) error {
 			t.state = TaskStateDone
 			events := succ.Success.Events
 
-			logger.Infof("Received %d events for module %s with task %s", len(events), t.module, t.binding.ID)
+			logger.Debugf("Received %d events for module %s with task %s", len(events), t.module, t.binding.ID)
 			for _, eventpb := range events {
 				event, err := schema.EventFromProto(eventpb)
 				if err != nil {

--- a/backend/provisioner/runner_scaling_provisioner.go
+++ b/backend/provisioner/runner_scaling_provisioner.go
@@ -103,7 +103,7 @@ func provisionRunner(scaling scaling.RunnerScaling) InMemResourceProvisionerFn {
 			}
 		}
 
-		logger.Infof("Updating module runtime for %s with endpoint %s and changeset %s", module.Name, endpointURI, changeset.String())
+		logger.Debugf("Updating module runtime for %s with endpoint %s and changeset %s", module.Name, endpointURI, changeset.String())
 		_, err = schemaClient.UpdateDeploymentRuntime(ctx, connect.NewRequest(&ftlv1.UpdateDeploymentRuntimeRequest{Event: &schemapb.ModuleRuntimeEvent{
 			Changeset: changeset.String(),
 			Key:       deployment.String(),

--- a/backend/provisioner/service.go
+++ b/backend/provisioner/service.go
@@ -178,7 +178,7 @@ func (s *Service) ProvisionChangeset(ctx context.Context, req *schema.Changeset)
 	}
 
 	for _, removing := range commitResponse.Msg.Changeset.RemovingModules {
-		logger.Infof("De-provisioning module %s %s", removing.Name, removing.Runtime.GetRunner().GetEndpoint())
+		logger.Debugf("De-provisioning module %s %s", removing.Name, removing.Runtime.GetRunner().GetEndpoint())
 		removing.Runtime.Deployment.State = schemapb.DeploymentState_DEPLOYMENT_STATE_DE_PROVISIONING
 		_, err = s.schemaClient.UpdateDeploymentRuntime(ctx, connect.NewRequest(&ftlv1.UpdateDeploymentRuntimeRequest{
 			Event: &schemapb.ModuleRuntimeEvent{
@@ -196,10 +196,11 @@ func (s *Service) ProvisionChangeset(ctx context.Context, req *schema.Changeset)
 	if err != nil {
 		return fmt.Errorf("error draining changeset: %w", err)
 	}
-	//_, err = s.schemaClient.DeProvisionChangeset(ctx, connect.NewRequest(&ftlv1.DeProvisionChangesetRequest{Changeset: req.Key.String()}))
-	//if err != nil {
-	//	return fmt.Errorf("error draining changeset: %w", err)
-	//}
+
+	_, err = s.schemaClient.FinalizeChangeset(ctx, connect.NewRequest(&ftlv1.FinalizeChangesetRequest{Changeset: req.Key.String()}))
+	if err != nil {
+		return fmt.Errorf("error draining changeset: %w", err)
+	}
 	return nil
 }
 

--- a/backend/schemaservice/events.go
+++ b/backend/schemaservice/events.go
@@ -256,6 +256,7 @@ func handleChangesetCommittedEvent(ctx context.Context, t SchemaState, e *schema
 		if dep.ModRuntime().ModDeployment().State != schema.DeploymentStateCanary {
 			return fmt.Errorf("deployment %s is not in correct state %d", dep.Name, dep.ModRuntime().ModDeployment().State)
 		}
+		dep.ModRuntime().ModDeployment().State = schema.DeploymentStateCanonical
 	}
 	logger := log.FromContext(ctx)
 	changeset.State = schema.ChangesetStateCommitted

--- a/backend/schemaservice/state.go
+++ b/backend/schemaservice/state.go
@@ -216,7 +216,7 @@ func (r *SchemaState) handleRuntimeEvent(e schema.RuntimeEvent) (*schema.Module,
 			}, fmt.Errorf("changeset %s not found", cs.String())
 		}
 		module := e.DeploymentKey().Payload.Module
-		for _, m := range c.Modules {
+		for _, m := range c.OwnedModules() {
 			if m.Name == module {
 				return m, func() {
 					r.changesetEvents[cs] = append(r.changesetEvents[cs], e)

--- a/backend/schemaservice/state_test.go
+++ b/backend/schemaservice/state_test.go
@@ -44,7 +44,7 @@ func TestStateMarshallingAfterCommonEvents(t *testing.T) {
 				&schema.Module{
 					Name: "test2",
 					Runtime: &schema.ModuleRuntime{
-						Deployment: &schema.ModuleRuntimeDeployment{DeploymentKey: deploymentKey},
+						Deployment: &schema.ModuleRuntimeDeployment{DeploymentKey: deploymentKey, State: schema.DeploymentStateProvisioning},
 					},
 				},
 			},


### PR DESCRIPTION
The provisioner should now run them through the changeset states to remove them from the changeset state map