### PR TITLE
feat: open cmd

### DIFF
--- a/cmd/ftl/cmd_open.go
+++ b/cmd/ftl/cmd_open.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"connectrpc.com/connect"
+	"github.com/alecthomas/kong"
+	ftlv1 "github.com/block/ftl/backend/protos/xyz/block/ftl/v1"
+	"github.com/block/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
+	"github.com/block/ftl/common/reflection"
+	"github.com/block/ftl/common/schema"
+	"github.com/block/ftl/internal/exec"
+	"github.com/block/ftl/internal/log"
+	"github.com/block/ftl/internal/projectconfig"
+)
+
+type openCmd struct {
+	Ref    reflection.Ref `arg:"" help:"Language of the module to create." placeholder:"MODULE.ITEM" predictor:"decls"`
+	Editor string         `arg:"" help:"Editor to open the file with." enum:"auto,vscode,intellij" default:"auto"`
+
+	TerminalProgram  string `help:"Terminal program this command is running in which can influence 'auto' editor" env:"TERM_PROGRAM" hidden:""`
+	TerminalEmulator string `help:"Terminal emulator can influence 'auto' editor" env:"TERMINAL_EMULATOR" hidden:""`
+}
+
+func (i openCmd) Run(ctx context.Context, ktctx *kong.Context, client ftlv1connect.AdminServiceClient, pc projectconfig.Config) error {
+	ref := i.Ref.ToSchema()
+	resp, err := client.GetSchema(ctx, connect.NewRequest(&ftlv1.GetSchemaRequest{}))
+	if err != nil {
+		return fmt.Errorf("could not get schema: %w", err)
+	}
+	sch, err := mergedSchemaFromResp(resp.Msg)
+	if err != nil {
+		return err
+	}
+	decl, ok := sch.Resolve(ref).Get()
+	if !ok {
+		return fmt.Errorf("could not find %q", ref)
+	}
+	if decl.Position().Filename == "" {
+		return fmt.Errorf("could not find location of %q", ref)
+	}
+	if i.Editor == "auto" {
+		if i.TerminalProgram == "vscode" {
+			i.Editor = "vscode"
+		} else if strings.Contains(i.TerminalEmulator, "JetBrains") {
+			i.Editor = "intellij"
+		} else {
+			return fmt.Errorf(`could not auto choose default editor, use one of the following values:
+	vscode
+	intellij`)
+		}
+	}
+	switch i.Editor {
+	case "vscode":
+		return openVisualStudioCode(ctx, decl.Position(), pc.Root())
+	case "intellij":
+		return openIntelliJ(ctx, decl.Position(), pc.Root())
+	default:
+		// TODO: print out valid editors
+		return fmt.Errorf("unsupported editor %q", i.Editor)
+	}
+}
+
+// mergedSchemaFromResp parses the schema from the response and applies any changesets.
+// modules that are removed by a changeset stay in the schema.
+func mergedSchemaFromResp(resp *ftlv1.GetSchemaResponse) (*schema.Schema, error) {
+	sch, err := schema.FromProto(resp.Schema)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse schema: %w", err)
+	}
+	for _, cs := range resp.Changesets {
+		fmt.Printf("Considering changeset %q\n", cs.Key)
+
+		for _, module := range cs.Modules {
+			moduleSch, err := schema.ModuleFromProto(module)
+			if err != nil {
+				return nil, fmt.Errorf("could not parse module: %w", err)
+			}
+
+			var found bool
+			for i, m := range sch.Modules {
+				if m.Name != module.Name {
+					continue
+				}
+				sch.Modules[i] = moduleSch
+				found = true
+				break
+			}
+			if !found {
+				sch.Modules = append(sch.Modules, moduleSch)
+			}
+		}
+	}
+	return sch, nil
+}
+
+func openVisualStudioCode(ctx context.Context, pos schema.Position, projectRoot string) error {
+	// TODO: schema filepath is has a root of `ftl/modulename`. Replace it with module root
+	path := pos.Filename + ":" + fmt.Sprint(pos.Line)
+	if pos.Column > 0 {
+		path += ":" + fmt.Sprint(pos.Column)
+	}
+	err := exec.Command(ctx, log.Debug, ".", "code", projectRoot, "--goto", path).RunBuffered(ctx)
+	if err != nil {
+		return fmt.Errorf("could not open visual studio code: %w", err)
+	}
+	return nil
+}
+
+func openIntelliJ(ctx context.Context, pos schema.Position, projectRoot string) error {
+	// TODO: schema filepath is has a root of `ftl/modulename`. Replace it with module root
+	// TODO: if idea is not available, explain how to activate it
+	err := exec.Command(ctx, log.Debug, ".", "idea", projectRoot, "--line", strconv.Itoa(pos.Line), "--column", strconv.Itoa(pos.Column), pos.Filename).RunBuffered(ctx)
+	if err != nil {
+		return fmt.Errorf("could not open IntelliJ IDEA: %w", err)
+	}
+	return nil
+}

