### PR TITLE
refactor: rpc.ContextWithClient copied into go-runtime

### DIFF
--- a/backend/controller/leases/clientleaser.go
+++ b/backend/controller/leases/clientleaser.go
@@ -8,15 +8,14 @@ import (
 
 	leasepb "github.com/block/ftl/backend/protos/xyz/block/ftl/lease/v1"
 	"github.com/block/ftl/backend/protos/xyz/block/ftl/lease/v1/leasepbconnect"
-	"github.com/block/ftl/internal/rpc"
 )
 
 var _ Leaser = (*clientLeaser)(nil)
 var _ Lease = (*clientLease)(nil)
 
-func NewClientLeaser(ctx context.Context) Leaser {
+func NewClientLeaser(ctx context.Context, client leasepbconnect.LeaseServiceClient) Leaser {
 	return &clientLeaser{
-		client: rpc.ClientFromContext[leasepbconnect.LeaseServiceClient](ctx),
+		client: client,
 	}
 }
 

--- a/cmd/ftl-controller/main.go
+++ b/cmd/ftl-controller/main.go
@@ -52,6 +52,6 @@ func main() {
 	adminClient := rpc.Dial(ftlv1connect.NewAdminServiceClient, cli.AdminEndpoint.String(), log.Error)
 	ctx = rpc.ContextWithClient(ctx, adminClient)
 
-	err = controller.Start(ctx, cli.ControllerConfig, adminClient, schemaClient, false)
+	err = controller.Start(ctx, cli.ControllerConfig, adminClient, schemaClient, leaseClient, false)
 	kctx.FatalIfErrorf(err)
 }

--- a/cmd/ftl/cmd_serve.go
+++ b/cmd/ftl/cmd_serve.go
@@ -25,6 +25,7 @@ import (
 	"github.com/block/ftl/backend/ingress"
 	"github.com/block/ftl/backend/lease"
 	"github.com/block/ftl/backend/protos/xyz/block/ftl/buildengine/v1/buildenginepbconnect"
+	"github.com/block/ftl/backend/protos/xyz/block/ftl/lease/v1/leasepbconnect"
 	ftlv1 "github.com/block/ftl/backend/protos/xyz/block/ftl/v1"
 	"github.com/block/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
 	"github.com/block/ftl/backend/provisioner"
@@ -121,6 +122,8 @@ func (s *serveCommonConfig) run(
 	ctx = rpc.ContextWithClient(ctx, controllerClient)
 	schemaClient := rpc.Dial(ftlv1connect.NewSchemaServiceClient, s.SchemaEndpoint.String(), log.Error)
 	ctx = rpc.ContextWithClient(ctx, schemaClient)
+	leaseClient := rpc.Dial(leasepbconnect.NewLeaseServiceClient, s.Lease.Bind.String(), log.Error)
+	ctx = rpc.ContextWithClient(ctx, leaseClient)
 
 	// We must use our own event source here
 	// The injected one is connected to the admin client for CLI commands, we need this one to connect directly
@@ -263,7 +266,7 @@ func (s *serveCommonConfig) run(
 	controllerCtx := log.ContextWithLogger(ctx, logger.Scope("controller"))
 
 	wg.Go(func() error {
-		if err := controller.Start(controllerCtx, config, adminClient, schemaClient, true); err != nil {
+		if err := controller.Start(controllerCtx, config, adminClient, schemaClient, leaseClient, true); err != nil {
 			logger.Errorf(err, "controller failed: %v", err)
 			return fmt.Errorf("controller failed: %w", err)
 		}

--- a/go-runtime/ftl/leases.go
+++ b/go-runtime/ftl/leases.go
@@ -16,9 +16,9 @@ import (
 	leasepb "github.com/block/ftl/backend/protos/xyz/block/ftl/lease/v1"
 	leaseconnect "github.com/block/ftl/backend/protos/xyz/block/ftl/lease/v1/leasepbconnect"
 	"github.com/block/ftl/common/reflection"
+	"github.com/block/ftl/go-runtime/server/rpccontext"
 	"github.com/block/ftl/internal/deploymentcontext"
 	"github.com/block/ftl/internal/log"
-	"github.com/block/ftl/internal/rpc"
 )
 
 // ErrLeaseHeld is returned when an attempt is made to acquire a lease that is
@@ -161,7 +161,7 @@ type leaseClient struct {
 var _ deploymentcontext.LeaseClient = &leaseClient{}
 
 func (c *leaseClient) Acquire(ctx context.Context, module string, key []string, ttl time.Duration) error {
-	c.stream = rpc.ClientFromContext[leaseconnect.LeaseServiceClient](ctx).AcquireLease(ctx)
+	c.stream = rpccontext.ClientFromContext[leaseconnect.LeaseServiceClient](ctx).AcquireLease(ctx)
 	realKeys := []string{"module", module}
 	realKeys = append(realKeys, key...)
 	req := &leasepb.AcquireLeaseRequest{Key: realKeys, Ttl: durationpb.New(ttl)}

--- a/go-runtime/internal/impl.go
+++ b/go-runtime/internal/impl.go
@@ -15,8 +15,8 @@ import (
 	"github.com/block/ftl/common/encoding"
 	"github.com/block/ftl/common/reflection"
 	"github.com/block/ftl/common/schema"
+	"github.com/block/ftl/go-runtime/server/rpccontext"
 	"github.com/block/ftl/internal/deploymentcontext"
-	"github.com/block/ftl/internal/rpc"
 )
 
 type mapCacheEntry struct {
@@ -54,7 +54,7 @@ func (r *RealFTL) PublishEvent(ctx context.Context, topic *schema.Ref, event any
 	if topic.Module != caller.Module {
 		return fmt.Errorf("can not publish to another module's topic: %s", topic)
 	}
-	client := rpc.ClientFromContext[pubsubpbconnect.PublishServiceClient](ctx)
+	client := rpccontext.ClientFromContext[pubsubpbconnect.PublishServiceClient](ctx)
 	body, err := encoding.Marshal(event)
 	if err != nil {
 		return fmt.Errorf("failed to marshal event: %w", err)

--- a/go-runtime/server/rpccontext/context.go
+++ b/go-runtime/server/rpccontext/context.go
@@ -1,0 +1,36 @@
+package rpccontext
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+)
+
+type PingResponse[T any] interface {
+	*T
+	GetNotReady() string
+}
+
+type Pingable[Req any, Resp any, RespPtr PingResponse[Resp]] interface {
+	Ping(ctx context.Context, req *connect.Request[Req]) (*connect.Response[Resp], error)
+}
+
+type clientKey[Client Pingable[Req, Resp, RespPtr], Req any, Resp any, RespPtr PingResponse[Resp]] struct{}
+
+// ContextWithClient returns a context with an RPC client attached.
+func ContextWithClient[Client Pingable[Req, Resp, RespPtr], Req any, Resp any, RespPtr PingResponse[Resp]](ctx context.Context, client Client) context.Context {
+	return context.WithValue(ctx, clientKey[Client, Req, Resp, RespPtr]{}, client)
+}
+
+// ClientFromContext returns the given RPC client from the context, or panics.
+func ClientFromContext[Client Pingable[Req, Resp, RespPtr], Req any, Resp any, RespPtr PingResponse[Resp]](ctx context.Context) Client {
+	value := ctx.Value(clientKey[Client, Req, Resp, RespPtr]{})
+	if value == nil {
+		panic("no RPC client in context")
+	}
+	return value.(Client) //nolint:forcetypeassert
+}
+
+func IsClientAvailableInContext[Client Pingable[Req, Resp, RespPtr], Req any, Resp any, RespPtr PingResponse[Resp]](ctx context.Context) bool {
+	return ctx.Value(clientKey[Client, Req, Resp, RespPtr]{}) != nil
+}


### PR DESCRIPTION
Step 1 of removing rpc.ContextwithClient from the backend. This functionality was intended to only be used for the go-runtime, but has crept its way into normal backends.

It's problematic because it's "spooky action from a distance", failing at runtime.