### PR TITLE
fix: sqlc command captures stderr

### DIFF
--- a/internal/sqlc/sqlc.go
+++ b/internal/sqlc/sqlc.go
@@ -70,7 +70,7 @@ func AddQueriesToSchema(ctx context.Context, projectRoot string, mc moduleconfig
 		return false, fmt.Errorf("failed to scaffold SQLC config file: %w", err)
 	}
 
-	if err := exec.Command(ctx, log.Debug, ".", "ftl-sqlc", "generate", "--file", cfg.getSQLCConfigPath()).RunBuffered(ctx); err != nil {
+	if err := exec.Command(ctx, log.Debug, ".", "ftl-sqlc", "generate", "--file", cfg.getSQLCConfigPath()).RunStderrError(ctx); err != nil {
 		return false, fmt.Errorf("sqlc generate failed: %w", err)
 	}
 


### PR DESCRIPTION
Previouslly the build engine would only receive "exit status code 1" as the build error, while the actual error was logged. This in turn left goose unable to figure how to fix the issue.