### PR TITLE
fix: cron called repeatedly when schema is updated

### DIFF
--- a/examples/go/echo/types.ftl.go
+++ b/examples/go/echo/types.ftl.go
@@ -2,20 +2,22 @@
 package echo
 
 import (
-	"context"
-	ftltime "ftl/time"
-	"github.com/block/ftl/common/reflection"
-	"github.com/block/ftl/go-runtime/server"
+    "context"
+    "github.com/block/ftl/common/reflection"
+    "github.com/block/ftl/go-runtime/server"
+    ftltime "ftl/time"
 )
 
+	
 type EchoClient func(context.Context, EchoRequest) (EchoResponse, error)
+	
 
 func init() {
 	reflection.Register(
-
+	
 		reflection.ProvideResourcesForVerb(
-			Echo,
-			server.VerbClient[ftltime.TimeClient, ftltime.TimeRequest, ftltime.TimeResponse](),
+            Echo,
+            server.VerbClient[ftltime.TimeClient, ftltime.TimeRequest, ftltime.TimeResponse](),
 			server.Config[string]("echo", "default"),
 		),
 	)


### PR DESCRIPTION
The original cron job in map was overwritting the updated time, using pointers means that there is only one instance to update