### PR TITLE
refactor: Refactor Cloudformation Provisioner

### DIFF
--- a/cmd/ftl-provisioner-cloudformation/cf_executor.go
+++ b/cmd/ftl-provisioner-cloudformation/cf_executor.go
@@ -2,40 +2,165 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	goformation "github.com/awslabs/goformation/v7/cloudformation"
+	cf "github.com/awslabs/goformation/v7/cloudformation/cloudformation"
 	"github.com/block/ftl/cmd/ftl-provisioner-cloudformation/executor"
+	"github.com/block/ftl/internal/log"
 )
 
-type CFExecutor struct {
+type CloudFormationExecutor struct {
 	cfn      *cloudformation.Client
 	secrets  *secretsmanager.Client
 	template *goformation.Template
+	config   *Config
+	stack    string
 
 	inputs []executor.State
 }
 
-func NewCFExecutor(ctx context.Context, cfn *cloudformation.Client, secrets *secretsmanager.Client) (*CFExecutor, error) {
-	e := &CFExecutor{
+func NewCloudFormationExecutor(stack string, cfn *cloudformation.Client, secrets *secretsmanager.Client, config *Config) *CloudFormationExecutor {
+	return &CloudFormationExecutor{
 		cfn:      cfn,
 		secrets:  secrets,
 		template: goformation.NewTemplate(),
+		stack:    stack,
+		config:   config,
 	}
-
-	return e, nil
 }
 
-func (e *CFExecutor) Stage() executor.Stage {
+func (e *CloudFormationExecutor) Stage() executor.Stage {
 	return executor.StageProvisioning
 }
 
-func (e *CFExecutor) Resources() []executor.ResourceKind {
+func (e *CloudFormationExecutor) Resources() []executor.ResourceKind {
 	return executor.AllResources
 }
 
-func (e *CFExecutor) Prepare(ctx context.Context, input executor.State) error {
+func (e *CloudFormationExecutor) Prepare(ctx context.Context, input executor.State) error {
 	e.inputs = append(e.inputs, input)
+
+	for _, resource := range e.inputs {
+		switch r := resource.(type) {
+		case executor.PostgresInputState:
+			tmpl := &PostgresTemplater{input: r, config: e.config}
+			if err := tmpl.AddToTemplate(e.template); err != nil {
+				return fmt.Errorf("failed to add postgres template: %w", err)
+			}
+		case executor.MySQLInputState:
+			tmpl := &MySQLTemplater{input: r, config: e.config}
+			if err := tmpl.AddToTemplate(e.template); err != nil {
+				return fmt.Errorf("failed to add mysql template: %w", err)
+			}
+		default:
+			return fmt.Errorf("unknown resource type: %T", r)
+		}
+	}
+
+	if len(e.inputs) == 0 {
+		// Stack can not be empty, insert a null resource to keep the stack around
+		e.template.Resources["NullResource"] = &cf.WaitConditionHandle{}
+	}
 	return nil
+}
+
+func (e *CloudFormationExecutor) Execute(ctx context.Context) ([]executor.State, error) {
+	logger := log.FromContext(ctx)
+
+	changeSet := generateChangeSetName(e.stack)
+	templateStr, err := e.template.JSON()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cloudformation template: %w", err)
+	}
+	if err := ensureStackExists(ctx, e.cfn, e.stack); err != nil {
+		return nil, fmt.Errorf("failed to verify the stack exists: %w", err)
+	}
+
+	logger.Debugf("creating change-set to stack %s", e.stack)
+	resp, err := e.cfn.CreateChangeSet(ctx, &cloudformation.CreateChangeSetInput{
+		StackName:     &e.stack,
+		ChangeSetName: &changeSet,
+		TemplateBody:  ptr(string(templateStr)),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create change-set: %w", err)
+	}
+	logger.Debugf("waiting for change-set %s to stack %s to become ready", *resp.Id, e.stack)
+	hadChanges, err := waitChangeSetReady(ctx, e.cfn, changeSet, e.stack)
+	if err != nil {
+		return nil, fmt.Errorf("failed to wait for change-set to become ready: %w", err)
+	}
+
+	if hadChanges {
+		logger.Debugf("executing change-set %s to stack %s", *resp.Id, e.stack)
+		_, err = e.cfn.ExecuteChangeSet(ctx, &cloudformation.ExecuteChangeSetInput{
+			ChangeSetName: &changeSet,
+			StackName:     &e.stack,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to execute change-set: %w", err)
+		}
+	} else {
+		logger.Debugf("no changes to execute for change-set %s to stack %s", *resp.Id, e.stack)
+	}
+
+	logger.Debugf("waiting for stack %s to be ready", e.stack)
+	cfOutputs, err := waitForStackReady(ctx, e.stack, e.cfn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to wait for stack to be ready: %w", err)
+	}
+
+	byResourceID, err := outputsByResourceID(cfOutputs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to group outputs by resource ID: %w", err)
+	}
+	logger.Debugf("grouped outputs by resource ID: %v", byResourceID)
+
+	outputs := make([]executor.State, 0, len(e.inputs))
+	for _, input := range e.inputs {
+		switch r := input.(type) {
+		case executor.PostgresInputState:
+			logger.Debugf("finding outputs for postgres resource %s", r.ResourceID)
+			res := byResourceID[r.ResourceID]
+			outputs = append(outputs, executor.PostgresInstanceReadyState{
+				PostgresInputState:  r,
+				MasterUserSecretARN: findValue(ctx, res, PropertyPsqlMasterUserARN),
+				WriteEndpoint:       findValue(ctx, res, PropertyPsqlWriteEndpoint),
+				ReadEndpoint:        findValue(ctx, res, PropertyPsqlReadEndpoint),
+			})
+		case executor.MySQLInputState:
+			logger.Debugf("finding outputs for mysql resource %s", r.ResourceID)
+			res := byResourceID[r.ResourceID]
+			outputs = append(outputs, executor.MySQLInstanceReadyState{
+				MySQLInputState:     r,
+				MasterUserSecretARN: findValue(ctx, res, PropertyMySQLMasterUserARN),
+				WriteEndpoint:       findValue(ctx, res, PropertyMySQLWriteEndpoint),
+				ReadEndpoint:        findValue(ctx, res, PropertyMySQLReadEndpoint),
+			})
+		}
+	}
+
+	logger.Debugf("stack %s is ready", e.stack)
+
+	return outputs, nil
+}
+
+func findValue(ctx context.Context, outputs []types.Output, property string) string {
+	logger := log.FromContext(ctx)
+	for _, output := range outputs {
+		decoded, err := decodeOutputKey(output)
+		if err != nil {
+			logger.Warnf("failed to decode output key: %s", err)
+			continue
+		}
+		if decoded.PropertyName == property {
+			return *output.OutputValue
+		}
+	}
+	logger.Warnf("no output found for key %s", property)
+	return ""
 }

--- a/cmd/ftl-provisioner-cloudformation/cf_executor.go
+++ b/cmd/ftl-provisioner-cloudformation/cf_executor.go
@@ -33,14 +33,6 @@ func NewCloudFormationExecutor(stack string, cfn *cloudformation.Client, secrets
 	}
 }
 
-func (e *CloudFormationExecutor) Stage() executor.Stage {
-	return executor.StageProvisioning
-}
-
-func (e *CloudFormationExecutor) Resources() []executor.ResourceKind {
-	return executor.AllResources
-}
-
 func (e *CloudFormationExecutor) Prepare(ctx context.Context, input executor.State) error {
 	e.inputs = append(e.inputs, input)
 
@@ -129,8 +121,8 @@ func (e *CloudFormationExecutor) Execute(ctx context.Context) ([]executor.State,
 			outputs = append(outputs, executor.PostgresInstanceReadyState{
 				PostgresInputState:  r,
 				MasterUserSecretARN: findValue(ctx, res, PropertyPsqlMasterUserARN),
-				WriteEndpoint:       findValue(ctx, res, PropertyPsqlWriteEndpoint),
-				ReadEndpoint:        findValue(ctx, res, PropertyPsqlReadEndpoint),
+				WriteEndpoint:       fmt.Sprintf("%s:%d", findValue(ctx, res, PropertyPsqlWriteEndpoint), 5432),
+				ReadEndpoint:        fmt.Sprintf("%s:%d", findValue(ctx, res, PropertyPsqlReadEndpoint), 5432),
 			})
 		case executor.MySQLInputState:
 			logger.Debugf("finding outputs for mysql resource %s", r.ResourceID)
@@ -138,8 +130,8 @@ func (e *CloudFormationExecutor) Execute(ctx context.Context) ([]executor.State,
 			outputs = append(outputs, executor.MySQLInstanceReadyState{
 				MySQLInputState:     r,
 				MasterUserSecretARN: findValue(ctx, res, PropertyMySQLMasterUserARN),
-				WriteEndpoint:       findValue(ctx, res, PropertyMySQLWriteEndpoint),
-				ReadEndpoint:        findValue(ctx, res, PropertyMySQLReadEndpoint),
+				WriteEndpoint:       fmt.Sprintf("%s:%d", findValue(ctx, res, PropertyMySQLWriteEndpoint), 3306),
+				ReadEndpoint:        fmt.Sprintf("%s:%d", findValue(ctx, res, PropertyMySQLReadEndpoint), 3306),
 			})
 		}
 	}

--- a/cmd/ftl-provisioner-cloudformation/cf_executor.go
+++ b/cmd/ftl-provisioner-cloudformation/cf_executor.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	goformation "github.com/awslabs/goformation/v7/cloudformation"
+	"github.com/block/ftl/cmd/ftl-provisioner-cloudformation/executor"
+)
+
+type CFExecutor struct {
+	cfn      *cloudformation.Client
+	secrets  *secretsmanager.Client
+	template *goformation.Template
+
+	inputs []executor.State
+}
+
+func NewCFExecutor(ctx context.Context, cfn *cloudformation.Client, secrets *secretsmanager.Client) (*CFExecutor, error) {
+	e := &CFExecutor{
+		cfn:      cfn,
+		secrets:  secrets,
+		template: goformation.NewTemplate(),
+	}
+
+	return e, nil
+}
+
+func (e *CFExecutor) Stage() executor.Stage {
+	return executor.StageProvisioning
+}
+
+func (e *CFExecutor) Resources() []executor.ResourceKind {
+	return executor.AllResources
+}
+
+func (e *CFExecutor) Prepare(ctx context.Context, input executor.State) error {
+	e.inputs = append(e.inputs, input)
+	return nil
+}

--- a/cmd/ftl-provisioner-cloudformation/cf_executor.go
+++ b/cmd/ftl-provisioner-cloudformation/cf_executor.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	goformation "github.com/awslabs/goformation/v7/cloudformation"
 	cf "github.com/awslabs/goformation/v7/cloudformation/cloudformation"
+
 	"github.com/block/ftl/cmd/ftl-provisioner-cloudformation/executor"
 	"github.com/block/ftl/internal/log"
 )

--- a/cmd/ftl-provisioner-cloudformation/executor/executor.go
+++ b/cmd/ftl-provisioner-cloudformation/executor/executor.go
@@ -1,0 +1,57 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+)
+
+type Stage int
+
+const (
+	// StageProvisioning is the stage where the infrastructure is being provisioned.
+	StageProvisioning Stage = iota
+	// StageSetup is the stage where the infrastructure is being setup after provisioning.
+	StageSetup Stage = iota
+	// StageDone is the stage where the resource is ready to be used.
+	StageDone Stage = iota
+)
+
+func (s Stage) String() string {
+	switch s {
+	case StageProvisioning:
+		return "provisioning"
+	case StageSetup:
+		return "setup"
+	case StageDone:
+		return "done"
+	default:
+		return fmt.Sprintf("unknown_stage_%d", s)
+	}
+}
+
+type ResourceKind string
+
+const (
+	ResourceKindPostgres ResourceKind = "postgres"
+	ResourceKindMySQL    ResourceKind = "mysql"
+)
+
+var AllResources []ResourceKind = nil
+
+// State of a single resource in execution.
+type State interface {
+	Stage() Stage
+	Kind() ResourceKind
+	DebugString() string
+}
+
+type Executor interface {
+	// Stage returns the stage that the executor belongs to.
+	Stage() Stage
+	// Resources returns the resources that the executor supports. Empty means all resources.
+	Resources() []ResourceKind
+	// Prepare prepares the executor for execution.
+	Prepare(ctx context.Context, input State) error
+	// Execute executes the executor, returning the next states.
+	Execute(ctx context.Context) ([]State, error)
+}

--- a/cmd/ftl-provisioner-cloudformation/executor/executor.go
+++ b/cmd/ftl-provisioner-cloudformation/executor/executor.go
@@ -36,7 +36,7 @@ const (
 	ResourceKindMySQL    ResourceKind = "mysql"
 )
 
-var AllResources []ResourceKind = nil
+var AllResources []ResourceKind
 
 // State of a single resource in execution.
 type State interface {

--- a/cmd/ftl-provisioner-cloudformation/executor/executor.go
+++ b/cmd/ftl-provisioner-cloudformation/executor/executor.go
@@ -2,32 +2,7 @@ package executor
 
 import (
 	"context"
-	"fmt"
 )
-
-type Stage int
-
-const (
-	// StageProvisioning is the stage where the infrastructure is being provisioned.
-	StageProvisioning Stage = iota
-	// StageSetup is the stage where the infrastructure is being setup after provisioning.
-	StageSetup Stage = iota
-	// StageDone is the stage where the resource is ready to be used.
-	StageDone Stage = iota
-)
-
-func (s Stage) String() string {
-	switch s {
-	case StageProvisioning:
-		return "provisioning"
-	case StageSetup:
-		return "setup"
-	case StageDone:
-		return "done"
-	default:
-		return fmt.Sprintf("unknown_stage_%d", s)
-	}
-}
 
 type ResourceKind string
 
@@ -40,16 +15,11 @@ var AllResources []ResourceKind
 
 // State of a single resource in execution.
 type State interface {
-	Stage() Stage
-	Kind() ResourceKind
 	DebugString() string
 }
 
 type Executor interface {
 	// Stage returns the stage that the executor belongs to.
-	Stage() Stage
-	// Resources returns the resources that the executor supports. Empty means all resources.
-	Resources() []ResourceKind
 	// Prepare prepares the executor for execution.
 	Prepare(ctx context.Context, input State) error
 	// Execute executes the executor, returning the next states.

--- a/cmd/ftl-provisioner-cloudformation/executor/executor_test.go
+++ b/cmd/ftl-provisioner-cloudformation/executor/executor_test.go
@@ -1,0 +1,65 @@
+package executor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+)
+
+type testState struct {
+	stage Stage
+	kind  ResourceKind
+}
+
+func (s *testState) Stage() Stage        { return s.stage }
+func (s *testState) Kind() ResourceKind  { return s.kind }
+func (s *testState) DebugString() string { return string(s.kind) }
+
+type testExecutor struct {
+	stage     Stage
+	resources []ResourceKind
+	prepared  bool
+	executed  bool
+}
+
+func (e *testExecutor) Stage() Stage              { return e.stage }
+func (e *testExecutor) Resources() []ResourceKind { return e.resources }
+
+func (e *testExecutor) Prepare(ctx context.Context, input State) error {
+	e.prepared = true
+	return nil
+}
+
+func (e *testExecutor) Execute(ctx context.Context) ([]State, error) {
+	e.executed = true
+	return []State{&testState{StageDone, ResourceKindPostgres}}, nil
+}
+
+func TestExecutorPrecedence(t *testing.T) {
+	// Create a specific executor for postgres and a default executor
+	specificExecutor := &testExecutor{
+		stage:     StageProvisioning,
+		resources: []ResourceKind{ResourceKindPostgres},
+	}
+	defaultExecutor := &testExecutor{
+		stage:     StageProvisioning,
+		resources: AllResources,
+	}
+
+	runner := &ProvisionRunner{
+		stage:        StageProvisioning,
+		CurrentState: []State{&testState{StageProvisioning, ResourceKindPostgres}},
+		Executors:    []Executor{defaultExecutor, specificExecutor},
+	}
+
+	states, err := runner.Run(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(states))
+	assert.Equal(t, StageDone, states[0].Stage())
+
+	assert.True(t, specificExecutor.prepared)
+	assert.True(t, specificExecutor.executed)
+	assert.False(t, defaultExecutor.prepared)
+	assert.False(t, defaultExecutor.executed)
+}

--- a/cmd/ftl-provisioner-cloudformation/executor/runner.go
+++ b/cmd/ftl-provisioner-cloudformation/executor/runner.go
@@ -1,0 +1,129 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+
+	"golang.org/x/sync/errgroup"
+)
+
+type ProvisionRunner struct {
+	stage   Stage
+	skipped []State // states that did not have executors at the current stage
+
+	CurrentState []State
+	Executors    []Executor
+}
+
+func (r *ProvisionRunner) Run(ctx context.Context) ([]State, error) {
+	for {
+		if r.stage >= StageDone {
+			return r.finalResult()
+		}
+
+		executors, err := r.executorMap()
+		if err != nil {
+			return nil, err
+		}
+
+		if err := r.prepare(ctx, executors); err != nil {
+			return nil, err
+		}
+
+		newStates, err := r.execute(ctx, executors)
+		if err != nil {
+			return nil, err
+		}
+
+		r.CurrentState = newStates
+		r.stage = r.stage + 1
+	}
+}
+
+func (r *ProvisionRunner) prepare(ctx context.Context, executors map[ResourceKind]Executor) error {
+	for _, state := range r.CurrentState {
+		executor, ok := executors[state.Kind()]
+		if !ok {
+			r.skipped = append(r.skipped, state)
+			continue
+		}
+
+		if err := executor.Prepare(ctx, state); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *ProvisionRunner) execute(ctx context.Context, executors map[ResourceKind]Executor) ([]State, error) {
+	reschan := make(chan []State, len(executors))
+	eg := errgroup.Group{}
+	for _, executor := range executors {
+		eg.Go(func() error {
+			outputs, err := executor.Execute(ctx)
+			if err != nil {
+				return err
+			}
+			reschan <- outputs
+			return nil
+		})
+	}
+
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+
+	result := r.skipped
+	for i := 0; i < len(executors); i++ {
+		states := <-reschan
+		result = append(result, states...)
+	}
+
+	return result, nil
+}
+
+func (r *ProvisionRunner) finalResult() ([]State, error) {
+	for _, state := range r.CurrentState {
+		if state.Stage() != StageDone {
+			// if the provisioner is misconfigured, not all states might be done
+			return nil, fmt.Errorf("state %s is not done", state.DebugString())
+		}
+	}
+
+	return r.CurrentState, nil
+}
+
+func (r *ProvisionRunner) executorMap() (map[ResourceKind]Executor, error) {
+	result := make(map[ResourceKind]Executor)
+
+	for _, state := range r.CurrentState {
+		var defaultExecutor Executor
+		found := false
+		for _, executor := range r.Executors {
+			if executor.Stage() != r.stage {
+				continue
+			}
+
+			if len(executor.Resources()) == 0 {
+				defaultExecutor = executor
+				continue
+			}
+
+			for _, resource := range executor.Resources() {
+				if resource == state.Kind() {
+					if found {
+						return nil, fmt.Errorf("multiple executors found for resource %s", state.Kind())
+					}
+					result[state.Kind()] = executor
+					found = true
+				}
+			}
+		}
+
+		if !found && defaultExecutor != nil {
+			result[state.Kind()] = defaultExecutor
+		}
+	}
+
+	return result, nil
+}

--- a/cmd/ftl-provisioner-cloudformation/executor/runner.go
+++ b/cmd/ftl-provisioner-cloudformation/executor/runner.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/block/ftl/internal/log"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/block/ftl/internal/log"
 )
 
 type Handler struct {

--- a/cmd/ftl-provisioner-cloudformation/executor/states.go
+++ b/cmd/ftl-provisioner-cloudformation/executor/states.go
@@ -1,6 +1,10 @@
 package executor
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/block/ftl/common/schema"
+)
 
 type PostgresInputState struct {
 	ResourceID string
@@ -8,11 +12,15 @@ type PostgresInputState struct {
 	Module     string
 }
 
-func (s *PostgresInputState) Stage() Stage {
+func (s PostgresInputState) Stage() Stage {
 	return StageProvisioning
 }
 
-func (s *PostgresInputState) DebugString() string {
+func (s PostgresInputState) Kind() ResourceKind {
+	return ResourceKindPostgres
+}
+
+func (s PostgresInputState) DebugString() string {
 	return fmt.Sprintf("PostgresInputState{ResourceID: %s, Cluster: %s, Module: %s}", s.ResourceID, s.Cluster, s.Module)
 }
 
@@ -22,11 +30,15 @@ type MySQLInputState struct {
 	Module     string
 }
 
-func (s *MySQLInputState) Stage() Stage {
+func (s MySQLInputState) Stage() Stage {
 	return StageProvisioning
 }
 
-func (s *MySQLInputState) DebugString() string {
+func (s MySQLInputState) Kind() ResourceKind {
+	return ResourceKindMySQL
+}
+
+func (s MySQLInputState) DebugString() string {
 	return fmt.Sprintf("MySQLInputState{ResourceID: %s, Cluster: %s, Module: %s}", s.ResourceID, s.Cluster, s.Module)
 }
 
@@ -38,11 +50,11 @@ type PostgresInstanceReadyState struct {
 	ReadEndpoint        string
 }
 
-func (s *PostgresInstanceReadyState) DebugString() string {
+func (s PostgresInstanceReadyState) DebugString() string {
 	return fmt.Sprintf("PostgresInstanceReadyState{%s}", s.PostgresInputState.DebugString())
 }
 
-func (s *PostgresInstanceReadyState) Stage() Stage {
+func (s PostgresInstanceReadyState) Stage() Stage {
 	return StageSetup
 }
 
@@ -54,10 +66,36 @@ type MySQLInstanceReadyState struct {
 	ReadEndpoint        string
 }
 
-func (s *MySQLInstanceReadyState) Stage() Stage {
+func (s MySQLInstanceReadyState) Stage() Stage {
 	return StageSetup
 }
 
-func (s *MySQLInstanceReadyState) DebugString() string {
+func (s MySQLInstanceReadyState) DebugString() string {
 	return fmt.Sprintf("MySQLInstanceReadyState{%s}", s.MySQLInputState.DebugString())
+}
+
+type PostgresDBDoneState struct {
+	PostgresInstanceReadyState
+	Connector schema.DatabaseConnector
+}
+
+func (s PostgresDBDoneState) DebugString() string {
+	return fmt.Sprintf("PostgresDBDoneState{%s}", s.PostgresInstanceReadyState.DebugString())
+}
+
+func (s PostgresDBDoneState) Stage() Stage {
+	return StageDone
+}
+
+type MySQLDBDoneState struct {
+	MySQLInstanceReadyState
+	Connector schema.DatabaseConnector
+}
+
+func (s MySQLDBDoneState) DebugString() string {
+	return fmt.Sprintf("MySQLDBDoneState{%s}", s.MySQLInstanceReadyState.DebugString())
+}
+
+func (s MySQLDBDoneState) Stage() Stage {
+	return StageDone
 }

--- a/cmd/ftl-provisioner-cloudformation/executor/states.go
+++ b/cmd/ftl-provisioner-cloudformation/executor/states.go
@@ -12,10 +12,6 @@ type PostgresInputState struct {
 	Module     string
 }
 
-func (s PostgresInputState) Stage() Stage {
-	return StageProvisioning
-}
-
 func (s PostgresInputState) Kind() ResourceKind {
 	return ResourceKindPostgres
 }
@@ -28,10 +24,6 @@ type MySQLInputState struct {
 	ResourceID string
 	Cluster    string
 	Module     string
-}
-
-func (s MySQLInputState) Stage() Stage {
-	return StageProvisioning
 }
 
 func (s MySQLInputState) Kind() ResourceKind {
@@ -54,20 +46,12 @@ func (s PostgresInstanceReadyState) DebugString() string {
 	return fmt.Sprintf("PostgresInstanceReadyState{%s}", s.PostgresInputState.DebugString())
 }
 
-func (s PostgresInstanceReadyState) Stage() Stage {
-	return StageSetup
-}
-
 type MySQLInstanceReadyState struct {
 	MySQLInputState
 
 	MasterUserSecretARN string
 	WriteEndpoint       string
 	ReadEndpoint        string
-}
-
-func (s MySQLInstanceReadyState) Stage() Stage {
-	return StageSetup
 }
 
 func (s MySQLInstanceReadyState) DebugString() string {
@@ -83,10 +67,6 @@ func (s PostgresDBDoneState) DebugString() string {
 	return fmt.Sprintf("PostgresDBDoneState{%s}", s.PostgresInstanceReadyState.DebugString())
 }
 
-func (s PostgresDBDoneState) Stage() Stage {
-	return StageDone
-}
-
 type MySQLDBDoneState struct {
 	MySQLInstanceReadyState
 	Connector schema.DatabaseConnector
@@ -94,8 +74,4 @@ type MySQLDBDoneState struct {
 
 func (s MySQLDBDoneState) DebugString() string {
 	return fmt.Sprintf("MySQLDBDoneState{%s}", s.MySQLInstanceReadyState.DebugString())
-}
-
-func (s MySQLDBDoneState) Stage() Stage {
-	return StageDone
 }

--- a/cmd/ftl-provisioner-cloudformation/executor/states.go
+++ b/cmd/ftl-provisioner-cloudformation/executor/states.go
@@ -1,0 +1,63 @@
+package executor
+
+import "fmt"
+
+type PostgresInputState struct {
+	ResourceID string
+	Cluster    string
+	Module     string
+}
+
+func (s *PostgresInputState) Stage() Stage {
+	return StageProvisioning
+}
+
+func (s *PostgresInputState) DebugString() string {
+	return fmt.Sprintf("PostgresInputState{ResourceID: %s, Cluster: %s, Module: %s}", s.ResourceID, s.Cluster, s.Module)
+}
+
+type MySQLInputState struct {
+	ResourceID string
+	Cluster    string
+	Module     string
+}
+
+func (s *MySQLInputState) Stage() Stage {
+	return StageProvisioning
+}
+
+func (s *MySQLInputState) DebugString() string {
+	return fmt.Sprintf("MySQLInputState{ResourceID: %s, Cluster: %s, Module: %s}", s.ResourceID, s.Cluster, s.Module)
+}
+
+type PostgresInstanceReadyState struct {
+	PostgresInputState
+
+	MasterUserSecretARN string
+	WriteEndpoint       string
+	ReadEndpoint        string
+}
+
+func (s *PostgresInstanceReadyState) DebugString() string {
+	return fmt.Sprintf("PostgresInstanceReadyState{%s}", s.PostgresInputState.DebugString())
+}
+
+func (s *PostgresInstanceReadyState) Stage() Stage {
+	return StageSetup
+}
+
+type MySQLInstanceReadyState struct {
+	MySQLInputState
+
+	MasterUserSecretARN string
+	WriteEndpoint       string
+	ReadEndpoint        string
+}
+
+func (s *MySQLInstanceReadyState) Stage() Stage {
+	return StageSetup
+}
+
+func (s *MySQLInstanceReadyState) DebugString() string {
+	return fmt.Sprintf("MySQLInstanceReadyState{%s}", s.MySQLInputState.DebugString())
+}

--- a/cmd/ftl-provisioner-cloudformation/mysql.go
+++ b/cmd/ftl-provisioner-cloudformation/mysql.go
@@ -3,8 +3,9 @@ package main
 import (
 	goformation "github.com/awslabs/goformation/v7/cloudformation"
 	"github.com/awslabs/goformation/v7/cloudformation/rds"
-	"github.com/block/ftl/cmd/ftl-provisioner-cloudformation/executor"
 	_ "github.com/go-sql-driver/mysql"
+
+	"github.com/block/ftl/cmd/ftl-provisioner-cloudformation/executor"
 )
 
 type MySQLTemplater struct {

--- a/cmd/ftl-provisioner-cloudformation/mysql.go
+++ b/cmd/ftl-provisioner-cloudformation/mysql.go
@@ -3,21 +3,20 @@ package main
 import (
 	goformation "github.com/awslabs/goformation/v7/cloudformation"
 	"github.com/awslabs/goformation/v7/cloudformation/rds"
+	"github.com/block/ftl/cmd/ftl-provisioner-cloudformation/executor"
 	_ "github.com/go-sql-driver/mysql"
 )
 
 type MySQLTemplater struct {
-	resourceID string
-	cluster    string
-	module     string
-	config     *Config
+	input  executor.MySQLInputState
+	config *Config
 }
 
 var _ ResourceTemplater = (*MySQLTemplater)(nil)
 
 func (p *MySQLTemplater) AddToTemplate(template *goformation.Template) error {
-	clusterID := cloudformationResourceID(p.resourceID, "cluster")
-	instanceID := cloudformationResourceID(p.resourceID, "instance")
+	clusterID := cloudformationResourceID(p.input.ResourceID, "cluster")
+	instanceID := cloudformationResourceID(p.input.ResourceID, "instance")
 	template.Resources[clusterID] = &rds.DBCluster{
 		Engine:                   ptr("aurora-mysql"),
 		MasterUsername:           ptr("root"),
@@ -30,26 +29,26 @@ func (p *MySQLTemplater) AddToTemplate(template *goformation.Template) error {
 			MinCapacity: ptr(0.5),
 			MaxCapacity: ptr(10.0),
 		},
-		Tags: ftlTags(p.cluster, p.module),
+		Tags: ftlTags(p.input.Cluster, p.input.Module),
 	}
 	template.Resources[instanceID] = &rds.DBInstance{
 		Engine:              ptr("aurora-mysql"),
 		DBInstanceClass:     ptr("db.serverless"),
 		DBClusterIdentifier: ptr(goformation.Ref(clusterID)),
-		Tags:                ftlTags(p.cluster, p.module),
+		Tags:                ftlTags(p.input.Cluster, p.input.Module),
 	}
 	addOutput(template.Outputs, goformation.GetAtt(clusterID, "Endpoint.Address"), &CloudformationOutputKey{
-		ResourceID:   p.resourceID,
+		ResourceID:   p.input.ResourceID,
 		ResourceKind: ResourceKindMySQL,
 		PropertyName: PropertyMySQLWriteEndpoint,
 	})
 	addOutput(template.Outputs, goformation.GetAtt(clusterID, "ReadEndpoint.Address"), &CloudformationOutputKey{
-		ResourceID:   p.resourceID,
+		ResourceID:   p.input.ResourceID,
 		ResourceKind: ResourceKindMySQL,
 		PropertyName: PropertyMySQLReadEndpoint,
 	})
 	addOutput(template.Outputs, goformation.GetAtt(clusterID, "MasterUserSecret.SecretArn"), &CloudformationOutputKey{
-		ResourceID:   p.resourceID,
+		ResourceID:   p.input.ResourceID,
 		ResourceKind: ResourceKindMySQL,
 		PropertyName: PropertyMySQLMasterUserARN,
 	})

--- a/cmd/ftl-provisioner-cloudformation/postgres.go
+++ b/cmd/ftl-provisioner-cloudformation/postgres.go
@@ -76,14 +76,6 @@ func NewPostgresSetupExecutor(secrets *secretsmanager.Client) *PostgresSetupExec
 
 var _ executor.Executor = &PostgresSetupExecutor{}
 
-func (e *PostgresSetupExecutor) Stage() executor.Stage {
-	return executor.StageSetup
-}
-
-func (e *PostgresSetupExecutor) Resources() []executor.ResourceKind {
-	return []executor.ResourceKind{executor.ResourceKindPostgres}
-}
-
 func (e *PostgresSetupExecutor) Prepare(_ context.Context, input executor.State) error {
 	e.inputs = append(e.inputs, input)
 	return nil
@@ -132,7 +124,7 @@ func postgresAdminDSN(ctx context.Context, secrets *secretsmanager.Client, secre
 		return "", fmt.Errorf("failed to get username and password from secret ARN: %w", err)
 	}
 
-	return endpointToDSN(&connector.Endpoint, connector.Database, 5432, adminUsername, adminPassword), nil
+	return endpointToDSN(&connector.Endpoint, connector.Database, adminUsername, adminPassword), nil
 }
 
 func postgresSetup(ctx context.Context, adminDSN string, connector *schema.AWSIAMAuthDatabaseConnector) error {

--- a/cmd/ftl-provisioner-cloudformation/task.go
+++ b/cmd/ftl-provisioner-cloudformation/task.go
@@ -12,17 +12,19 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/jpillora/backoff"
 
+	"github.com/block/ftl/cmd/ftl-provisioner-cloudformation/executor"
 	"github.com/block/ftl/internal/log"
 )
 
 type task struct {
 	stackID string
+	runner  *executor.ProvisionRunner
 
 	err     atomic.Value[error]
-	outputs atomic.Value[[]types.Output]
+	outputs atomic.Value[[]executor.State]
 }
 
-func (t *task) waitForStackReady(ctx context.Context, client *cloudformation.Client) ([]types.Output, error) {
+func waitForStackReady(ctx context.Context, stackID string, client *cloudformation.Client) ([]types.Output, error) {
 	retry := backoff.Backoff{
 		Min:    100 * time.Millisecond,
 		Max:    5 * time.Second,
@@ -30,7 +32,7 @@ func (t *task) waitForStackReady(ctx context.Context, client *cloudformation.Cli
 	}
 	for {
 		desc, err := client.DescribeStacks(ctx, &cloudformation.DescribeStacksInput{
-			StackName: &t.stackID,
+			StackName: &stackID,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to describe stack: %w", err)
@@ -74,55 +76,16 @@ func (t *task) waitForStackReady(ctx context.Context, client *cloudformation.Cli
 	}
 }
 
-func (t *task) postUpdate(ctx context.Context, secrets *secretsmanager.Client, outputs []types.Output) error {
-	byResourceID, err := outputsByResourceID(outputs)
-	if err != nil {
-		return fmt.Errorf("failed to group outputs by resource ID: %w", err)
-	}
-
-	for resourceID, outputs := range byResourceID {
-		byName, err := outputsByPropertyName(outputs)
-		if err != nil {
-			return fmt.Errorf("failed to group outputs by property name: %w", err)
-		}
-		if err := PostgresPostUpdate(ctx, secrets, byName, resourceID); err != nil {
-			return fmt.Errorf("failed to post-update postgres: %w", err)
-		}
-	}
-
-	return nil
-}
-
 func (t *task) Start(oldCtx context.Context, client *cloudformation.Client, secrets *secretsmanager.Client, changeSetID string) {
 	ctx := context.WithoutCancel(oldCtx)
 	logger := log.FromContext(ctx)
 	go func() {
-		if changeSetID != "" {
-			logger.Debugf("Executing change-set: %s", changeSetID)
-			_, err := client.ExecuteChangeSet(ctx, &cloudformation.ExecuteChangeSetInput{
-				ChangeSetName: &changeSetID,
-				StackName:     &t.stackID,
-			})
-			if err != nil {
-				logger.Errorf(err, "failed to execute change-set")
-				t.err.Store(fmt.Errorf("failed to execute change-set: %w", err))
-				return
-			}
-		}
-		logger.Debugf("Waiting for stack to be ready: %s", t.stackID)
-		outputs, err := t.waitForStackReady(ctx, client)
+		outputs, err := t.runner.Run(ctx)
 		if err != nil {
-			logger.Errorf(err, "failed to wait for stack to be ready")
+			logger.Errorf(err, "failed to execute provisioner")
 			t.err.Store(err)
 			return
 		}
-		logger.Debugf("Stack ready: %s", t.stackID)
-		if err := t.postUpdate(ctx, secrets, outputs); err != nil {
-			logger.Errorf(err, "failed to post-update")
-			t.err.Store(err)
-			return
-		}
-		logger.Debugf("Post-update complete: %s", t.stackID)
 		t.outputs.Store(outputs)
 	}()
 }

--- a/internal/concurrency/resgroup.go
+++ b/internal/concurrency/resgroup.go
@@ -1,0 +1,35 @@
+package concurrency
+
+type ResourceGroup[T any] struct {
+	funcs []func() (T, error)
+
+	reschan chan T
+	errchan chan error
+}
+
+func (r *ResourceGroup[T]) Go(f func() (T, error)) {
+	if r.reschan == nil {
+		r.reschan = make(chan T, 64)
+		r.errchan = make(chan error, 64)
+	}
+
+	r.funcs = append(r.funcs, f)
+
+	go func() {
+		res, err := f()
+		r.reschan <- res
+		r.errchan <- err
+	}()
+}
+
+func (r *ResourceGroup[T]) Wait() ([]T, error) {
+	results := make([]T, 0, len(r.funcs))
+	for range r.funcs {
+		err := <-r.errchan
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, <-r.reschan)
+	}
+	return results, nil
+}

--- a/internal/concurrency/resgroup_test.go
+++ b/internal/concurrency/resgroup_test.go
@@ -1,0 +1,52 @@
+package concurrency
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+)
+
+func TestResourceGroup(t *testing.T) {
+	t.Run("successful concurrent execution", func(t *testing.T) {
+		rg := &ResourceGroup[int]{}
+
+		rg.Go(func() (int, error) {
+			return 1, nil
+		})
+
+		rg.Go(func() (int, error) {
+			return 2, nil
+		})
+
+		rg.Go(func() (int, error) {
+			return 3, nil
+		})
+
+		results, err := rg.Wait()
+		assert.NoError(t, err)
+
+		actualSum := 0
+		for _, v := range results {
+			actualSum += v
+		}
+		assert.Equal(t, 6, actualSum)
+	})
+
+	t.Run("handles errors", func(t *testing.T) {
+		rg := &ResourceGroup[string]{}
+		expectedErr := errors.New("test error")
+
+		rg.Go(func() (string, error) {
+			return "", expectedErr
+		})
+
+		rg.Go(func() (string, error) {
+			return "success", nil
+		})
+
+		results, err := rg.Wait()
+		assert.Equal(t, err, expectedErr)
+		assert.Equal(t, results, nil)
+	})
+}


### PR DESCRIPTION
Separates the CF provisioning into stages with specific inputs and outputs.

This will allow us to overwrite some outputs from CF execution with either hard coded values or executions from a shared CF stack to use a common RDS instance for DBs if desired.

On a high level, the idea here is that we define an ordered list of `Stage`s to execute, and a set of `Ecxecutor`s applying to each stage, and a set of resource types, converting a `State` instance in that stage to a state in a followup `Stage`

So, a Postgres provisioner gets added to the CF template in `StageProvisioning` and the virtual DB and user are created in `StageSetup` after which we reach the final stage `StageDone` from which the runtime updates are created.

This allows us to configure optional executors for `StageProvisioning` in the future while still use rest of the provisioning tasks unchanged.