### PR TITLE
feat: Raft Ops

### DIFF
--- a/charts/ftl/templates/ingress.yaml
+++ b/charts/ftl/templates/ingress.yaml
@@ -38,6 +38,13 @@ spec:
               name: ftl-schema
               port:
                 number: 8892
+        - path: /xyz.block.ftl.raft.v1.RaftService/
+          pathType: Prefix
+          backend:
+            service:
+              name: ftl-schema
+              port:
+                number: 8892
         - path: /xyz.block.ftl.v1.VerbService/
           pathType: Prefix
           backend:

--- a/charts/ftl/templates/schema-deployment.yaml
+++ b/charts/ftl/templates/schema-deployment.yaml
@@ -55,6 +55,8 @@ spec:
               value: "http://0.0.0.0:{{ .Values.schema.services.schema.containerPort }}"
             - name: RAFT_INITIAL_MEMBERS
               value: "{{- range $index := until (.Values.schema.replicas | int ) }}{{- if ne $index 0 -}},{{- end -}}ftl-schema-{{ add $index 1  }}.ftl-schema-raft:{{$.Values.schema.services.raft.port}}{{- end -}}"
+            - name: RAFT_INITIAL_REPLICA_IDS
+              value: "{{- range $index := until (.Values.schema.replicas | int ) }}{{- if ne $index 0 -}},{{- end -}}{{ add $index 1  }}{{- end -}}"
             - name: RAFT_DATA_DIR
               value: "/tmp/ftl-schema-$(ORDINAL_NUMBER)"
             - name: ORDINAL_NUMBER

--- a/charts/ftl/templates/schema-deployment.yaml
+++ b/charts/ftl/templates/schema-deployment.yaml
@@ -58,15 +58,13 @@ spec:
             - name: RAFT_INITIAL_REPLICA_IDS
               value: "{{- range $index := until (.Values.schema.replicas | int ) }}{{- if ne $index 0 -}},{{- end -}}{{ add $index 1  }}{{- end -}}"
             - name: RAFT_DATA_DIR
-              value: "/tmp/ftl-schema-$(ORDINAL_NUMBER)"
+              value: "/tmp/ftl-schema"
             - name: ORDINAL_NUMBER
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
             - name: RAFT_ADDRESS
               value: "ftl-schema-$(ORDINAL_NUMBER).ftl-schema-raft:8992"
-            - name: RAFT_REPLICA_ID
-              value: "$(ORDINAL_NUMBER)"
             - name: RAFT_LISTEN_ADDRESS
               value: "$(MY_POD_IP):8992"
             - name: RAFT_CONTROL_ADDRESS

--- a/internal/raft/controlapi.go
+++ b/internal/raft/controlapi.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
+	"github.com/lni/dragonboat/v4"
+
 	raftpb "github.com/block/ftl/backend/protos/xyz/block/ftl/raft/v1"
 	ftlv1 "github.com/block/ftl/backend/protos/xyz/block/ftl/v1"
 	"github.com/block/ftl/internal/log"
-	"github.com/lni/dragonboat/v4"
 )
 
 // AddMember to the cluster. This needs to be called on an existing running cluster member,

--- a/internal/raft/controlapi.go
+++ b/internal/raft/controlapi.go
@@ -1,0 +1,69 @@
+package raft
+
+import (
+	"context"
+	"fmt"
+
+	"connectrpc.com/connect"
+	raftpb "github.com/block/ftl/backend/protos/xyz/block/ftl/raft/v1"
+	ftlv1 "github.com/block/ftl/backend/protos/xyz/block/ftl/v1"
+	"github.com/block/ftl/internal/log"
+	"github.com/lni/dragonboat/v4"
+)
+
+// AddMember to the cluster. This needs to be called on an existing running cluster member,
+// before the new member is started.
+func (c *Cluster) AddMember(ctx context.Context, req *connect.Request[raftpb.AddMemberRequest]) (*connect.Response[raftpb.AddMemberResponse], error) {
+	logger := log.FromContext(ctx).Scope("raft")
+
+	shards := req.Msg.ShardIds
+	replicaID := req.Msg.ReplicaId
+	address := req.Msg.Address
+
+	logger.Infof("Adding member %s to shard %d on replica %d", address, shards, replicaID)
+
+	for _, shardID := range shards {
+		if err := c.withRetry(ctx, shardID, replicaID, func(ctx context.Context) error {
+			logger.Debugf("Requesting add replica to shard %d on replica %d", shardID, replicaID)
+			return c.nh.SyncRequestAddReplica(ctx, shardID, replicaID, address, 0)
+		}, dragonboat.ErrShardNotReady, dragonboat.ErrTimeout); err != nil {
+			return nil, fmt.Errorf("failed to add member: %w", err)
+		}
+	}
+	return connect.NewResponse(&raftpb.AddMemberResponse{}), nil
+}
+
+func (c *Cluster) RemoveMember(ctx context.Context, req *connect.Request[raftpb.RemoveMemberRequest]) (*connect.Response[raftpb.RemoveMemberResponse], error) {
+	logger := log.FromContext(ctx).Scope("raft")
+	logger.Infof("Request to remove member %d from shards %v on replica %d", req.Msg.ReplicaId, req.Msg.ShardIds, req.Msg.ReplicaId)
+
+	for _, shardID := range req.Msg.ShardIds {
+		if err := c.removeShardMember(ctx, shardID, req.Msg.ReplicaId); err != nil {
+			return nil, fmt.Errorf("failed to remove member from shard %d: %w", shardID, err)
+		}
+	}
+
+	return connect.NewResponse(&raftpb.RemoveMemberResponse{}), nil
+}
+
+// Ping the cluster.
+func (c *Cluster) Ping(ctx context.Context, req *connect.Request[ftlv1.PingRequest]) (*connect.Response[ftlv1.PingResponse], error) {
+	return connect.NewResponse(&ftlv1.PingResponse{}), nil
+}
+
+// removeShardMember from the given shard. This removes the given member from the membership group
+// and blocks until the change has been committed
+func (c *Cluster) removeShardMember(ctx context.Context, shardID uint64, replicaID uint64) error {
+	logger := log.FromContext(ctx).Scope("raft")
+	logger.Infof("Removing replica %d from shard %d", shardID, replicaID)
+
+	if err := c.withRetry(ctx, shardID, replicaID, func(ctx context.Context) error {
+		logger.Debugf("Requesting delete replica from shard %d on replica %d", shardID, replicaID)
+		return c.nh.SyncRequestDeleteReplica(ctx, shardID, replicaID, 0)
+	}, dragonboat.ErrShardNotReady, dragonboat.ErrTimeout); err != nil {
+		// This can happen if the cluster is shutting down and no longer has quorum.
+		logger.Warnf("Removing replica %d from shard %d failed: %s", replicaID, shardID, err)
+		return err
+	}
+	return nil
+}

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -188,7 +188,7 @@ func (s *Server) Serve(ctx context.Context) error {
 		for i, hook := range s.startHooks {
 			logger.Debugf("Running start hook %d/%d", i+1, len(s.startHooks))
 			if err := hook(ctx); err != nil {
-				logger.Errorf(err, "start hook failed")
+				return fmt.Errorf("start hook failed: %w", err)
 			}
 		}
 


### PR DESCRIPTION
Generates a random replica id for non initial members. Properly restarts the pod if the id is taken. Makes initial member ids adjustable.

After this, and with the help of the Raft API, we should be able to recover any corrupted data nodes (as long as we retain quorum)

Next, I will write a quick runbook on managing the Raft cluster.