### PR TITLE
chore: fix docs styling and cleanup

### DIFF
--- a/docs/docs/getting-started/quick-start.md
+++ b/docs/docs/getting-started/quick-start.md
@@ -47,11 +47,9 @@ Download binaries from the [latest release page](https://github.com/block/ftl/re
   </TabItem>
 </Tabs>
 
----
-
 ### Install the VSCode extension
 
-The [FTL VSCode extension](https://marketplace.visualstudio.com/items?itemName=FTL.ftl) will run FTL within VSCode, and provide LSP support for FTL, displaying errors within the editor.
+The [FTL VSCode extension](https://marketplace.visualstudio.com/items?itemName=FTL.ftl) provides error and problem reporting through the language server and includes code snippets for common FTL patterns.
 
 ## Development
 
@@ -158,15 +156,7 @@ Any number of modules can be added to your project, adjacent to each other.
 
 ### Start the FTL cluster
 
-#### VSCode
-
-If using VSCode, opening the directory will prompt you to start FTL:
-
-![VSCode](/img/quick-start/vscode.png)
-
-#### Manually
-
-Alternatively start the local FTL development cluster from the command-line:
+Start the local FTL development cluster from the command-line:
 
 ![ftl dev](/img/quick-start/ftldev.png)
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -54,7 +54,6 @@ const config: Config = {
           // Remove this to remove the "edit this page" links.
           editUrl: 'https://github.com/block/ftl/tree/main/docs/',
         },
-        blog: false,
         theme: {
           customCss: './src/css/custom.css',
         },

--- a/docs/package.json
+++ b/docs/package.json
@@ -21,7 +21,8 @@
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-icons": "^5.4.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.7.0",

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -6,25 +6,58 @@
 
 /* You can override the default Infima variables here. */
 :root {
-  --ifm-color-primary: #2e8555;
-  --ifm-color-primary-dark: #29784c;
-  --ifm-color-primary-darker: #277148;
-  --ifm-color-primary-darkest: #205d3b;
-  --ifm-color-primary-light: #33925d;
-  --ifm-color-primary-lighter: #359962;
-  --ifm-color-primary-lightest: #3cad6e;
+  --ifm-color-primary: #6366f1;
+  --ifm-color-primary-dark: #4f46e5;
+  --ifm-color-primary-darker: #4338ca;
+  --ifm-color-primary-darkest: #3730a3;
+  --ifm-color-primary-light: #818cf8;
+  --ifm-color-primary-lighter: #a5b4fc;
+  --ifm-color-primary-lightest: #c7d2fe;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+  --ifm-footer-background-color: #312e81; /* Indigo 900 */
+  --ifm-footer-color: #e0e7ff; /* Indigo 100 */
+  --ifm-footer-link-color: #c7d2fe; /* Indigo 200 */
+  --ifm-footer-title-color: #e0e7ff; /* Indigo 100 */
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
-[data-theme='dark'] {
-  --ifm-color-primary: #25c2a0;
-  --ifm-color-primary-dark: #21af90;
-  --ifm-color-primary-darker: #1fa588;
-  --ifm-color-primary-darkest: #1a8870;
-  --ifm-color-primary-light: #29d5b0;
-  --ifm-color-primary-lighter: #32d8b4;
-  --ifm-color-primary-lightest: #4fddbf;
+[data-theme="dark"] {
+  --ifm-color-primary: #818cf8;
+  --ifm-color-primary-dark: #6366f1;
+  --ifm-color-primary-darker: #4f46e5;
+  --ifm-color-primary-darkest: #4338ca;
+  --ifm-color-primary-light: #a5b4fc;
+  --ifm-color-primary-lighter: #c7d2fe;
+  --ifm-color-primary-lightest: #e0e7ff;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+  --ifm-footer-background-color: #1e1b4b; /* Indigo 950 */
+  --ifm-footer-color: #e0e7ff; /* Indigo 100 */
+  --ifm-footer-link-color: #c7d2fe; /* Indigo 200 */
+  --ifm-footer-title-color: #e0e7ff; /* Indigo 100 */
+}
+
+/* Custom hero button styling */
+.hero .button.button--secondary {
+  background-color: white;
+  color: var(--ifm-color-primary);
+  border: 2px solid white;
+  transition: all 0.2s ease-in-out;
+}
+
+.hero .button.button--secondary:hover {
+  background-color: transparent;
+  color: white;
+}
+
+/* Dark mode overrides */
+[data-theme="dark"] .hero .button.button--secondary {
+  background-color: rgba(255, 255, 255, 0.1);
+  color: white;
+  border: 1px solid rgba(255, 255, 255, 0.5);
+}
+
+[data-theme="dark"] .hero .button.button--secondary:hover {
+  background-color: rgba(255, 255, 255, 0.2);
+  border-color: white;
 }

--- a/docs/src/pages/index.module.css
+++ b/docs/src/pages/index.module.css
@@ -8,25 +8,25 @@
   text-align: center;
   position: relative;
   overflow: hidden;
-  background-color: var(--ifm-color-primary);
-  color: var(--ifm-font-color-base-inverse);
+}
+
+@media screen and (max-width: 996px) {
+  .heroBanner {
+    padding: 2rem;
+  }
 }
 
 .buttons {
   display: flex;
   align-items: center;
   justify-content: center;
+  gap: 1rem;
   margin-top: 2rem;
 }
 
 .version {
-  margin-top: 2rem;
-  font-size: 0.9rem;
+  margin-top: 1rem;
   opacity: 0.8;
-}
-
-.version p {
-  margin: 0.5rem 0;
 }
 
 .version a {
@@ -35,41 +35,19 @@
 }
 
 .features {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 2rem;
+  display: flex;
+  align-items: center;
   padding: 2rem 0;
+  width: 100%;
 }
 
-.feature {
-  padding: 1.5rem;
-  border-radius: var(--ifm-card-border-radius);
-  background: var(--ifm-card-background-color);
-  box-shadow: var(--ifm-card-shadow);
-}
-
-.feature h3 {
-  font-size: 1.5rem;
-  margin-bottom: 1rem;
-}
-
-.feature p {
-  margin: 0;
-  font-size: 1rem;
-  line-height: 1.6;
-}
-
-.feature a {
+.featureIcon {
+  font-size: 4rem;
   color: var(--ifm-color-primary);
-  text-decoration: none;
+  margin-bottom: 1rem;
+  transition: transform 0.2s ease-in-out;
 }
 
-.feature a:hover {
-  text-decoration: underline;
-}
-
-@media screen and (max-width: 996px) {
-  .heroBanner {
-    padding: 2rem;
-  }
+.featureIcon:hover {
+  transform: scale(1.1);
 }

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -1,35 +1,47 @@
-import type { ReactNode } from 'react'
-import clsx from 'clsx'
 import Link from '@docusaurus/Link'
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext'
-import Layout from '@theme/Layout'
 import Heading from '@theme/Heading'
+import Layout from '@theme/Layout'
+import clsx from 'clsx'
+import type { ReactNode } from 'react'
+import { BiCodeBlock } from 'react-icons/bi'
+import { BsCodeSlash, BsGearWideConnected, BsRobot } from 'react-icons/bs'
+import { TbVersions } from 'react-icons/tb'
 
 import styles from './index.module.css'
 
 const features = [
   {
     title: 'Infrastructure as code',
-    content:
+    Icon: BiCodeBlock,
+    description:
       "Not YAML. Declare your infrastructure in the same language you're writing in as type-safe values, rather than in separate configuration files disassociated from their point of use.",
   },
   {
     title: 'Language agnostic',
-    content:
+    Icon: BsCodeSlash,
+    description:
       'FTL makes it possible to write backend code in your language of choice. You write normal code, and FTL extracts a service interface from your code directly, making your functions and types automatically available to all supported languages.',
   },
   {
     title: 'Fearless development against production',
-    content: 'There is no substitute for production data. FTL plans to support forking of production infrastructure and code during development.',
+    Icon: BsGearWideConnected,
+    description: 'There is no substitute for production data. FTL plans to support forking of production infrastructure and code during development.',
   },
   {
     title: 'Fearlessly modify types',
-    content:
-      'Multiple versions of a single verb with different signatures can be live concurrently. See <a href="https://www.unison-lang.org/">Unison</a> for inspiration. We can statically detect changes that would violate runtime and persistent data constraints.',
+    Icon: TbVersions,
+    description: (
+      <>
+        Multiple versions of a single verb with different signatures can be live concurrently. See <Link to='https://www.unison-lang.org/'>Unison</Link> for
+        inspiration. We can statically detect changes that would violate runtime and persistent data constraints.
+      </>
+    ),
   },
   {
     title: 'AI from the ground up',
-    content:
+    Icon: BsRobot,
+    description:
       'We plan to integrate AI sensibly and deeply into the FTL platform. Automated AI-driven tuning suggestions, automated third-party API integration, and so on.',
   },
 ]
@@ -39,13 +51,11 @@ function HomepageHeader() {
   return (
     <header className={clsx('hero hero--primary', styles.heroBanner)}>
       <div className='container'>
-        <Heading as='h1' className='hero__title'>
-          {siteConfig.title}
-        </Heading>
+        <h1 className='hero__title'>{siteConfig.title}</h1>
         <p className='hero__subtitle'>{siteConfig.tagline}</p>
         <div className={styles.buttons}>
-          <Link className='button button--secondary button--lg' to='/docs/getting-started/quick-start'>
-            Get started
+          <Link className='button button--secondary button--lg' to='docs/getting-started/quick-start'>
+            Get Started
           </Link>
         </div>
         <div className={styles.version}>
@@ -58,11 +68,16 @@ function HomepageHeader() {
   )
 }
 
-function Feature({ title, content }: { title: string; content: string }) {
+function Feature({ title, Icon, description }: { title: string; Icon: React.ComponentType<React.ComponentProps<'svg'>>; description: ReactNode }) {
   return (
-    <div className={styles.feature}>
-      <Heading as='h3'>{title}</Heading>
-      <p dangerouslySetInnerHTML={{ __html: content }} />
+    <div className={clsx('col col--4')}>
+      <div className='text--center'>
+        <Icon className={styles.featureIcon} />
+      </div>
+      <div className='text--center padding-horiz--md'>
+        <Heading as='h3'>{title}</Heading>
+        <p>{description}</p>
+      </div>
     </div>
   )
 }
@@ -73,13 +88,15 @@ export default function Home(): ReactNode {
     <Layout title={siteConfig.title} description={siteConfig.tagline}>
       <HomepageHeader />
       <main>
-        <div className='container'>
-          <div className={styles.features}>
-            {features.map((props, idx) => (
-              <Feature key={idx} {...props} />
-            ))}
+        <section className={styles.features}>
+          <div className='container'>
+            <div className='row'>
+              {features.map((props, idx) => (
+                <Feature key={idx} {...props} />
+              ))}
+            </div>
           </div>
-        </div>
+        </section>
       </main>
     </Layout>
   )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.0.0(react@19.0.0)
+      react-icons:
+        specifier: ^5.4.0
+        version: 5.4.0(react@19.0.0)
     devDependencies:
       '@docusaurus/module-type-aliases':
         specifier: 3.7.0
@@ -7653,6 +7656,11 @@ packages:
 
   react-fast-compare@3.2.2:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
+
+  react-icons@5.4.0:
+    resolution: {integrity: sha512-7eltJxgVt7X64oHh6wSWNwwbKTCtMfK35hcjvJS0yxEAhPM8oUKdS3+kqaW1vicIltw+kR2unHaa12S9pPALoQ==}
+    peerDependencies:
+      react: '*'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -18342,6 +18350,10 @@ snapshots:
   react-error-overlay@6.0.11: {}
 
   react-fast-compare@3.2.2: {}
+
+  react-icons@5.4.0(react@19.0.0):
+    dependencies:
+      react: 19.0.0
 
   react-is@16.13.1: {}
 


### PR DESCRIPTION
- Remove nasty green colors (replace with tailwind colors to better match the console)
- Remove section about VSCode extension starting the dev server
- Add some icons
- Route directly to quick start page if "Get Started" is clicked on the homepage
- Add back empty `blog` folder to silence build warnings
![Screenshot 2025-02-07 at 10 26 54 AM](https://github.com/user-attachments/assets/56134199-5594-40fe-a060-868707282fae)
![Screenshot 2025-02-07 at 10 26 56 AM](https://github.com/user-attachments/assets/af872055-8701-40dd-afa2-0f6332b9de74)
![Screenshot 2025-02-07 at 10 27 08 AM](https://github.com/user-attachments/assets/a42c2881-b343-40b0-bda5-aece9695d334)
