### PR TITLE
fix: random ctx cancelled errors

### DIFF
--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -200,7 +200,7 @@ func (s *Server) Serve(ctx context.Context) error {
 	})
 
 	err = tree.Wait()
-	if err != nil {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		return fmt.Errorf("failed to start server: %w", err)
 	}
 


### PR DESCRIPTION
I was getting
```
error: controller0 failed: failed to start server: FTL terminating with signal interrupt: context canceled: failed to start server: 
```
FTL terminating with signal interrupt: context canceled
occasionally in ftl dev. This fixes it