### PR TITLE
chore: re-enable TestStateIter.

### DIFF
--- a/internal/raft/cluster_test.go
+++ b/internal/raft/cluster_test.go
@@ -155,9 +155,6 @@ func TestLeavingCluster(t *testing.T) {
 }
 
 func TestStateIter(t *testing.T) {
-	// TODO: This is flaky, fix and re-enable when Raft is used
-	t.Skip()
-
 	if testing.Short() {
 		t.SkipNow()
 	}


### PR DESCRIPTION
I ran this 200 times with no issues. Maybe recent cluster test improvements have stabilised this as well