### PR TITLE
fix: only generate .ftl stubs for languages that need it

### DIFF
--- a/go-runtime/compile/stubs.go
+++ b/go-runtime/compile/stubs.go
@@ -32,6 +32,10 @@ type ExternalDeploymentContext struct {
 }
 
 func GenerateStubs(ctx context.Context, dir string, moduleSch *schema.Module, config moduleconfig.AbsModuleConfig, nativeConfig optional.Option[moduleconfig.AbsModuleConfig]) error {
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", dir, err)
+	}
+
 	var goModVersion string
 	var replacements []*modfile.Replace
 	var err error

--- a/internal/buildengine/stubs.go
+++ b/internal/buildengine/stubs.go
@@ -85,10 +85,6 @@ func generateStubsForEachLanguage(ctx context.Context, projectRoot string, modul
 			config := metas[module.Name].module.Config
 			wg.Go(func() error {
 				path := stubsModuleDir(projectRoot, language, module.Name)
-				err := os.MkdirAll(path, 0750)
-				if err != nil {
-					return fmt.Errorf("failed to create directory %s: %w", path, err)
-				}
 				var nativeConfig optional.Option[moduleconfig.ModuleConfig]
 				if config.Module == "builtin" || config.Language != language {
 					nativeConfig = optional.Some(assignedMeta.module.Config)


### PR DESCRIPTION
I noticed that we were creating empty folders in `.ftl/kotlin` at the root of ftl projects. Since we don't use this for `kotlin` and `java` I've moved the folder creation to the language plugin instead.

BEFORE:
![Screenshot 2025-02-20 at 3 06 57 PM](https://github.com/user-attachments/assets/005b3def-fbc5-41f3-8f2b-36d44d88d433)

AFTER:
![Screenshot 2025-02-20 at 3 40 17 PM](https://github.com/user-attachments/assets/ff529484-8a1b-46ff-a14d-0315423b337b)


