### PR TITLE
fix: remove context cancelled error

### DIFF
--- a/internal/buildengine/engine.go
+++ b/internal/buildengine/engine.go
@@ -420,7 +420,7 @@ func (e *Engine) watchForModuleChanges(ctx context.Context, period time.Duration
 
 	// Build and deploy all modules first.
 	err = e.BuildAndDeploy(ctx, 1, true)
-	if err != nil {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		logger.Errorf(err, "Initial deploy failed")
 	}
 


### PR DESCRIPTION
Previously you would get
```
 error: Initial deploy failed: build failed: failed to generate language stubs: plugin failed to generate stubs: canceled: context canceled
```
When ctrl+c during the initial build