### PR TITLE
fix: dependency cycles can be fixed by the user without restarting

### DIFF
--- a/internal/buildengine/engine.go
+++ b/internal/buildengine/engine.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"connectrpc.com/connect"
@@ -858,29 +859,22 @@ func (e *Engine) BuildAndDeploy(ctx context.Context, replicas int32, waitForDepl
 		}
 	}()
 
-	buildGroup := errgroup.Group{}
-
 	modulesToDeploy := []Module{}
-	buildGroup.Go(func() error {
-		return e.buildWithCallback(ctx, func(buildCtx context.Context, module Module) error {
-			e.modulesToBuild.Store(module.Config.Module, false)
-			e.rawEngineUpdates <- &buildenginepb.EngineEvent{
-				Event: &buildenginepb.EngineEvent_ModuleDeployWaiting{
-					ModuleDeployWaiting: &buildenginepb.ModuleDeployWaiting{
-						Module: module.Config.Module,
-					},
+	buildErr := e.buildWithCallback(ctx, func(buildCtx context.Context, module Module) error {
+		e.modulesToBuild.Store(module.Config.Module, false)
+		e.rawEngineUpdates <- &buildenginepb.EngineEvent{
+			Event: &buildenginepb.EngineEvent_ModuleDeployWaiting{
+				ModuleDeployWaiting: &buildenginepb.ModuleDeployWaiting{
+					Module: module.Config.Module,
 				},
-			}
-			if singleChangeset {
-				modulesToDeploy = append(modulesToDeploy, module)
-				return nil
-			}
-			return e.deploy(ctx, []Module{module}, replicas)
-		}, moduleNames...)
-	})
-
-	// Wait for all build attempts to complete
-	buildErr := buildGroup.Wait()
+			},
+		}
+		if singleChangeset {
+			modulesToDeploy = append(modulesToDeploy, module)
+			return nil
+		}
+		return e.deploy(ctx, []Module{module}, replicas)
+	}, moduleNames...)
 	if buildErr != nil {
 		return fmt.Errorf("build failed: %w", buildErr)
 	}
@@ -972,9 +966,16 @@ func (e *Engine) buildWithCallback(ctx context.Context, callback buildCallback, 
 		return err
 	}
 
-	topology, err := TopologicalSort(graph)
-	if err != nil {
-		return err
+	topology, topoErr := TopologicalSort(graph)
+	if topoErr != nil {
+		dependencyCycleErr, ok := topoErr.(DependencyCycleError)
+		if !ok {
+			return err
+		}
+		if err := e.handleDependencyCycleError(ctx, dependencyCycleErr, graph, callback); err != nil {
+			return errors.Join(err, topoErr)
+		}
+		return topoErr
 	}
 	errCh := make(chan error, 1024)
 	for _, group := range topology {
@@ -1039,6 +1040,75 @@ func (e *Engine) buildWithCallback(ctx context.Context, callback buildCallback, 
 	}
 
 	return nil
+}
+
+func (e *Engine) handleDependencyCycleError(ctx context.Context, depErr DependencyCycleError, graph map[string][]string, callback buildCallback) error {
+	// Mark each cylic module as having an error
+	for _, module := range depErr.Modules {
+		meta, ok := e.moduleMetas.Load(module)
+		if !ok {
+			return fmt.Errorf("module %q not found in dependency cycle", module)
+		}
+		configProto, err := langpb.ModuleConfigToProto(meta.module.Config.Abs())
+		if err != nil {
+			return fmt.Errorf("failed to marshal module config: %w", err)
+		}
+		e.rawEngineUpdates <- &buildenginepb.EngineEvent{
+			Timestamp: timestamppb.Now(),
+			Event: &buildenginepb.EngineEvent_ModuleBuildFailed{
+				ModuleBuildFailed: &buildenginepb.ModuleBuildFailed{
+					Config: configProto,
+					Errors: &langpb.ErrorList{
+						Errors: []*langpb.Error{
+							{
+								Msg:   depErr.Error(),
+								Level: langpb.Error_ERROR_LEVEL_ERROR,
+								Type:  langpb.Error_ERROR_TYPE_FTL,
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	// Build the remaining modules
+	remaining := slices.Filter(maps.Keys(graph), func(module string) bool {
+		return !slices.Contains(depErr.Modules, module) && module != "builtin"
+	})
+	if len(remaining) == 0 {
+		return nil
+	}
+	remainingModulesErr := e.buildWithCallback(ctx, callback, remaining...)
+
+	wg := &sync.WaitGroup{}
+	for _, module := range depErr.Modules {
+		// Make sure each module in dependency cycle has an active build stream so changes to dependencies are detected
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			ignoredSchemas := make(chan *schema.Module, 1)
+			fakeDeps := map[string]*schema.Module{
+				"builtin": schema.Builtins(),
+			}
+			for _, dep := range graph[module] {
+				if sch, ok := e.controllerSchema.Load(dep); ok {
+					fakeDeps[dep] = sch
+					continue
+				}
+				// not build yet, probably due to dependency cycle
+				fakeDeps[dep] = &schema.Module{
+					Name:     dep,
+					Comments: []string{"Dependency not built yet due to dependency cycle"},
+				}
+			}
+			_ = e.build(ctx, module, fakeDeps, ignoredSchemas)
+			close(ignoredSchemas)
+		}()
+	}
+	wg.Wait()
+	return remainingModulesErr
 }
 
 func (e *Engine) tryBuild(ctx context.Context, mustBuild map[string]bool, moduleName string, builtModules map[string]*schema.Module, schemas chan *schema.Module, callback buildCallback) error {

--- a/internal/buildengine/testdata/depcycle1/go.mod
+++ b/internal/buildengine/testdata/depcycle1/go.mod
@@ -1,5 +1,5 @@
 module ftl/depcycle1
 
-go 1.23.0
+go 1.24.0
 
 replace github.com/block/ftl => ../../../..

--- a/internal/buildengine/testdata/depcycle2/go.mod
+++ b/internal/buildengine/testdata/depcycle2/go.mod
@@ -1,5 +1,5 @@
 module ftl/depcycle2
 
-go 1.23.0
+go 1.24.0
 
 replace github.com/block/ftl => ./../../..

--- a/internal/buildengine/topological.go
+++ b/internal/buildengine/topological.go
@@ -14,7 +14,7 @@ type DependencyCycleError struct {
 var _ error = DependencyCycleError{}
 
 func (e DependencyCycleError) Error() string {
-	return fmt.Sprintf("detected a module dependency cycle that impacts these modules: %v", e.Modules)
+	return fmt.Sprintf("detected a module dependency cycle that impacts these modules: %q", e.Modules)
 }
 
 // TopologicalSort attempts to order the modules supplied in the graph based on

--- a/internal/buildengine/topological.go
+++ b/internal/buildengine/topological.go
@@ -7,6 +7,16 @@ import (
 	"golang.org/x/exp/maps"
 )
 
+type DependencyCycleError struct {
+	Modules []string
+}
+
+var _ error = DependencyCycleError{}
+
+func (e DependencyCycleError) Error() string {
+	return fmt.Sprintf("detected a module dependency cycle that impacts these modules: %v", e.Modules)
+}
+
 // TopologicalSort attempts to order the modules supplied in the graph based on
 // their topologically sorted order. A cycle in the module dependency graph
 // will cause this sort to be incomplete. The sorted modules are returned as a
@@ -42,7 +52,7 @@ func TopologicalSort(graph map[string][]string) (groups [][]string, cycleError e
 			// a member of the cyclical dependency chain
 			modules := maps.Keys(modulesByName)
 			sort.Strings(modules)
-			cycleError = fmt.Errorf("detected a module dependency cycle that impacts these modules: %q", modules)
+			cycleError = DependencyCycleError{Modules: modules}
 			break
 		}
 		orderedGroup := maps.Keys(group)


### PR DESCRIPTION
Fixes https://github.com/block/ftl/issues/4568
Changes:
- Modules with dependency cycles are treated as failed to build (status item goes red, error is logged)
- Once a dependency is detected, we send a build command for the module but ignore the error
    - This means we have an active build stream so module changes are detected
    - Once the user has fixed a dependency cycle, the updated module will rebuild and then all other modules in the cycle will rebuild (normal dependency build logic)
- Other modules can be built and deployed as usual (previously all modules would sit waiting for the dependency cycle to be resolved)