### PR TITLE
fix: deploy watches for specific changeset to end

### DIFF
--- a/backend/provisioner/deployment.go
+++ b/backend/provisioner/deployment.go
@@ -108,10 +108,6 @@ func (t *Task) Progress(ctx context.Context) error {
 				if err != nil {
 					return fmt.Errorf("error updating runtime: %w", err)
 				}
-				if err != nil {
-					return err
-				}
-
 			}
 			return nil
 


### PR DESCRIPTION
fixes https://github.com/block/ftl/issues/4487
Multiple modules were being treated as deployed because we were only checking if *any* changeset completed, not whether the changeset with that module completed