### PR TITLE
fix: prevent immediate execution of new migrations

### DIFF
--- a/cmd/ftl/cmd_new_migration.go
+++ b/cmd/ftl/cmd_new_migration.go
@@ -91,8 +91,8 @@ func newMigration(dir, name string) (string, error) {
 	name = fmt.Sprintf("%s_%s.sql", timestamp, name)
 
 	// create migrations dir if missing
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return "", err
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return "", fmt.Errorf("could not create migrations directory at %s: %w", dir, err)
 	}
 
 	// check file does not already exist
@@ -104,10 +104,12 @@ func newMigration(dir, name string) (string, error) {
 	// write new migration
 	file, err := os.Create(path)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("could not create migration file at %s: %w", path, err)
 	}
 
 	defer dbutil.MustClose(file)
-	_, err = file.WriteString(migrationTemplate)
-	return path, err
+	if _, err := file.WriteString(migrationTemplate); err != nil {
+		return "", fmt.Errorf("could not write to migration file at %s: %w", path, err)
+	}
+	return path, nil
 }


### PR DESCRIPTION
Steps to repro:
- Run `ftl dev`
- Create a module
- Define a db in the module
- Run `ftl new-sql-migration <modulename>.<dbname> <migrationname>`

The new migration would be created and then FTL will immediately detect it and deploy the module, causing the empty migration to be completed. Writing the actual migration now does nothing...

Hacky fix: We generate the migrartion with placeholder text which makes the migration invalid. This causes the automatic build to fail, preventing the migration until the user updates it with an actual migration.