### PR TITLE
fix: missing field moduleDeployWaiting in build events

### DIFF
--- a/frontend/console/src/features/engine/engine.utils.ts
+++ b/frontend/console/src/features/engine/engine.utils.ts
@@ -15,6 +15,7 @@ export const getModuleName = (event: EngineEvent): string | undefined => {
     case 'moduleDeployStarted':
     case 'moduleDeployFailed':
     case 'moduleDeploySuccess':
+    case 'moduleDeployWaiting':
       return event.event.value.module
 
     default:
@@ -52,8 +53,10 @@ export const getEventText = (event: EngineEvent | undefined): string => {
       return 'Deploy failed'
     case 'moduleDeploySuccess':
       return 'Deploy succeeded'
+    case 'moduleDeployWaiting':
+      return 'Deploy waiting'
     default:
-      return 'Unknown event'
+      return `Unknown event ${event.event.case}`
   }
 }
 
@@ -73,6 +76,7 @@ export const getModuleStatus = (event: EngineEvent | undefined): ModuleStatus =>
     case 'moduleBuildStarted':
     case 'moduleBuildWaiting':
     case 'moduleDeployStarted':
+    case 'moduleDeployWaiting':
       return 'busy'
     default:
       return 'idle'

--- a/frontend/console/src/features/infrastructure/BuildEngineEvents.tsx
+++ b/frontend/console/src/features/infrastructure/BuildEngineEvents.tsx
@@ -53,6 +53,7 @@ const EventContent = ({ event }: { event: EngineEvent }) => {
       case 'moduleDeployStarted':
       case 'moduleDeployFailed':
       case 'moduleDeploySuccess':
+      case 'moduleDeployWaiting':
         return event.event.value.module
       default:
         return 'engine'


### PR DESCRIPTION
Fixes #4596 

* Added `moduleDeployWaiting` to console UI

![Screenshot 2025-02-24 at 11 14 22 AM](https://github.com/user-attachments/assets/c6ba76ab-d404-4aad-8d41-1da50cdde63e)