--- a/cmd/ftl/cmd_open.go
+++ b/cmd/ftl/cmd_open.go
@@ -6,8 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/alecthomas/kong"
-
+	errors "github.com/alecthomas/errors"
 	"github.com/block/ftl/backend/protos/xyz/block/ftl/admin/v1/adminpbconnect"
 	"github.com/block/ftl/backend/protos/xyz/block/ftl/buildengine/v1/buildenginepbconnect"
 	"github.com/block/ftl/common/reflection"
@@ -18,20 +17,26 @@ import (
 	"github.com/block/ftl/internal/projectconfig"
 )
 
+const (
+	autodetect = "auto"
+	vscode     = "vscode"
+	intellij   = "intellij"
+)
+
 type openCmd struct {
 	Ref    reflection.Ref `arg:"" help:"Language of the module to create." placeholder:"MODULE.ITEM" predictor:"decls"`
 	Editor string         `arg:"" help:"Editor to open the file with." enum:"auto,vscode,intellij" default:"auto"`
 
-	TerminalProgram  string `help:"Terminal program this command is running in which can influence 'auto' editor" env:"TERM_PROGRAM" hidden:""`
-	TerminalEmulator string `help:"Terminal emulator can influence 'auto' editor" env:"TERMINAL_EMULATOR" hidden:""`
+	TerminalProgram  string `help:"Helps detect if the terminal is running within an IDE, used for 'auto' IDE detection" env:"TERM_PROGRAM" hidden:""`
+	TerminalEmulator string `help:"Helps detect if the terminal is running within an IDE, used for 'auto' IDE detection" env:"TERMINAL_EMULATOR" hidden:""`
 }
 
