### PR TITLE
chore: remove toml parsing from the JVM runtime

### DIFF
--- a/jvm-runtime/ftl-runtime/common/deployment/pom.xml
+++ b/jvm-runtime/ftl-runtime/common/deployment/pom.xml
@@ -45,10 +45,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.tomlj</groupId>
-            <artifactId>tomlj</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>

--- a/jvm-runtime/ftl-runtime/pom.xml
+++ b/jvm-runtime/ftl-runtime/pom.xml
@@ -60,8 +60,6 @@
         <version.formatter.plugin>2.25.0</version.formatter.plugin>
         <version.impsort.plugin>1.12.0</version.impsort.plugin>
         <kotlinpoet.version>2.1.0</kotlinpoet.version>
-        <tomlj.version>1.1.1</tomlj.version>
-        <antlr4-runtime.version>4.13.2</antlr4-runtime.version>
         <git-commit-id-plugin.version>9.0.1</git-commit-id-plugin.version>
     </properties>
 
@@ -116,11 +114,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <dependency>
-                <groupId>org.tomlj</groupId>
-                <artifactId>tomlj</artifactId>
-                <version>${tomlj.version}</version>
-            </dependency>
 
             <dependency>
                 <groupId>com.squareup</groupId>
@@ -165,11 +158,6 @@
                 <groupId>io.grpc</groupId>
                 <artifactId>grpc-stub</artifactId>
                 <version>${grpc.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.antlr</groupId>
-                <artifactId>antlr4-runtime</artifactId>
-                <version>${antlr4-runtime.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/jvm-runtime/plugin/common/jvmcommon.go
+++ b/jvm-runtime/plugin/common/jvmcommon.go
@@ -586,7 +586,7 @@ func launchQuarkusProcessAsync(ctx context.Context, devModeBuild string, buildCt
 		logger := log.FromContext(ctx)
 		logger.Infof("Using dev mode build command '%s'", devModeBuild)
 		command := exec.Command(ctx, log.Debug, buildCtx.Config.Dir, "bash", "-c", devModeBuild)
-		command.Env = append(command.Env, fmt.Sprintf("FTL_BIND=%s", bind), "MAVEN_OPTS=-Xmx1024m")
+		command.Env = append(command.Env, fmt.Sprintf("FTL_BIND=%s", bind), "MAVEN_OPTS=-Xmx1024m", "FTL_MODULE_NAME="+buildCtx.Config.Module)
 		command.Stdout = stdout
 		command.Stderr = os.Stderr
 		err := command.Run()
@@ -647,6 +647,7 @@ func build(ctx context.Context, bctx buildContext, autoRebuild bool) (*langpb.Bu
 	config := bctx.Config
 	logger.Infof("Using build command '%s'", config.Build)
 	command := exec.Command(ctx, log.Debug, config.Dir, "bash", "-c", config.Build)
+	command.Env = append(command.Env, "FTL_MODULE_NAME="+bctx.Config.Module)
 	command.Stdout = output
 	command.Stderr = os.Stderr
 	err = command.Run()


### PR DESCRIPTION
This lib is unmaintained, and uses an old version of antlr that results in annoying messages