### PR TITLE
fix: charts unable to calculate schema endpoint value

### DIFF
--- a/charts/ftl/templates/admin-deployment.yaml
+++ b/charts/ftl/templates/admin-deployment.yaml
@@ -54,7 +54,7 @@ spec:
             - name: FTL_BIND
               value: "http://0.0.0.0:8892"
             - name: FTL_SCHEMA_ENDPOINT
-              value: "http://{{ include "ftl.fullname" . }}-schema:{{ .Values.schema.service.port }}"
+              value: "http://ftl-schema:8892"
             - name: LOG_LEVEL
               value: "{{ .Values.admin.logLevel }}"
             - name: LOG_JSON

--- a/charts/ftl/templates/cron.yaml
+++ b/charts/ftl/templates/cron.yaml
@@ -42,7 +42,7 @@ spec:
             - name: FTL_TIMELINE_ENDPOINT
               value: "http://{{ .Values.timeline.service.name }}:{{ .Values.timeline.service.port }}"
             - name: FTL_SCHEMA_ENDPOINT
-              value: "http://{{ .Values.schema.service.name }}:{{ .Values.schema.service.port }}"
+              value: "http://ftl-schema:8892"
       {{- if .Values.cron.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.cron.nodeSelector | nindent 8 }}


### PR DESCRIPTION
Consolidating `FTL_SCHEMA_ENDPOINT` to literal `http://ftl-schema:8892` the same as elsewhere to fix this error:
I think because ftl schema now has multiple services incl raft?
```
│ Error: template: ftl-aws/charts/ftl/templates/cron.yaml:41:39: executing "ftl-aws/charts/ftl/templates/cron.yaml" at <.Values.schema.service.name>: nil pointer evaluating interface {}.name
│ 
│   with helm_release.ftl,
│   on main.tf line 136, in resource "helm_release" "ftl":
│  136: resource "helm_release" "ftl" {
│ 
```