### PR TITLE
fix: proper error when trying to deploy with unsupported resources

### DIFF
--- a/backend/provisioner/deployment_test.go
+++ b/backend/provisioner/deployment_test.go
@@ -98,7 +98,6 @@ func TestDeployment_Progress(t *testing.T) {
 				&schema.Database{Name: "b", Type: "postgres"},
 			},
 		}, nil, nil)
-
 		assert.Equal(t, 2, len(dpl.State().Pending))
 
 		_, err := dpl.Progress(ctx)

--- a/backend/provisioner/service.go
+++ b/backend/provisioner/service.go
@@ -290,6 +290,9 @@ func (s *Service) HandleChangesetPreparing(ctx context.Context, req *schema.Chan
 			syncExistingRuntimes(existingModule, module)
 		}
 		group.Go(func() error {
+			if err := s.registry.VerifyDeploymentSupported(ctx, module); err != nil {
+				return err
+			}
 			deployment := s.registry.CreateDeployment(ctx, req.Key, module, existingModule, func(element *schema.RuntimeElement) error {
 				cs := req.Key.String()
 				_, err := s.schemaClient.UpdateDeploymentRuntime(ctx, connect.NewRequest(&ftlv1.UpdateDeploymentRuntimeRequest{


### PR DESCRIPTION
Now, instead of panic and hanging forever, a deployment to an environment with unsupported resources gives an error like this:
```
> ftl deploy postgres
info:postgres:build: Building...
info:postgres:build: Module built (2.59s)
◞[postgres]

ftl: error: failed to deploy: failed to deploy changeset: unknown: failed to apply changeset: error running deployments: resource type postgres is not supported in this environment
```