### PR TITLE
feat: `ftl call -v` prints out more info (just request key for now)

### DIFF
--- a/cmd/ftl/cmd_call.go
+++ b/cmd/ftl/cmd_call.go
@@ -27,7 +27,7 @@ type callCmd struct {
 	Wait    time.Duration  `short:"w" help:"Wait up to this elapsed time for the FTL cluster to become available." default:"1m"`
 	Verb    reflection.Ref `arg:"" required:"" help:"Full path of Verb to call." predictor:"verbs"`
 	Request string         `arg:"" optional:"" help:"JSON5 request payload." default:"{}"`
-	Info    bool           `flag:"info" short:"i" help:"Print extra information."`
+	Verbose bool           `flag:"" short:"v" help:"Print verbose information."`
 }
 
 func (c *callCmd) Run(
@@ -52,7 +52,7 @@ func (c *callCmd) Run(
 
 	logger.Debugf("Calling %s", c.Verb)
 
-	return callVerb(ctx, verbClient, schemaClient, c.Verb, requestJSON, c.Info)
+	return callVerb(ctx, verbClient, schemaClient, c.Verb, requestJSON, c.Verbose)
 }
 
 func callVerb(
@@ -61,7 +61,7 @@ func callVerb(
 	schemaClient *schemaeventsource.EventSource,
 	verb reflection.Ref,
 	requestJSON []byte,
-	printInfo bool,
+	verbose bool,
 ) error {
 	logger := log.FromContext(ctx)
 	// otherwise, we have a match so call the verb
@@ -82,7 +82,7 @@ func callVerb(
 		return err
 	}
 
-	if printInfo {
+	if verbose {
 		requestKey, ok, err := headers.GetRequestKey(resp.Header())
 		if err != nil {
 			return fmt.Errorf("could not get request key: %w", err)

--- a/cmd/ftl/cmd_replay.go
+++ b/cmd/ftl/cmd_replay.go
@@ -20,9 +20,9 @@ import (
 )
 
 type replayCmd struct {
-	Wait time.Duration  `short:"w" help:"Wait up to this elapsed time for the FTL cluster to become available." default:"1m"`
-	Verb reflection.Ref `arg:"" required:"" help:"Full path of Verb to call." predictor:"verbs"`
-	Info bool           `flag:"info" short:"i" help:"Print extra information."`
+	Wait    time.Duration  `short:"w" help:"Wait up to this elapsed time for the FTL cluster to become available." default:"1m"`
+	Verb    reflection.Ref `arg:"" required:"" help:"Full path of Verb to call." predictor:"verbs"`
+	Verbose bool           `flag:"" short:"v" help:"Print verbose information."`
 }
 
 func (c *replayCmd) Run(
@@ -99,5 +99,5 @@ func (c *replayCmd) Run(
 	logger.Infof("Calling %s with body:", c.Verb)
 	status.PrintJSON(ctx, []byte(requestJSON))
 	logger.Infof("Response:")
-	return callVerb(ctx, verbClient, eventSource, c.Verb, []byte(requestJSON), c.Info)
+	return callVerb(ctx, verbClient, eventSource, c.Verb, []byte(requestJSON), c.Verbose)
 }

--- a/cmd/ftl/cmd_replay.go
+++ b/cmd/ftl/cmd_replay.go
@@ -22,6 +22,7 @@ import (
 type replayCmd struct {
 	Wait time.Duration  `short:"w" help:"Wait up to this elapsed time for the FTL cluster to become available." default:"1m"`
 	Verb reflection.Ref `arg:"" required:"" help:"Full path of Verb to call." predictor:"verbs"`
+	Info bool           `flag:"info" short:"i" help:"Print extra information."`
 }
 
 func (c *replayCmd) Run(
@@ -98,5 +99,5 @@ func (c *replayCmd) Run(
 	logger.Infof("Calling %s with body:", c.Verb)
 	status.PrintJSON(ctx, []byte(requestJSON))
 	logger.Infof("Response:")
-	return callVerb(ctx, verbClient, eventSource, c.Verb, []byte(requestJSON))
+	return callVerb(ctx, verbClient, eventSource, c.Verb, []byte(requestJSON), c.Info)
 }

--- a/internal/routing/verb_routing.go
+++ b/internal/routing/verb_routing.go
@@ -85,6 +85,7 @@ func (s *VerbCallRouter) Call(ctx context.Context, req *connect.Request[ftlv1.Ca
 	callEvent.Response = result.Ok(resp.Msg)
 	s.timelineClient.Publish(ctx, callEvent)
 	observability.Calls.Request(ctx, req.Msg.Verb, start, optional.None[string]())
+	headers.SetRequestKey(resp.Header(), requestKey)
 	return resp, nil
 }
 


### PR DESCRIPTION
- It can be helpful to know the request key to then understand what happened as part of the call (via the timeline)
    - Goose will make use of this
- We will probably want more info in the future so i made the flag not request key specific
- Verb router now includes the request key in the call response it creates