### PR TITLE
fix: delete clients that no longer exist

### DIFF
--- a/jvm-runtime/ftl-runtime/common/deployment/src/main/java/xyz/block/ftl/deployment/PackageOutput.java
+++ b/jvm-runtime/ftl-runtime/common/deployment/src/main/java/xyz/block/ftl/deployment/PackageOutput.java
@@ -1,0 +1,73 @@
+package xyz.block.ftl.deployment;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jboss.logging.Logger;
+
+import io.quarkus.deployment.util.FileUtil;
+
+public class PackageOutput implements AutoCloseable {
+
+    private static final Logger log = Logger.getLogger(PackageOutput.class);
+
+    private final Path outputDir;
+    private final String packageName;
+    private final Map<String, StringBuilder> files = new HashMap<>();
+
+    public PackageOutput(Path outputDir, String packageName) {
+        this.outputDir = outputDir;
+        this.packageName = packageName.replaceAll("\\.", "/");
+    }
+
+    public StringBuilder writeKotlin(String fileName) throws IOException {
+        StringBuilder value = new StringBuilder();
+        files.put(packageName + "/" + fileName + ".kt", value);
+        return value;
+    }
+
+    public StringBuilder writeJava(String fileName) throws IOException {
+        StringBuilder value = new StringBuilder();
+        files.put(fileName, value);
+        return value;
+    }
+
+    @Override
+    public void close() {
+        try {
+            Path packageDir = outputDir.resolve(packageName);
+            if (Files.exists(packageDir)) {
+                try (var s = Files.list(packageDir)) {
+                    s.forEach(path -> {
+                        if (!files.containsKey(path.getFileName().toString())) {
+                            try {
+                                FileUtil.deleteIfExists(path);
+                            } catch (IOException e) {
+                                log.errorf(e, "Failed to delete path: %s", path);
+                            }
+                        }
+                    });
+                }
+            }
+            Files.createDirectories(packageDir);
+            for (var e : files.entrySet()) {
+                Path target = outputDir.resolve(e.getKey());
+                byte[] fileBytes = e.getValue().toString().getBytes(StandardCharsets.UTF_8);
+                if (Files.exists(target)) {
+                    var existing = Files.readAllBytes(target);
+                    if (Arrays.equals(fileBytes, existing)) {
+                        continue;
+                    }
+                }
+                Files.write(target, fileBytes);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/jvm-runtime/ftl-runtime/java/deployment/src/main/java/xyz/block/ftl/javalang/deployment/JavaCodeGenerator.java
+++ b/jvm-runtime/ftl-runtime/java/deployment/src/main/java/xyz/block/ftl/javalang/deployment/JavaCodeGenerator.java
@@ -1,7 +1,6 @@
 package xyz.block.ftl.javalang.deployment;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -34,6 +33,7 @@ import xyz.block.ftl.TypeAlias;
 import xyz.block.ftl.TypeAliasMapper;
 import xyz.block.ftl.VerbClient;
 import xyz.block.ftl.deployment.JVMCodeGenerator;
+import xyz.block.ftl.deployment.PackageOutput;
 import xyz.block.ftl.deployment.VerbType;
 import xyz.block.ftl.schema.v1.Data;
 import xyz.block.ftl.schema.v1.Enum;
@@ -51,7 +51,7 @@ public class JavaCodeGenerator extends JVMCodeGenerator {
 
     @Override
     protected void generateTypeAliasMapper(String module, xyz.block.ftl.schema.v1.TypeAlias typeAlias,
-            String packageName, Optional<String> nativeTypeAlias, Path outputDir) throws IOException {
+            String packageName, Optional<String> nativeTypeAlias, PackageOutput outputDir) throws IOException {
         TypeSpec.Builder typeBuilder = TypeSpec.interfaceBuilder(className(typeAlias.getName()) + TYPE_MAPPER)
                 .addAnnotation(AnnotationSpec.builder(TypeAlias.class)
                         .addMember("name", "\"" + typeAlias.getName() + "\"")
@@ -71,11 +71,11 @@ public class JavaCodeGenerator extends JVMCodeGenerator {
         TypeSpec theType = typeBuilder.build();
         JavaFile javaFile = JavaFile.builder(packageName, theType)
                 .build();
-        javaFile.writeTo(outputDir);
+        javaFile.writeTo(outputDir.writeJava(javaFile.toJavaFileObject().getName()));
     }
 
     protected void generateTopicConsumer(Module module, Topic data, String packageName, Map<DeclRef, Type> typeAliasMap,
-            Map<DeclRef, String> nativeTypeAliasMap, Path outputDir) throws IOException {
+            Map<DeclRef, String> nativeTypeAliasMap, PackageOutput outputDir) throws IOException {
         String thisType = className(data.getName());
 
         TypeSpec.Builder dataBuilder = TypeSpec.interfaceBuilder(thisType)
@@ -102,11 +102,11 @@ public class JavaCodeGenerator extends JVMCodeGenerator {
         JavaFile javaFile = JavaFile.builder(packageName, dataBuilder.build())
                 .build();
 
-        javaFile.writeTo(outputDir);
+        javaFile.writeTo(outputDir.writeJava(javaFile.toJavaFileObject().getName()));
     }
 
     protected void generateEnum(Module module, Enum ennum, String packageName, Map<DeclRef, Type> typeAliasMap,
-            Map<DeclRef, String> nativeTypeAliasMap, Map<DeclRef, List<EnumInfo>> enumVariantInfoMap, Path outputDir)
+            Map<DeclRef, String> nativeTypeAliasMap, Map<DeclRef, List<EnumInfo>> enumVariantInfoMap, PackageOutput outputDir)
             throws IOException {
         String interfaceType = className(ennum.getName());
         if (ennum.hasType()) {
@@ -131,7 +131,7 @@ public class JavaCodeGenerator extends JVMCodeGenerator {
                 dataBuilder.addEnumConstant(i.getName(), TypeSpec.anonymousClassBuilder(format, value).build());
             }
             JavaFile javaFile = JavaFile.builder(packageName, dataBuilder.build()).build();
-            javaFile.writeTo(outputDir);
+            javaFile.writeTo(outputDir.writeJava(javaFile.toJavaFileObject().getName()));
         } else {
             // Enums without a type are (confusingly) "type enums". Java can't represent these directly, so we use a
             // sealed class
@@ -187,16 +187,16 @@ public class JavaCodeGenerator extends JVMCodeGenerator {
                     addTypeEnumInterfaceMethods(packageName, interfaceType, dataBuilder, name, valueType,
                             variantValuesTypes, false);
                     JavaFile javaFile = JavaFile.builder(packageName, dataBuilder.build()).build();
-                    javaFile.writeTo(outputDir);
+                    javaFile.writeTo(outputDir.writeJava(javaFile.toJavaFileObject().getName()));
                 }
             }
             JavaFile javaFile = JavaFile.builder(packageName, interfaceBuilder.build()).build();
-            javaFile.writeTo(outputDir);
+            javaFile.writeTo(outputDir.writeJava(javaFile.toJavaFileObject().getName()));
         }
     }
 
     protected void generateDataObject(Module module, Data data, String packageName, Map<DeclRef, Type> typeAliasMap,
-            Map<DeclRef, String> nativeTypeAliasMap, Map<DeclRef, List<EnumInfo>> enumVariantInfoMap, Path outputDir)
+            Map<DeclRef, String> nativeTypeAliasMap, Map<DeclRef, List<EnumInfo>> enumVariantInfoMap, PackageOutput outputDir)
             throws IOException {
         String thisType = className(data.getName());
         TypeSpec.Builder dataBuilder = TypeSpec.classBuilder(thisType)
@@ -267,11 +267,11 @@ public class JavaCodeGenerator extends JVMCodeGenerator {
         JavaFile javaFile = JavaFile.builder(packageName, dataBuilder.build())
                 .build();
 
-        javaFile.writeTo(outputDir);
+        javaFile.writeTo(outputDir.writeJava(javaFile.toJavaFileObject().getName()));
     }
 
     protected void generateVerb(Module module, Verb verb, String packageName, Map<DeclRef, Type> typeAliasMap,
-            Map<DeclRef, String> nativeTypeAliasMap, Path outputDir)
+            Map<DeclRef, String> nativeTypeAliasMap, PackageOutput outputDir)
             throws IOException {
         String verbName = verb.getName();
         TypeSpec.Builder clientBuilder = TypeSpec.interfaceBuilder(className(verbName) + CLIENT)
@@ -297,7 +297,7 @@ public class JavaCodeGenerator extends JVMCodeGenerator {
         }
         clientBuilder.addMethod(callMethod.build());
         JavaFile javaFile = JavaFile.builder(packageName, clientBuilder.build()).build();
-        javaFile.writeTo(outputDir);
+        javaFile.writeTo(outputDir.writeJava(javaFile.toJavaFileObject().getName()));
     }
 
     private String toJavaName(String name) {

--- a/jvm-runtime/ftl-runtime/kotlin/deployment/src/main/java/xyz/block/ftl/kotlin/deployment/KotlinCodeGenerator.java
+++ b/jvm-runtime/ftl-runtime/kotlin/deployment/src/main/java/xyz/block/ftl/kotlin/deployment/KotlinCodeGenerator.java
@@ -3,7 +3,6 @@ package xyz.block.ftl.kotlin.deployment;
 import static com.squareup.kotlinpoet.TypeNames.BOOLEAN;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -35,6 +34,7 @@ import xyz.block.ftl.TypeAlias;
 import xyz.block.ftl.TypeAliasMapper;
 import xyz.block.ftl.VerbClient;
 import xyz.block.ftl.deployment.JVMCodeGenerator;
+import xyz.block.ftl.deployment.PackageOutput;
 import xyz.block.ftl.deployment.VerbType;
 import xyz.block.ftl.schema.v1.Data;
 import xyz.block.ftl.schema.v1.Enum;
@@ -52,8 +52,7 @@ public class KotlinCodeGenerator extends JVMCodeGenerator {
 
     @Override
     protected void generateTypeAliasMapper(String module, xyz.block.ftl.schema.v1.TypeAlias typeAlias, String packageName,
-            Optional<String> nativeTypeAlias,
-            Path outputDir) throws IOException {
+            Optional<String> nativeTypeAlias, PackageOutput outputDir) throws IOException {
         String thisType = className(typeAlias.getName()) + TYPE_MAPPER;
         TypeSpec.Builder typeBuilder = TypeSpec.interfaceBuilder(thisType)
                 .addAnnotation(AnnotationSpec.builder(TypeAlias.class)
@@ -72,14 +71,14 @@ public class KotlinCodeGenerator extends JVMCodeGenerator {
                     ClassName.bestGuess(nativeTypeAlias.get()), new ClassName("kotlin", "String")), CodeBlock.of(""));
         }
 
-        FileSpec javaFile = FileSpec.builder(packageName, thisType)
+        FileSpec kotlinFile = FileSpec.builder(packageName, thisType)
                 .addType(typeBuilder.build())
                 .build();
-        javaFile.writeTo(outputDir);
+        kotlinFile.writeTo(outputDir.writeKotlin(kotlinFile.getName()));
     }
 
     protected void generateTopicConsumer(Module module, Topic data, String packageName, Map<DeclRef, Type> typeAliasMap,
-            Map<DeclRef, String> nativeTypeAliasMap, Path outputDir) throws IOException {
+            Map<DeclRef, String> nativeTypeAliasMap, PackageOutput outputDir) throws IOException {
         String thisType = className(data.getName());
 
         TypeSpec.Builder dataBuilder = TypeSpec.interfaceBuilder(ClassName.bestGuess(thisType));
@@ -106,11 +105,11 @@ public class KotlinCodeGenerator extends JVMCodeGenerator {
                 .addType(dataBuilder.build())
                 .build();
 
-        javaFile.writeTo(outputDir);
+        javaFile.writeTo(outputDir.writeKotlin(javaFile.getName()));
     }
 
     protected void generateEnum(Module module, Enum data, String packageName, Map<DeclRef, Type> typeAliasMap,
-            Map<DeclRef, String> nativeTypeAliasMap, Map<DeclRef, List<EnumInfo>> enumVariantInfoMap, Path outputDir)
+            Map<DeclRef, String> nativeTypeAliasMap, Map<DeclRef, List<EnumInfo>> enumVariantInfoMap, PackageOutput outputDir)
             throws IOException {
         String thisType = className(data.getName());
         if (data.hasType()) {
@@ -137,7 +136,7 @@ public class KotlinCodeGenerator extends JVMCodeGenerator {
             FileSpec kotlinFile = FileSpec.builder(packageName, thisType)
                     .addType(dataBuilder.build())
                     .build();
-            kotlinFile.writeTo(outputDir);
+            kotlinFile.writeTo(outputDir.writeKotlin(kotlinFile.getName()));
         } else {
             // Enums without a type are (confusingly) "type enums". Kotlin can't represent these directly, so we use a
             // sealed interface
@@ -187,18 +186,18 @@ public class KotlinCodeGenerator extends JVMCodeGenerator {
                     FileSpec wrapperFile = FileSpec.builder(packageName, name)
                             .addType(dataBuilder.build())
                             .build();
-                    wrapperFile.writeTo(outputDir);
+                    wrapperFile.writeTo(outputDir.writeKotlin(wrapperFile.getName()));
                 }
             }
             FileSpec interfaceFile = FileSpec.builder(packageName, thisType)
                     .addType(interfaceBuilder.build())
                     .build();
-            interfaceFile.writeTo(outputDir);
+            interfaceFile.writeTo(outputDir.writeKotlin(interfaceFile.getName()));
         }
     }
 
     protected void generateDataObject(Module module, Data data, String packageName, Map<DeclRef, Type> typeAliasMap,
-            Map<DeclRef, String> nativeTypeAliasMap, Map<DeclRef, List<EnumInfo>> enumVariantInfoMap, Path outputDir)
+            Map<DeclRef, String> nativeTypeAliasMap, Map<DeclRef, List<EnumInfo>> enumVariantInfoMap, PackageOutput outputDir)
             throws IOException {
         String thisType = className(data.getName());
         TypeSpec.Builder dataBuilder = TypeSpec.classBuilder(thisType)
@@ -241,11 +240,11 @@ public class KotlinCodeGenerator extends JVMCodeGenerator {
         FileSpec kotlinClass = FileSpec.builder(packageName, thisType)
                 .addType(dataBuilder.build())
                 .build();
-        kotlinClass.writeTo(outputDir);
+        kotlinClass.writeTo(outputDir.writeKotlin(kotlinClass.getName()));
     }
 
     protected void generateVerb(Module module, Verb verb, String packageName, Map<DeclRef, Type> typeAliasMap,
-            Map<DeclRef, String> nativeTypeAliasMap, Path outputDir)
+            Map<DeclRef, String> nativeTypeAliasMap, PackageOutput outputDir)
             throws IOException {
         String name = verb.getName();
         String thisType = className(name) + CLIENT;
@@ -270,7 +269,7 @@ public class KotlinCodeGenerator extends JVMCodeGenerator {
         FileSpec javaFile = FileSpec.builder(packageName, thisType)
                 .addType(typeBuilder.build())
                 .build();
-        javaFile.writeTo(outputDir);
+        javaFile.writeTo(outputDir.writeKotlin(javaFile.getName()));
     }
 
     private String toJavaName(String name) {


### PR DESCRIPTION
Fixes: #4734

Note that this does not fix the 'leftover kotlin .class files' problem, this needs to be fixed in Quarkus itself.