### PR TITLE
chore: do not run raft tests in parallel.

### DIFF
--- a/internal/raft/cluster_test.go
+++ b/internal/raft/cluster_test.go
@@ -55,7 +55,6 @@ func (s *IntStateMachine) Save(writer io.Writer) error     { return nil }
 func (s *IntStateMachine) Close() error                    { return nil }
 
 func TestClusterWith2Shards(t *testing.T) {
-	t.Parallel()
 	if testing.Short() {
 		t.SkipNow()
 	}
@@ -79,7 +78,6 @@ func TestClusterWith2Shards(t *testing.T) {
 }
 
 func TestJoiningExistingCluster(t *testing.T) {
-	t.Parallel()
 	if testing.Short() {
 		t.SkipNow()
 	}
@@ -145,7 +143,6 @@ func TestJoiningExistingCluster(t *testing.T) {
 }
 
 func TestLeavingCluster(t *testing.T) {
-	t.Parallel()
 	if testing.Short() {
 		t.SkipNow()
 	}
@@ -168,7 +165,6 @@ func TestLeavingCluster(t *testing.T) {
 }
 
 func TestStateIter(t *testing.T) {
-	t.Parallel()
 	if testing.Short() {
 		t.SkipNow()
 	}
@@ -188,7 +184,6 @@ func TestStateIter(t *testing.T) {
 }
 
 func TestInvalidEvents(t *testing.T) {
-	t.Parallel()
 	if testing.Short() {
 		t.SkipNow()
 	}


### PR DESCRIPTION
This made the tests flaky as we could get port binding collisions