### PR TITLE
fix: clean go compile errors and prevent infinite loop

### DIFF
--- a/go-runtime/compile/build.go
+++ b/go-runtime/compile/build.go
@@ -641,12 +641,13 @@ func compile(ctx context.Context, mainDir string, buildEnv []string, devMode boo
 	lines := strings.Split(err.Error(), "\n")
 	for i := 1; i < len(lines); {
 		if strings.HasPrefix(lines[i], "\t") {
-			lines[i-1] = lines[i-1] + " : " + lines[i]
+			lines[i-1] = lines[i-1] + ": " + strings.TrimSpace(lines[i])
+			lines = append(lines[:i], lines[i+1:]...)
 		} else {
 			i++
 		}
 	}
-	for _, line := range strings.Split(err.Error(), "\n") {
+	for _, line := range lines {
 		if strings.HasPrefix(line, "# ") {
 			continue
 		}


### PR DESCRIPTION
- Remove extra whitespace
- Forgot to remove line from slice when we joined it with another line