### PR TITLE
chore: move raft to listen to 8893 instead of 8992.

### DIFF
--- a/charts/ftl/templates/schema-deployment.yaml
+++ b/charts/ftl/templates/schema-deployment.yaml
@@ -67,9 +67,9 @@ spec:
                 fieldRef:
                   fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
             - name: RAFT_ADDRESS
-              value: "ftl-schema-$(ORDINAL_NUMBER).ftl-schema-raft:8992"
+              value: "ftl-schema-$(ORDINAL_NUMBER).ftl-schema-raft:{{$.Values.schema.services.raft.port}}"
             - name: RAFT_LISTEN_ADDRESS
-              value: "$(MY_POD_IP):8992"
+              value: "$(MY_POD_IP):{{$.Values.schema.services.raft.port}}"
             - name: RAFT_CONTROL_ADDRESS
               value: "http://ftl-schema:8892"
           ports:

--- a/charts/ftl/values.yaml
+++ b/charts/ftl/values.yaml
@@ -349,8 +349,8 @@ schema:
       port: 8892
     raft:
       annotations: null
-      containerPort: 8992
-      port: 8992
+      containerPort: 8893
+      port: 8893
   podAnnotations: null
   nodeSelector: null
   affinity: null


### PR DESCRIPTION
8992 is easier to mistake for 8892