### PR TITLE
fix: find initial build errs in stdout for jvm modules

### DIFF
--- a/jvm-runtime/plugin/common/error_detector.go
+++ b/jvm-runtime/plugin/common/error_detector.go
@@ -46,10 +46,10 @@ func (o *errorDetector) FinalizeCapture() []builderrors.Error {
 
 	var errs []builderrors.Error
 	lines := slices.Filter(strings.Split(o.output, "\n"), func(s string) bool {
-		return strings.HasPrefix(s, "[ERROR] ")
+		return strings.HasPrefix(s, "[ERROR]")
 	})
 	for _, line := range lines {
-		line = strings.TrimPrefix(line, "[ERROR] ")
+		line = strings.TrimSpace(strings.TrimPrefix(line, "[ERROR]"))
 		if len(line) == 0 {
 			continue
 		}

--- a/jvm-runtime/plugin/common/error_detector.go
+++ b/jvm-runtime/plugin/common/error_detector.go
@@ -21,7 +21,7 @@ type errorDetector struct {
 }
 
 func (o *errorDetector) Write(p []byte) (n int, err error) {
-	//forward output to stdout
+	// Forward output to stdout
 	fmt.Printf("%s", string(p))
 	if !o.ended.Load() {
 		o.output += string(p)

--- a/jvm-runtime/plugin/common/error_detector.go
+++ b/jvm-runtime/plugin/common/error_detector.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/alecthomas/atomic"
+
 	"github.com/block/ftl/common/builderrors"
 	"github.com/block/ftl/common/slices"
 )

--- a/jvm-runtime/plugin/common/error_detector.go
+++ b/jvm-runtime/plugin/common/error_detector.go
@@ -31,6 +31,18 @@ func (o *errorDetector) Write(p []byte) (n int, err error) {
 func (o *errorDetector) FinalizeCapture() []builderrors.Error {
 	o.ended.Store(true)
 
+	// Example error output:
+	// [ERROR] /example/path/StockPricePublisher.kt: (31, 24) 'public' function exposes its 'internal' parameter type 'StockPricesTopic'.
+	// [ERROR] Failed to execute goal io.quarkus:quarkus-maven-plugin:3.18.1:dev (default-cli) on project stockprices: Unable to execute mojo: Compilation failure
+	// [ERROR] /example/path/StockPricePublisher.kt:[31,24] 'public' function exposes its 'internal' parameter type 'StockPricesTopic'.
+	// [ERROR] -> [Help 1]
+	// [ERROR]
+	// [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
+	// [ERROR] Re-run Maven using the -X switch to enable full debug logging.
+	// [ERROR]
+	// [ERROR] For more information about the errors and possible solutions, please read the following articles:
+	// [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
+
 	var errs []builderrors.Error
 	lines := slices.Filter(strings.Split(o.output, "\n"), func(s string) bool {
 		return strings.HasPrefix(s, "[ERROR] ")

--- a/jvm-runtime/plugin/common/error_detector.go
+++ b/jvm-runtime/plugin/common/error_detector.go
@@ -1,0 +1,54 @@
+package common
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/alecthomas/atomic"
+	"github.com/block/ftl/common/builderrors"
+	"github.com/block/ftl/common/slices"
+)
+
+var _ io.Writer = &errorDetector{}
+
+// errorDetector is a writer that forwards output to stdout, while capturing output until a safe state is reached.
+// When safe state is reached, the output is then parsed for errors.
+type errorDetector struct {
+	output string
+	ended  atomic.Value[bool]
+}
+
+func (o *errorDetector) Write(p []byte) (n int, err error) {
+	//forward output to stdout
+	fmt.Printf("%s", string(p))
+	if !o.ended.Load() {
+		o.output += string(p)
+	}
+	return len(p), nil
+}
+
+func (o *errorDetector) FinalizeCapture() []builderrors.Error {
+	o.ended.Store(true)
+
+	var errs []builderrors.Error
+	lines := slices.Filter(strings.Split(o.output, "\n"), func(s string) bool {
+		return strings.HasPrefix(s, "[ERROR] ")
+	})
+	for _, line := range lines {
+		line = strings.TrimPrefix(line, "[ERROR] ")
+		if len(line) == 0 {
+			continue
+		}
+		if strings.HasPrefix(line, "To see the full") || strings.HasPrefix(line, "->") {
+			// This looks like the end of the errors and the start of help text
+			break
+		}
+		errs = append(errs, builderrors.Error{
+			Msg:   line,
+			Type:  builderrors.COMPILER,
+			Level: builderrors.ERROR,
+		})
+	}
+	return errs
+}

--- a/jvm-runtime/plugin/common/jvmcommon.go
+++ b/jvm-runtime/plugin/common/jvmcommon.go
@@ -577,7 +577,7 @@ func (s *Service) connectReloadClient(ctx context.Context, hotReloadEndpoint str
 
 			buildErrs := output.FinalizeCapture()
 			if len(buildErrs) == 0 {
-				buildErrs = []builderrors.Error{{Msg: "The dev mode process exited", Level: builderrors.ERROR, Type: builderrors.COMPILER}}
+				buildErrs = []builderrors.Error{{Msg: "Compile process unexpectedly exited without reporting any errors", Level: builderrors.ERROR, Type: builderrors.COMPILER}}
 			}
 			err = stream.Send(&langpb.BuildResponse{Event: &langpb.BuildResponse_BuildFailure{
 				BuildFailure: &langpb.BuildFailure{

--- a/jvm-runtime/plugin/common/jvmcommon.go
+++ b/jvm-runtime/plugin/common/jvmcommon.go
@@ -383,6 +383,7 @@ func (s *Service) runQuarkusDev(ctx context.Context, req *connect.Request[langpb
 		return err
 	}
 	logger.Debugf("Dev mode process started")
+	_ = output.FinalizeCapture()
 
 	schemaHash := sha256.SHA256{}
 	errorHash := sha256.SHA256{}


### PR DESCRIPTION
Maven logs initial compile errors to `stdout` which means FTL logs them but doesn't capture them.
This fix captures these logs while forwarding them to stdout, then if we do not get a connection from quarkus we search the logs for errors.

This allows build errors to contain the actual errors, which in turn lets users or Goose to fix them.