### PR TITLE
fix: snippets for @Topic are not @Export by default

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -52,12 +52,13 @@
 
 /* Dark mode overrides */
 [data-theme="dark"] .hero .button.button--secondary {
-  background-color: rgba(255, 255, 255, 0.1);
-  color: white;
-  border: 1px solid rgba(255, 255, 255, 0.5);
+  background-color: white;
+  color: var(--ifm-color-primary);
+  border: 2px solid white;
 }
 
 [data-theme="dark"] .hero .button.button--secondary:hover {
-  background-color: rgba(255, 255, 255, 0.2);
+  background-color: transparent;
+  color: white;
   border-color: white;
 }

--- a/internal/lsp/markdown/completion/java/pubSubTopic.md
+++ b/internal/lsp/markdown/completion/java/pubSubTopic.md
@@ -24,6 +24,7 @@ See https://block.github.io/ftl/docs/reference/pubsub/
 record ${1:Event}(${2:// Event fields}) {
 }
 
+@Export
 @Topic(name = "${3:topicName}", partitions = 1)
 interface ${4:TopicName} extends WriteableTopic<${1:Event}, SinglePartitionMapper> {
 } 

--- a/internal/lsp/markdown/completion/kotlin/pubSubTopic.md
+++ b/internal/lsp/markdown/completion/kotlin/pubSubTopic.md
@@ -24,5 +24,6 @@ data class ${1:Event}(
 	${2:// Event fields}
 )
 
+@Export
 @Topic(name = "${3:topicName}", partitions = 1)
 interface ${4:TopicName} : WriteableTopic<${1:Event}, SinglePartitionMapper> 


### PR DESCRIPTION
Fixes #4638

Example:
```kt
data class Event(
  // Event fields
)

@Export
@Topic(name = "topicName", partitions = 1)
interface TopicName : WriteableTopic<Event, SinglePartitionMapper>
```