### PR TITLE
fix: automatic scale up for raft clusters

### DIFF
--- a/charts/ftl/values.yaml
+++ b/charts/ftl/values.yaml
@@ -375,6 +375,8 @@ schema:
       value: "$(ORDINAL_NUMBER)"
     - name: RAFT_LISTEN_ADDRESS
       value: "$(MY_POD_IP):8992"
+    - name: RAFT_CONTROL_ADDRESS
+      value: "http://ftl-schema:8892"
 
   revisionHistoryLimit: 0
 

--- a/internal/raft/cluster_test.go
+++ b/internal/raft/cluster_test.go
@@ -182,7 +182,6 @@ func testBuilder(t *testing.T, addresses []*net.TCPAddr, id uint64, address stri
 	return raft.NewBuilder(&raft.RaftConfig{
 		ReplicaID:          id,
 		Address:            address,
-		ControlBind:        controlBind,
 		DataDir:            t.TempDir(),
 		InitialMembers:     members,
 		HeartbeatRTT:       1,


### PR DESCRIPTION
Adds the Raft control service to existing grpc servers, and uses it to join the cluster if the shard is not an initial member.

Scaling down is not automatic yet. When we scale down, we will need to do it manually via an endpoint I will add next.