### PR TITLE
chore: add Cursor rules for docs

### DIFF
--- a/.cursor/rules/docs.mdc
+++ b/.cursor/rules/docs.mdc
@@ -1,0 +1,8 @@
+---
+description: Rules for documentation
+globs: docs/**/*
+alwaysApply: false
+---
+- This project uses Docusaurus (@https://docusaurus.io/docs) for documentation
+- There should be four tabs for every code example: Go, Kotlin, Java, and Schema
+- Run `./scripts/ftl schema example` to see an example of what the FTL schema likes.

--- a/cmd/ftl/cmd_schema.go
+++ b/cmd/ftl/cmd_schema.go
@@ -5,4 +5,5 @@ type schemaCmd struct {
 	Diff     schemaDiffCmd     `cmd:"" help:"Print any schema differences between this cluster and another cluster. Returns an exit code of 1 if there are differences."`
 	Generate schemaGenerateCmd `cmd:"" help:"Stream the schema from the cluster and generate files from the template."`
 	EBNF     schemaEBNFCmd     `cmd:"" help:"Print the EBNF grammar for the FTL schema."`
+	Example  schemaExampleCmd  `cmd:"" help:"Print an example FTL schema."`
 }

--- a/cmd/ftl/cmd_schema_example.go
+++ b/cmd/ftl/cmd_schema_example.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/alecthomas/types/must"
+	"github.com/block/ftl/common/schema"
+)
+
+var exampleSchema = must.Get(schema.ParseString("schema", `
+// Built-in types for FTL.
+builtin module builtin {
+  // CatchRequest is a request structure for catch verbs.
+  export data CatchRequest<Req> {
+    verb builtin.Ref
+    request Req
+    requestType String
+    error String
+  }
+
+  export data Empty {
+  }
+
+  // FailedEvent is used in dead letter topics.
+  export data FailedEvent<Event> {
+    event Event
+    error String
+  }
+
+  // HTTP request structure used for HTTP ingress verbs.
+  export data HttpRequest<Body, Path, Query> {
+    method String
+    path String
+    pathParameters Path
+    query Query
+    headers {String: [String]}
+    body Body
+  }
+
+  // HTTP response structure used for HTTP ingress verbs.
+  export data HttpResponse<Body, Error> {
+    status Int
+    headers {String: [String]}
+    // Either "body" or "error" must be present, not both.
+    body Body?
+    error Error?
+  }
+
+  // A reference to a declaration in the schema.
+  export data Ref {
+    module String
+    name String
+  }
+}
+
+module http {
+  export data ApiError {
+    message String +alias json "message"
+  }
+
+  export data GetPathParams {
+    name String +alias json "name"
+  }
+
+  export data GetQueryParams {
+    age Int? +alias json "age"
+  }
+
+  export data GetResponse {
+    name String +alias json "name"
+    age Int? +alias json "age"
+  }
+
+  export data PostRequest {
+    name String +alias json "name"
+    age Int +alias json "age"
+  }
+
+  export data PostResponse {
+    name String +alias json "name"
+    age Int +alias json "age"
+  }
+
+  export verb get(builtin.HttpRequest<Unit, http.GetPathParams, http.GetQueryParams>) builtin.HttpResponse<http.GetResponse, http.ApiError>  
+    +ingress http GET /get/{name}
+
+  export verb post(builtin.HttpRequest<http.PostRequest, Unit, Unit>) builtin.HttpResponse<http.PostResponse, http.ApiError>  
+    +ingress http POST /post
+}
+
+module time {
+  export data TimeRequest {
+  }
+
+  export data TimeResponse {
+    time Time
+  }
+
+  verb internal(time.TimeRequest) time.TimeResponse
+
+  // Time returns the current time.
+  export verb time(time.TimeRequest) time.TimeResponse  
+    +calls time.internal
+}
+
+module echo {
+  config default String
+
+  // An echo request.
+  export data EchoRequest {
+    name String? +alias json "name"
+  }
+
+  export data EchoResponse {
+    message String +alias json "message"
+  }
+
+  // Echo returns a greeting with the current time.
+  export verb echo(echo.EchoRequest) echo.EchoResponse  
+    +calls time.time
+    +config echo.default
+}
+`))
+
+type schemaExampleCmd struct {
+}
+
+func (c *schemaExampleCmd) Run() error {
+	fmt.Print(exampleSchema)
+	return nil
+}

--- a/examples/go/time/time.go
+++ b/examples/go/time/time.go
@@ -21,7 +21,7 @@ func Time(ctx context.Context, req TimeRequest, ic InternalClient) (TimeResponse
 	return TimeResponse{Time: internalTime.Time}, nil
 }
 
-//ftl:verb export
+//ftl:verb
 func Internal(ctx context.Context, req TimeRequest) (TimeResponse, error) {
 	return TimeResponse{Time: time.Now()}, nil
 }


### PR DESCRIPTION
Also added an "ftl schema example" command for LLMs (and humans) to use to see an example schema.