### PR TITLE
fix: improve console build in dev mode

### DIFF
--- a/cmd/ftl/cmd_serve.go
+++ b/cmd/ftl/cmd_serve.go
@@ -266,10 +266,10 @@ func (s *serveCommonConfig) run(
 	})
 
 	if !s.NoConsole {
-		if err := consolefrontend.PrepareServer(ctx); err != nil {
-			return fmt.Errorf("failed to prepare console server: %w", err)
-		}
 		wg.Go(func() error {
+			if err := consolefrontend.PrepareServer(ctx); err != nil {
+				return fmt.Errorf("failed to prepare console server: %w", err)
+			}
 			// Deliberately start Console in the foreground.
 			ctx = log.ContextWithLogger(ctx, log.FromContext(ctx).Scope("console"))
 			err := console.Start(ctx, s.Console, schemaEventSource, timelineClient, adminClient, routing.NewVerbRouter(ctx, schemaEventSource, timelineClient), buildEngineClient)

--- a/frontend/console/local.go
+++ b/frontend/console/local.go
@@ -19,12 +19,19 @@ import (
 	"github.com/block/ftl/internal/exec"
 	"github.com/block/ftl/internal/flock"
 	"github.com/block/ftl/internal/log"
+	"github.com/block/ftl/internal/terminal"
 )
 
 var proxyURL, _ = url.Parse("http://localhost:5173") //nolint:errcheck
 var proxy = httputil.NewSingleHostReverseProxy(proxyURL)
 
 func PrepareServer(ctx context.Context) error {
+	sm := terminal.FromContext(ctx)
+	const console = "FTL Console (dev)"
+	sm.SetModuleState(console, terminal.BuildStateBuilding)
+	defer func() {
+		sm.SetModuleState(console, terminal.BuildStateTerminated)
+	}()
 	gitRoot, ok := internal.GitRoot(os.Getenv("FTL_DIR")).Get()
 	if !ok {
 		return fmt.Errorf("failed to find Git root")


### PR DESCRIPTION
This adds a status indicator for the console build, and moves it into a gorouting so it does not block startup.

This should not affect FTL when built with the release tag