### PR TITLE
fix: engine is idle if modules are waiting for failed modules

### DIFF
--- a/cmd/ftl/cmd_await_summary.go
+++ b/cmd/ftl/cmd_await_summary.go
@@ -34,7 +34,7 @@ func (c *awaitSummaryCmd) Run(ctx context.Context, buildEngineClient buildengine
 
 	start := time.Now()
 	idleDuration := 1500 * time.Millisecond
-	engineEnded := optional.None[*buildenginepb.EngineEnded]()
+	engineEnded := optional.Some(&buildenginepb.EngineEnded{})
 
 	streamChan := make(chan *buildenginepb.EngineEvent)
 	errChan := make(chan error)

--- a/internal/buildengine/engine.go
+++ b/internal/buildengine/engine.go
@@ -619,17 +619,19 @@ func isIdle(moduleStates map[string]moduleState) bool {
 	}
 	for _, state := range moduleStates {
 		switch state {
-		case moduleStateFailed,
-			moduleStateDeployed,
-			moduleStateBuildWaiting, // Modules can stay in this state if dependant modules fail to build
-			moduleStateDeployWaiting:
-			return true
 		case moduleStateExplicitlyBuilding,
 			moduleStateAutoRebuilding,
 			moduleStateDeploying:
+			return false
+
+		case moduleStateFailed,
+			moduleStateDeployed,
+			moduleStateBuildWaiting, // Modules can stay in this state if dependant modules fail to build
+			moduleStateDeployWaiting,
+			moduleStateBuilt:
 		}
 	}
-	return false
+	return true
 }
 
 // watchForEventsToPublish listens for raw build events, collects state, and publishes public events to BuildUpdates topic.

--- a/internal/buildengine/engine.go
+++ b/internal/buildengine/engine.go
@@ -614,11 +614,22 @@ const (
 )
 
 func isIdle(moduleStates map[string]moduleState) bool {
-	countByState := map[moduleState]int{}
-	for _, state := range moduleStates {
-		countByState[state]++
+	if len(moduleStates) == 0 {
+		return true
 	}
-	return countByState[moduleStateFailed]+countByState[moduleStateDeployed] == len(moduleStates)
+	for _, state := range moduleStates {
+		switch state {
+		case moduleStateFailed,
+			moduleStateDeployed,
+			moduleStateBuildWaiting, // Modules can stay in this state if dependant modules fail to build
+			moduleStateDeployWaiting:
+			return true
+		case moduleStateExplicitlyBuilding,
+			moduleStateAutoRebuilding,
+			moduleStateDeploying:
+		}
+	}
+	return false
 }
 
 // watchForEventsToPublish listens for raw build events, collects state, and publishes public events to BuildUpdates topic.


### PR DESCRIPTION
Handle case where modules stay in "waiting for build" state if a module it depends on failed to build.
Also `ftl await-summary` handles no module state.