### PR TITLE
fix: handle deletion of queries file

### DIFF
--- a/go-runtime/compile/build.go
+++ b/go-runtime/compile/build.go
@@ -640,7 +640,7 @@ func scaffoldBuildTemplateAndTidy(ctx context.Context, config moduleconfig.AbsMo
 				return fmt.Errorf("failed to delete %s: %w", ftlQueriesFilename, err)
 			}
 			if err := filesTransaction.ModifiedFiles(filepath.Join(config.Dir, ftlQueriesFilename)); err != nil {
-				return fmt.Errorf("failed to mark %s as modified: %w", ftlQueriesFilename, err)
+				return fmt.Errorf("failed to mark %s as deleted: %w", ftlQueriesFilename, err)
 			}
 		}
 		if err := filesTransaction.ModifiedFiles(filepath.Join(config.Dir, ftlTypesFilename)); err != nil {

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -2,6 +2,7 @@ package watch
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -274,6 +275,10 @@ func (t *modifyFilesTransaction) ModifiedFiles(paths ...string) error {
 	}
 
 	for _, path := range paths {
+		if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+			delete(moduleHashes.Hashes, path)
+			continue
+		}
 		hash, matched, err := computeFileHash(moduleHashes.Config.Dir, path, t.watcher.patterns)
 		if err != nil {
 			return err


### PR DESCRIPTION
Builds would fail if all queries were removed because marking a file as changed within the build assumed the file still existed.