### PR TITLE
feat: send debug and above logs to timeline from provisioner and plugins

### DIFF
--- a/backend/provisioner/service.go
+++ b/backend/provisioner/service.go
@@ -79,7 +79,7 @@ func Start(
 	schemaClient schemaconnect.SchemaServiceClient,
 	timelineClient *timeline.Client,
 ) error {
-	timelineLogSink := timeline.NewLogSink(timelineClient, log.Trace)
+	timelineLogSink := timeline.NewLogSink(timelineClient, log.Debug)
 	go timelineLogSink.RunLogLoop(ctx)
 	logger := log.FromContext(ctx).AddSink(timelineLogSink)
 	ctx = log.ContextWithLogger(ctx, logger)

--- a/cmd/ftl-provisioner-cloudformation/provisioner.go
+++ b/cmd/ftl-provisioner-cloudformation/provisioner.go
@@ -71,7 +71,7 @@ func NewCloudformationProvisioner(ctx context.Context, config Config) (context.C
 	}
 
 	timelineClient := timeline.NewClient(ctx, config.TimelineEndpoint)
-	timelineLogSink := timeline.NewLogSink(timelineClient, log.Info)
+	timelineLogSink := timeline.NewLogSink(timelineClient, log.Debug)
 	go timelineLogSink.RunLogLoop(ctx)
 	logger = logger.AddSink(timelineLogSink)
 	ctx = log.ContextWithLogger(ctx, logger)

--- a/cmd/ftl-provisioner-sandbox/provisioner.go
+++ b/cmd/ftl-provisioner-sandbox/provisioner.go
@@ -51,7 +51,7 @@ func NewSandboxProvisioner(ctx context.Context, config Config) (context.Context,
 	}
 
 	timelineClient := timeline.NewClient(ctx, config.TimelineEndpoint)
-	timelineLogSink := timeline.NewLogSink(timelineClient, log.Info)
+	timelineLogSink := timeline.NewLogSink(timelineClient, log.Debug)
 	go timelineLogSink.RunLogLoop(ctx)
 	logger = logger.AddSink(timelineLogSink)
 	ctx = log.ContextWithLogger(ctx, logger)


### PR DESCRIPTION
Changed log level from Info/Trace to Debug for timeline logging in:
- Main provisioner service
- CloudFormation provisioner plugin
- Sandbox provisioner plugin

This ensures all debug and above logs are sent to the timeline for better visibility into provisioning operations.