### PR TITLE
fix: module status in console not matching actual engine status

### DIFF
--- a/frontend/console/src/features/engine/hooks/use-stream-engine-events.ts
+++ b/frontend/console/src/features/engine/hooks/use-stream-engine-events.ts
@@ -27,15 +27,10 @@ export const useStreamEngineEvents = (enabled = true) => {
             const newEvent = response.event as EngineEvent
             if (!old) return { pages: [[newEvent]], pageParams: [0] }
 
-            // Check if this event already exists to avoid duplicates
-            const eventExists = old.pages[0]?.some(
-              (event) => event.timestamp?.seconds === newEvent.timestamp?.seconds && event.timestamp?.nanos === newEvent.timestamp?.nanos,
-            )
-            if (eventExists) return old
-
+            // Add the new event to the end of the first page to maintain chronological order
             return {
               ...old,
-              pages: [[newEvent, ...old.pages[0]], ...old.pages.slice(1)],
+              pages: [[...old.pages[0], newEvent], ...old.pages.slice(1)],
             }
           })
         }

--- a/frontend/console/src/features/infrastructure/BuildEngineEvents.tsx
+++ b/frontend/console/src/features/infrastructure/BuildEngineEvents.tsx
@@ -107,9 +107,11 @@ const EventContent = ({ event }: { event: EngineEvent }) => {
 }
 
 export const BuildEngineEvents = ({ events }: BuildEngineEventsProps) => {
+  const reversedEvents = [...events].reverse()
+
   return (
     <div className='overflow-x-hidden w-full'>
-      <List items={events} renderItem={(event) => <EventContent event={event} />} className='text-xs w-full' />
+      <List items={reversedEvents} renderItem={(event) => <EventContent event={event} />} className='text-xs w-full' />
     </div>
   )
 }


### PR DESCRIPTION
There were many random cases where the console status would not match the status displayed in the terminal:

![Screenshot 2025-02-03 at 11 44 56 AM](https://github.com/user-attachments/assets/cd9a3bd5-4f64-450c-9ef3-1e8951fd0acd)
![Screenshot 2025-02-03 at 12 34 11 PM](https://github.com/user-attachments/assets/25af1053-4da5-428b-b478-afc71c73a37c)

This change fixes some of the logic in the updates and simplifies the frontend code now that we can rely on order and deduplication on the backend.
![Screenshot 2025-02-03 at 12 35 23 PM](https://github.com/user-attachments/assets/99e7a3d7-69a7-4a18-85ca-e8e1bf619c5f)
