### PR TITLE
chore: improve CI times for console e2e

### DIFF
--- a/frontend/console/e2e/global-setup.ts
+++ b/frontend/console/e2e/global-setup.ts
@@ -2,33 +2,60 @@ import { type FullConfig, chromium } from '@playwright/test'
 
 const globalSetup = async (config: FullConfig) => {
   console.log('Waiting for server to be available...')
+  const startTime = Date.now()
 
   const browser = await chromium.launch()
   const context = await browser.newContext()
   const page = await context.newPage()
-  await page.goto('http://localhost:8899/modules')
 
-  console.log('Waiting for modules to be ready...')
-  const moduleNames = ['time', 'echo', 'cron', 'http', 'pubsub']
-  await page.waitForFunction(
-    (modules) => {
-      const readyModules = modules.filter((module) => {
-        const moduleElement = document.querySelector(`li#module-tree-module-${module}`)
-        if (!moduleElement) return false
+  try {
+    await page.goto('http://localhost:8899/modules')
+    console.log(`Server available after ${(Date.now() - startTime) / 1000}s`)
 
-        const greenDot = moduleElement.querySelector('.bg-green-400')
-        return greenDot !== null
-      })
-      console.log('Ready modules:', readyModules.join(', '))
-      return readyModules.length === modules.length
-    },
-    moduleNames,
-    { timeout: 240000 },
-  )
+    console.log('Waiting for modules to be ready...')
+    const moduleNames = ['time', 'echo', 'cron', 'http', 'pubsub']
+    const moduleStartTime = Date.now()
 
-  console.log('All modules are ready!')
+    await page.waitForFunction(
+      (modules) => {
+        const readyModules = modules.filter((module) => {
+          const moduleElement = document.querySelector(`li#module-tree-module-${module}`)
+          if (!moduleElement) {
+            console.log(`Module ${module} element not found`)
+            return false
+          }
 
-  await browser.close()
+          const greenDot = moduleElement.querySelector('.bg-green-400')
+          const isReady = greenDot !== null
+          if (isReady) {
+            const timestamp = new Date().toISOString()
+            console.log(`[${timestamp}] Module ${module} is ready`)
+          }
+          return isReady
+        })
+
+        if (readyModules.length === modules.length) {
+          const timestamp = new Date().toISOString()
+          console.log(`[${timestamp}] All modules are ready!`)
+          return true
+        }
+
+        const pendingModules = modules.filter((m) => !readyModules.includes(m))
+        console.log('Still waiting for modules:', pendingModules.join(', '))
+        return false
+      },
+      moduleNames,
+      { timeout: 240000 },
+    )
+
+    console.log(`All modules ready after ${(Date.now() - moduleStartTime) / 1000}s`)
+    console.log(`Total startup time: ${(Date.now() - startTime) / 1000}s`)
+  } catch (error) {
+    console.error('Error during startup:', error)
+    throw error
+  } finally {
+    await browser.close()
+  }
 }
 
 export default globalSetup

--- a/frontend/console/playwright.config.ts
+++ b/frontend/console/playwright.config.ts
@@ -12,8 +12,8 @@ const config: PlaywrightTestConfig = {
   forbidOnly: !!process.env.CI,
   /* Retry on CI only. */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  /* Use 2 workers in CI, auto-detect cores in development */
+  workers: process.env.CI ? 2 : undefined,
   /* With additional example modules, it can take a bit of time for everything to start up. */
   timeout: 90 * 1000,
   reporter: 'html',
@@ -28,19 +28,17 @@ const config: PlaywrightTestConfig = {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
     },
-
     {
       name: 'firefox',
       use: { ...devices['Desktop Firefox'] },
     },
-
     {
       name: 'webkit',
       use: { ...devices['Desktop Safari'] },
     },
   ],
   webServer: {
-    command: 'ftl dev',
+    command: process.env.CI ? 'ftl dev -j 2' : 'ftl dev',
     url: 'http://localhost:8899',
     reuseExistingServer: !process.env.CI,
     /* If the test ends up needing to pull the postgres docker image, this can take a while. Give it a few minutes. */


### PR DESCRIPTION
Some changes/optimizations for the console e2e tests

- Add more logging to report on module deployment time when starting `ftl dev`
  ```
  All modules ready after 96.698s
  Total startup time: 101.976s
  ```
- Increase number of workers for playwright to `2` (previous was `1` on CI)
- Increase number of cores for `ftl dev` to `2` on CI 