### PR TITLE
fix: flaky cron test

### DIFF
--- a/backend/cron/service_test.go
+++ b/backend/cron/service_test.go
@@ -49,7 +49,7 @@ func TestCron(t *testing.T) {
 				Request:  &schema.Unit{},
 				Response: &schema.Unit{},
 				Metadata: []schema.Metadata{
-					&schema.MetadataCronJob{Cron: "*/2 * * * * *"},
+					&schema.MetadataCronJob{Cron: "0/2 * * * * *"},
 				},
 			},
 			&schema.Verb{
@@ -57,7 +57,7 @@ func TestCron(t *testing.T) {
 				Request:  &schema.Unit{},
 				Response: &schema.Unit{},
 				Metadata: []schema.Metadata{
-					&schema.MetadataCronJob{Cron: "*/2 * * * * *"},
+					&schema.MetadataCronJob{Cron: "1/2 * * * * *"},
 				},
 			},
 		},


### PR DESCRIPTION
Fixes #4237

Hopefully. I couldn't reproduce locally.

What I suspect was happening is that the 2 crons were running at the same schedule so it could be possible for `echo` to fire twice before `time` gets a chance to run. 