### PR TITLE
chore: remove duplicate log

### DIFF
--- a/internal/buildengine/engine.go
+++ b/internal/buildengine/engine.go
@@ -435,10 +435,7 @@ func (e *Engine) watchForModuleChanges(ctx context.Context, period time.Duration
 	}()
 
 	// Build and deploy all modules first.
-	err = e.BuildAndDeploy(ctx, 1, true, false)
-	if err != nil && !errors.Is(err, context.Canceled) {
-		logger.Errorf(err, "Initial deploy failed")
-	}
+	_ = e.BuildAndDeploy(ctx, 1, true, false) //nolint:errcheck
 
 	moduleHashes := map[string][]byte{}
 	e.controllerSchema.Range(func(name string, sch *schema.Module) bool {


### PR DESCRIPTION
fixes https://github.com/block/ftl/issues/4548
Build engine logs each build error as they happen, and logs a summary of all errors after the first time the engine goes idle.
We don't need to also print out build errors after the first build attempt.