### PR TITLE
fix: collect ftl build logs and format output

### DIFF
--- a/jvm-runtime/plugin/common/error_detector.go
+++ b/jvm-runtime/plugin/common/error_detector.go
@@ -4,12 +4,11 @@ import (
 	"io"
 	"strings"
 
-	"github.com/block/ftl/internal/log"
-
 	"github.com/alecthomas/atomic"
 
 	"github.com/block/ftl/common/builderrors"
 	"github.com/block/ftl/common/slices"
+	"github.com/block/ftl/internal/log"
 )
 
 var _ io.Writer = &errorDetector{}


### PR DESCRIPTION
- Captures errors from jvm build logs (like we do already for `ftl dev` build logs)
- Format the output from jvm build to be consistent with the rest of our logs