### PR TITLE
fix: errs from stderr should be trimmed of whitespace

### DIFF
--- a/cmd/ftl/cmd_await_summary.go
+++ b/cmd/ftl/cmd_await_summary.go
@@ -126,8 +126,9 @@ streamLoop:
 				}
 				posStr += ": "
 			}
-			return fmt.Sprintf("  [%s] %s%s", errorType, posStr, e.Msg)
-		}), "\n"))
+			errorMsg := strings.ReplaceAll(e.Msg, "\n", "\n    ")
+			return fmt.Sprintf("  [%s] %s%s", errorType, posStr, errorMsg)
+		}), "\n"), "\n")
 	}
 
 	fmt.Printf("\n\nSchema:\n%s", schema.String())

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec" //nolint:depguard
+	"strings"
 	"syscall"
 
 	"github.com/kballard/go-shellquote"
@@ -83,7 +84,7 @@ func (c *Cmd) RunStderrError(ctx context.Context) error {
 	c.Cmd.Stderr = errorBuffer.WriterAt(ctx, c.level)
 
 	if err := c.Run(); err != nil {
-		return errors.New(string(errorBuffer.Bytes()))
+		return errors.New(strings.TrimSpace(string(errorBuffer.Bytes())))
 	}
 
 	return nil


### PR DESCRIPTION
Otherwise we typically have an extra newline at the end of each error.
Also fixed the spacing of `ftl await-summary` due to this whitespace change.