### PR TITLE
refactor: split runtime types into separate files

### DIFF
--- a/common/schema/databaseruntime.go
+++ b/common/schema/databaseruntime.go
@@ -9,9 +9,9 @@ type DatabaseRuntime struct {
 	Connections *DatabaseRuntimeConnections `parser:"" protobuf:"1,optional"`
 }
 
-func (m *DatabaseRuntime) runtimeElement() {
+var _ Runtime = (*DatabaseRuntime)(nil)
 
-}
+func (m *DatabaseRuntime) runtimeElement() {}
 
 var _ Symbol = (*DatabaseRuntime)(nil)
 

--- a/common/schema/moduleruntime.go
+++ b/common/schema/moduleruntime.go
@@ -1,13 +1,5 @@
 package schema
 
-import (
-	"time"
-
-	"github.com/alecthomas/types/optional"
-
-	"github.com/block/ftl/internal/key"
-)
-
 type DeploymentState int
 
 const (
@@ -28,13 +20,6 @@ type Runtime interface {
 	runtimeElement()
 }
 
-var _ Runtime = (*ModuleRuntimeScaling)(nil)
-var _ Runtime = (*ModuleRuntimeRunner)(nil)
-var _ Runtime = (*ModuleRuntimeDeployment)(nil)
-var _ Runtime = (*VerbRuntime)(nil)
-var _ Runtime = (*TopicRuntime)(nil)
-var _ Runtime = (*DatabaseRuntime)(nil)
-
 // ModuleRuntime is runtime configuration for a module that can be dynamically updated.
 type ModuleRuntime struct {
 	Base       ModuleRuntimeBase        `protobuf:"1"` // Base is always present.
@@ -43,65 +28,11 @@ type ModuleRuntime struct {
 	Runner     *ModuleRuntimeRunner     `protobuf:"4,optional"`
 }
 
-type ModuleRuntimeBase struct {
-	CreateTime time.Time `protobuf:"1"`
-	Language   string    `protobuf:"2"`
-	OS         string    `protobuf:"3,optional"`
-	Arch       string    `protobuf:"4,optional"`
-	// Image is the name of the runner image. Defaults to "ftl0/ftl-runner".
-	// Must not include a tag, as FTL's version will be used as the tag.
-	Image string `protobuf:"5,optional"`
-}
-
-//protobuf:1
-type ModuleRuntimeDeployment struct {
-	DeploymentKey key.Deployment             `protobuf:"2"`
-	CreatedAt     time.Time                  `protobuf:"3"`
-	ActivatedAt   optional.Option[time.Time] `protobuf:"4"`
-	State         DeploymentState            `protobuf:"5"`
-}
-
-func (m *ModuleRuntimeDeployment) runtimeElement() {
-
-}
-
-//protobuf:2
-type ModuleRuntimeScaling struct {
-	MinReplicas int32 `protobuf:"1"`
-}
-
-func (m *ModuleRuntimeScaling) runtimeElement() {
-}
-
-//protobuf:3
-type ModuleRuntimeRunner struct {
-	// Endpoint is the endpoint of the deployed module.
-	Endpoint string `protobuf:"1"`
-}
-
-func (m *ModuleRuntimeRunner) runtimeElement() {
-}
-
-func (m *ModuleRuntimeRunner) GetEndpoint() string {
-	if m == nil {
-		return ""
-	}
-	return m.Endpoint
-
-}
-
 func (m *ModuleRuntime) GetScaling() *ModuleRuntimeScaling {
 	if m == nil {
 		return nil
 	}
 	return m.Scaling
-}
-
-func (m *ModuleRuntimeScaling) GetMinReplicas() int32 {
-	if m == nil {
-		return 0
-	}
-	return m.MinReplicas
 }
 
 func (m *ModuleRuntime) GetDeployment() *ModuleRuntimeDeployment {
@@ -128,20 +59,6 @@ func (m *ModuleRuntime) ModDeployment() *ModuleRuntimeDeployment {
 		m.Deployment = &ModuleRuntimeDeployment{}
 	}
 	return m.Deployment
-}
-
-func (m *ModuleRuntimeDeployment) GetCreatedAt() time.Time {
-	if m == nil {
-		return time.Time{}
-	}
-	return m.CreatedAt
-}
-
-func (m *ModuleRuntimeDeployment) GetDeploymentKey() key.Deployment {
-	if m == nil {
-		return key.Deployment{}
-	}
-	return m.DeploymentKey
 }
 
 func (m *ModuleRuntime) ModScaling() *ModuleRuntimeScaling {

--- a/common/schema/moduleruntimebase.go
+++ b/common/schema/moduleruntimebase.go
@@ -1,0 +1,15 @@
+package schema
+
+import (
+	"time"
+)
+
+type ModuleRuntimeBase struct {
+	CreateTime time.Time `protobuf:"1"`
+	Language   string    `protobuf:"2"`
+	OS         string    `protobuf:"3,optional"`
+	Arch       string    `protobuf:"4,optional"`
+	// Image is the name of the runner image. Defaults to "ftl0/ftl-runner".
+	// Must not include a tag, as FTL's version will be used as the tag.
+	Image string `protobuf:"5,optional"`
+}

--- a/common/schema/moduleruntimedeployment.go
+++ b/common/schema/moduleruntimedeployment.go
@@ -1,0 +1,35 @@
+package schema
+
+import (
+	"time"
+
+	"github.com/alecthomas/types/optional"
+
+	"github.com/block/ftl/internal/key"
+)
+
+//protobuf:1
+type ModuleRuntimeDeployment struct {
+	DeploymentKey key.Deployment             `protobuf:"2"`
+	CreatedAt     time.Time                  `protobuf:"3"`
+	ActivatedAt   optional.Option[time.Time] `protobuf:"4"`
+	State         DeploymentState            `protobuf:"5"`
+}
+
+var _ Runtime = (*ModuleRuntimeDeployment)(nil)
+
+func (m *ModuleRuntimeDeployment) runtimeElement() {}
+
+func (m *ModuleRuntimeDeployment) GetCreatedAt() time.Time {
+	if m == nil {
+		return time.Time{}
+	}
+	return m.CreatedAt
+}
+
+func (m *ModuleRuntimeDeployment) GetDeploymentKey() key.Deployment {
+	if m == nil {
+		return key.Deployment{}
+	}
+	return m.DeploymentKey
+}

--- a/common/schema/moduleruntimerunner.go
+++ b/common/schema/moduleruntimerunner.go
@@ -1,0 +1,19 @@
+package schema
+
+//protobuf:3
+type ModuleRuntimeRunner struct {
+	// Endpoint is the endpoint of the deployed module.
+	Endpoint string `protobuf:"1"`
+}
+
+var _ Runtime = (*ModuleRuntimeRunner)(nil)
+
+func (m *ModuleRuntimeRunner) runtimeElement() {}
+
+func (m *ModuleRuntimeRunner) GetEndpoint() string {
+	if m == nil {
+		return ""
+	}
+	return m.Endpoint
+
+}

--- a/common/schema/moduleruntimescaling.go
+++ b/common/schema/moduleruntimescaling.go
@@ -1,0 +1,17 @@
+package schema
+
+//protobuf:2
+type ModuleRuntimeScaling struct {
+	MinReplicas int32 `protobuf:"1"`
+}
+
+var _ Runtime = (*ModuleRuntimeScaling)(nil)
+
+func (m *ModuleRuntimeScaling) runtimeElement() {}
+
+func (m *ModuleRuntimeScaling) GetMinReplicas() int32 {
+	if m == nil {
+		return 0
+	}
+	return m.MinReplicas
+}

--- a/common/schema/topic.go
+++ b/common/schema/topic.go
@@ -58,12 +58,3 @@ func (t *Topic) GetProvisioned() ResourceSet {
 func (t *Topic) ResourceID() string {
 	return t.Name
 }
-
-//protobuf:5
-type TopicRuntime struct {
-	KafkaBrokers []string `parser:"" protobuf:"1"`
-	TopicID      string   `parser:"" protobuf:"2"`
-}
-
-func (m *TopicRuntime) runtimeElement() {
-}

--- a/common/schema/topicruntime.go
+++ b/common/schema/topicruntime.go
@@ -1,0 +1,11 @@
+package schema
+
+//protobuf:5
+type TopicRuntime struct {
+	KafkaBrokers []string `parser:"" protobuf:"1"`
+	TopicID      string   `parser:"" protobuf:"2"`
+}
+
+var _ Runtime = (*TopicRuntime)(nil)
+
+func (m *TopicRuntime) runtimeElement() {}

--- a/common/schema/verbruntime.go
+++ b/common/schema/verbruntime.go
@@ -5,6 +5,8 @@ type VerbRuntime struct {
 	Subscription *VerbRuntimeSubscription `protobuf:"1,optional"`
 }
 
+var _ Runtime = (*VerbRuntime)(nil)
+
 func (m *VerbRuntime) runtimeElement() {
 }
 


### PR DESCRIPTION
Just makes it a bit easier to navigate.