### PR TITLE
fix: improve rpc wait

### DIFF
--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -199,7 +199,10 @@ func Wait[Req any, Resp any, RespPtr PingResponse[Resp]](ctx context.Context, re
 			}
 			delay := retry.Duration()
 			logger.Tracef("Ping failed waiting %s for client: %+v", delay, err)
-			time.Sleep(delay)
+			select {
+			case <-ctx.Done():
+			case <-time.After(delay):
+			}
 		}
 	}()
 


### PR DESCRIPTION
If the context is cancelled it should abort immediatly