### PR TITLE
fix: validate built module against schema

### DIFF
--- a/common/schema/validate.go
+++ b/common/schema/validate.go
@@ -57,10 +57,26 @@ func (s *Schema) Validate() (*Schema, error) {
 
 // ValidateModuleInSchema clones and normalises a schema and semantically validates a single module within it.
 // If no module is provided, all modules in the schema are validated.
+// m can be a new or updated module that will be added to the schema before validation.
 //
 //nolint:maintidx
 func ValidateModuleInSchema(schema *Schema, m optional.Option[*Module]) (*Schema, error) {
 	schema = dc.DeepCopy(schema)
+
+	if m, ok := m.Get(); ok {
+		// Replace original version of module with new version in case they differ
+		var found bool
+		for i, module := range schema.Modules {
+			if module.Name == m.Name {
+				schema.Modules[i] = m
+				found = true
+			}
+		}
+		if !found {
+			schema.Modules = append(schema.Modules, m)
+		}
+	}
+
 	modules := map[string]bool{}
 	merr := []error{}
 	ingress := map[string]*Verb{}

--- a/go-runtime/goplugin/service.go
+++ b/go-runtime/goplugin/service.go
@@ -440,6 +440,13 @@ func build(ctx context.Context, projectConfig projectconfig.Config, stubsRoot st
 	if !ok {
 		return buildFailure(buildCtx, isAutomaticRebuild, buildErrs...), nil
 	}
+	if _, err := schema.ValidateModuleInSchema(buildCtx.Schema, optional.Some(module)); err != nil {
+		return buildFailure(buildCtx, isAutomaticRebuild, builderrors.Error{
+			Type:  builderrors.FTL,
+			Level: builderrors.ERROR,
+			Msg:   err.Error(),
+		}), nil
+	}
 
 	moduleProto := module.ToProto()
 	deploy := []string{"main", "launch"}

--- a/go-runtime/schema/schema_integration_test.go
+++ b/go-runtime/schema/schema_integration_test.go
@@ -460,7 +460,7 @@ func testExtractModuleSubscriber(t *testing.T) {
 	actual := schema.Normalise(r.Module)
 	expected := `module subscriber {
         verb consumesSubscriptionFromExternalTopic(pubsub.PayinEvent) Unit
-		+subscribe publisher.publicBroadcast from=beginning
+		+subscribe pubsub.publicBroadcast from=beginning
 	}
 `
 	assert.Equal(t, normaliseString(expected), normaliseString(actual.String()))

--- a/go-runtime/schema/testdata/subscriber/subscriber.go
+++ b/go-runtime/schema/testdata/subscriber/subscriber.go
@@ -6,7 +6,7 @@ import (
 )
 
 //ftl:verb
-//ftl:subscribe publisher.publicBroadcast from=beginning
+//ftl:subscribe pubsub.publicBroadcast from=beginning
 func ConsumesSubscriptionFromExternalTopic(ctx context.Context, req pubsub.PayinEvent) error {
 	return nil
 }

--- a/internal/buildengine/stubs.go
+++ b/internal/buildengine/stubs.go
@@ -48,10 +48,13 @@ func CleanStubs(ctx context.Context, projectRoot string) error {
 func SyncStubReferences(ctx context.Context, projectRoot string, moduleNames []string, metas map[string]moduleMeta, view *schema.Schema) error {
 	wg, wgctx := errgroup.WithContext(ctx)
 	for _, meta := range metas {
-		stubsRoot := stubsLanguageDir(projectRoot, meta.module.Config.Language)
-		if err := meta.plugin.SyncStubReferences(wgctx, meta.module.Config, stubsRoot, moduleNames, view); err != nil {
-			return err //nolint:wrapcheck
-		}
+		wg.Go(func() error {
+			stubsRoot := stubsLanguageDir(projectRoot, meta.module.Config.Language)
+			if err := meta.plugin.SyncStubReferences(wgctx, meta.module.Config, stubsRoot, moduleNames, view); err != nil {
+				return err //nolint:wrapcheck
+			}
+			return nil
+		})
 	}
 	err := wg.Wait()
 	if err != nil {


### PR DESCRIPTION
Build plugins could claim a module was built when it was actually invalid when validated against the build schema.