### PR TITLE
fix: update terminal status bar when last module being removed

### DIFF
--- a/internal/terminal/status.go
+++ b/internal/terminal/status.go
@@ -463,6 +463,8 @@ func (r *terminalStatusManager) recalculateLines() {
 			msg = strings.TrimSpace(msg)
 		}
 		r.moduleLine.message = msg
+	} else if r.moduleLine != nil {
+		r.moduleLine.message = ""
 	}
 	for _, i := range r.lines {
 		if i.message != "" && i != r.moduleLine {


### PR DESCRIPTION
Steps to repro:
- ftl dev
- In the interactive console:
    - `ftl kill` each module
    - We would end up with the old status getting printed still and leaking into the normal logs
    - `ftl schema get` 
    - Each line of schema output would be interlaced with the old module status