-func (i openCmd) Run(ctx context.Context, ktctx *kong.Context, buildEngineClient buildenginepbconnect.BuildEngineServiceClient, adminClient adminpbconnect.AdminServiceClient, pc projectconfig.Config) error {
+func (i openCmd) Run(ctx context.Context, buildEngineClient buildenginepbconnect.BuildEngineServiceClient, adminClient adminpbconnect.AdminServiceClient, pc projectconfig.Config) error {
 	// Currently dev state is the easiest way to get schema and module paths
 	// We should use admin client to get schema directly when we have a single directory for modules in a project
 	state, err := devstate.WaitForDevState(ctx, buildEngineClient, adminClient, false)
 	if err != nil {
-		return fmt.Errorf("could not get dev state: %w", err)
+		return errors.Wrapf(err, "could not get dev state")
 	}
 
 	odecl, _ := state.Schema.ResolveWithModule(&schema.Ref{Module: i.Ref.Module, Name: i.Ref.Name})
@@ -43,25 +48,22 @@ func (i openCmd) Run(ctx context.Context, ktctx *kong.Context, buildEngineClient
 		return fmt.Errorf("could not find file of %q", i.Ref)
 	}
 
-	if i.Editor == "auto" {
+	if i.Editor == autodetect {
 		if i.TerminalProgram == "vscode" {
-			i.Editor = "vscode"
+			i.Editor = vscode
 		} else if strings.Contains(i.TerminalEmulator, "JetBrains") {
-			i.Editor = "intellij"
+			i.Editor = intellij
 		} else {
-			return fmt.Errorf(`could not auto choose default editor, use one of the following values:
-	vscode
-	intellij`)
+			return fmt.Errorf("could not auto choose default editor, expected one of %s", strings.Join([]string{vscode, intellij}, ", "))
 		}
 	}
 	switch i.Editor {
-	case "vscode":
+	case vscode:
 		return openVisualStudioCode(ctx, decl.Position(), pc.Root())
-	case "intellij":
+	case intellij:
 		return openIntelliJ(ctx, decl.Position(), pc.Root())
 	default:
-		// TODO: print out valid editors
-		return fmt.Errorf("unsupported editor %q", i.Editor)
+		return fmt.Errorf("unsupported editor %q, expected one of %s", i.Editor, strings.Join([]string{vscode, intellij}, ", "))
 	}
 }
 
@@ -72,16 +74,15 @@ func openVisualStudioCode(ctx context.Context, pos schema.Position, projectRoot 
 	}
 	err := exec.Command(ctx, log.Debug, ".", "code", projectRoot, "--goto", path).RunBuffered(ctx)
 	if err != nil {
-		return fmt.Errorf("could not open visual studio code: %w", err)
+		return errors.Wrapf(err, "could not open visual studio code")
 	}
 	return nil
 }
 
 func openIntelliJ(ctx context.Context, pos schema.Position, projectRoot string) error {
-	// TODO: if `idea` is not available, explain how to activate it in IntelliJ
 	err := exec.Command(ctx, log.Debug, ".", "idea", projectRoot, "--line", strconv.Itoa(pos.Line), "--column", strconv.Itoa(pos.Column), pos.Filename).RunBuffered(ctx)
 	if err != nil {
-		return fmt.Errorf("could not open IntelliJ IDEA: %w", err)
+		return errors.Wrapf(err, "could not open IntelliJ IDEA")
 	}
 	return nil
 }

--- a/cmd/ftl/cmd_open.go
+++ b/cmd/ftl/cmd_open.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	errors "github.com/alecthomas/errors"
+
 	"github.com/block/ftl/backend/protos/xyz/block/ftl/admin/v1/adminpbconnect"
 	"github.com/block/ftl/backend/protos/xyz/block/ftl/buildengine/v1/buildenginepbconnect"
 	"github.com/block/ftl/common/reflection"

--- a/cmd/ftl/cmd_open.go
+++ b/cmd/ftl/cmd_open.go
@@ -43,10 +43,10 @@ func (i openCmd) Run(ctx context.Context, buildEngineClient buildenginepbconnect
 	odecl, _ := state.Schema.ResolveWithModule(&schema.Ref{Module: i.Ref.Module, Name: i.Ref.Name})
 	decl, ok := odecl.Get()
 	if !ok {
-		return fmt.Errorf("could not find %q", i.Ref)
+		return errors.Errorf("could not find %q", i.Ref)
 	}
 	if decl.Position().Filename == "" {
-		return fmt.Errorf("could not find file of %q", i.Ref)
+		return errors.Errorf("could not find file of %q", i.Ref)
 	}
 
 	if i.Editor == autodetect {
@@ -55,7 +55,7 @@ func (i openCmd) Run(ctx context.Context, buildEngineClient buildenginepbconnect
 		} else if strings.Contains(i.TerminalEmulator, "JetBrains") {
 			i.Editor = intellij
 		} else {
-			return fmt.Errorf("could not auto choose default editor, expected one of %s", strings.Join([]string{vscode, intellij}, ", "))
+			return errors.Errorf("could not auto choose default editor, expected one of %s", strings.Join([]string{vscode, intellij}, ", "))
 		}
 	}
 	switch i.Editor {
@@ -64,7 +64,7 @@ func (i openCmd) Run(ctx context.Context, buildEngineClient buildenginepbconnect
 	case intellij:
 		return openIntelliJ(ctx, decl.Position(), pc.Root())
 	default:
-		return fmt.Errorf("unsupported editor %q, expected one of %s", i.Editor, strings.Join([]string{vscode, intellij}, ", "))
+		return errors.Errorf("unsupported editor %q, expected one of %s", i.Editor, strings.Join([]string{vscode, intellij}, ", "))
 	}
 }
 

--- a/cmd/ftl/cmd_open.go
+++ b/cmd/ftl/cmd_open.go
@@ -32,6 +32,7 @@ func (i openCmd) Run(ctx context.Context, ktctx *kong.Context, client ftlv1conne
 	if err != nil {
 		return fmt.Errorf("could not get schema: %w", err)
 	}
+	// merge changesets into schema so we get the latest decl positions
 	sch, err := mergedSchemaFromResp(resp.Msg)
 	if err != nil {
 		return err
@@ -119,4 +120,8 @@ func openIntelliJ(ctx context.Context, pos schema.Position, projectRoot string) 
 		return fmt.Errorf("could not open IntelliJ IDEA: %w", err)
 	}
 	return nil
+}
+
+func filePathForPosition(pos schema.Position, modulePath string) string {
+	// TODO: implement
 }

--- a/cmd/ftl/cmd_open.go
+++ b/cmd/ftl/cmd_open.go
@@ -8,6 +8,7 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/alecthomas/kong"
+
 	ftlv1 "github.com/block/ftl/backend/protos/xyz/block/ftl/v1"
 	"github.com/block/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
 	"github.com/block/ftl/common/reflection"

--- a/cmd/ftl/main.go
+++ b/cmd/ftl/main.go
@@ -67,7 +67,7 @@ type SharedCLI struct {
 	Goose     gooseCmd     `cmd:"" help:"Run a goose command."`
 	Mysql     mySQLCmd     `cmd:"" help:"Manage MySQL databases."`
 	Postgres  postgresCmd  `cmd:"" help:"Manage PostgreSQL databases."`
-	Open      openCmd      `cmd:"" help:"Open a file in the editor at the location of a schema declaration."`
+	Open      openCmd      `cmd:"" help:"Open a declaration in an IDE."`
 }
 
 type BuildAndDeploy struct {

--- a/cmd/ftl/main.go
+++ b/cmd/ftl/main.go
@@ -67,6 +67,7 @@ type SharedCLI struct {
 	Goose     gooseCmd     `cmd:"" help:"Run a goose command."`
 	Mysql     mySQLCmd     `cmd:"" help:"Manage MySQL databases."`
 	Postgres  postgresCmd  `cmd:"" help:"Manage PostgreSQL databases."`
+	Open      openCmd      `cmd:"" help:"Open a file in the editor at the location of a schema declaration."`
 }
 
 type BuildAndDeploy struct {

--- a/internal/terminal/predictors.go
+++ b/internal/terminal/predictors.go
@@ -11,6 +11,7 @@ import (
 
 func Predictors(view *schemaeventsource.View) map[string]complete.Predictor {
 	return map[string]complete.Predictor{
+		"decls":         &declPredictor[schema.Decl]{view: *view},
 		"verbs":         &declPredictor[*schema.Verb]{view: *view},
 		"configs":       &declPredictor[*schema.Config]{view: *view},
 		"secrets":       &declPredictor[*schema.Secret]{view: *view},


### PR DESCRIPTION
`ftl open <ref> <editor>`

IDEs:
- `vscode`
- `intellij`

Editor is autodetected within vscode and intellij terminals.

TODO:
- Rename `open` -> `edit`
- Remove auto
- Make this its own package so its easy for console to use it too
- Use this to open editors: https://github.com/Binbiubiubiu/launch_editor/