### PR TITLE
fix: fail go build on infinite ref loop

### DIFF
--- a/common/schema/visit.go
+++ b/common/schema/visit.go
@@ -1,5 +1,7 @@
 package schema
 
+import "slices"
+
 // Visit all nodes in the schema.
 func Visit(n Node, visit func(n Node, next func() error) error) error {
 	return visit(n, func() error {
@@ -12,11 +14,13 @@ func Visit(n Node, visit func(n Node, next func() error) error) error {
 	})
 }
 
-// VisitWithParent all nodes in the schema providing the parent node when visiting its schema children.
-func VisitWithParent(n Node, parent Node, visit func(n Node, parent Node, next func() error) error) error {
-	return visit(n, parent, func() error {
+// VisitWithParents visits all nodes in the schema providing the parent nodes on each visit
+func VisitWithParents(n Node, parents []Node, visit func(n Node, parents []Node, next func() error) error) error {
+	return visit(n, parents, func() error {
 		for _, child := range n.schemaChildren() {
-			if err := VisitWithParent(child, n, visit); err != nil {
+			childParents := slices.Clone(parents)
+			childParents = append(childParents, n)
+			if err := VisitWithParents(child, childParents, visit); err != nil {
 				return err
 			}
 		}

--- a/go-runtime/schema/extract.go
+++ b/go-runtime/schema/extract.go
@@ -293,10 +293,11 @@ func (cd *combinedData) updateDeclVisibility() {
 // propagateTypeErrors propagates type errors to referencing nodes. This improves error messaging for the LSP client by
 // surfacing errors all the way up the schema chain.
 func (cd *combinedData) propagateTypeErrors() {
-	_ = schema.VisitWithParent(cd.module, nil, func(n schema.Node, p schema.Node, next func() error) error { //nolint:errcheck
-		if p == nil {
+	_ = schema.VisitWithParents(cd.module, nil, func(n schema.Node, ps []schema.Node, next func() error) error { //nolint:errcheck
+		if len(ps) == 0 {
 			return next()
 		}
+		p := ps[len(ps)-1]
 		ref, ok := n.(*schema.Ref)
 		if !ok {
 			return next()


### PR DESCRIPTION
fixes https://github.com/block/ftl/issues/4623

Repro steps:
- Inject a verb's client into itself
- We now show this error: `cyclic references are not allowed: stockdb.saveStockPriceHandler refers to stockdb.saveStockPriceHandler`

