### PR TITLE
feat: Logs via timeline in `dev` mode

### DIFF
--- a/backend/provisioner/service.go
+++ b/backend/provisioner/service.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"connectrpc.com/connect"
@@ -20,6 +21,7 @@ import (
 	"github.com/block/ftl/backend/provisioner/scaling"
 	"github.com/block/ftl/common/reflect"
 	"github.com/block/ftl/common/schema"
+	"github.com/block/ftl/common/slices"
 	"github.com/block/ftl/internal/channels"
 	"github.com/block/ftl/internal/key"
 	"github.com/block/ftl/internal/log"
@@ -282,7 +284,10 @@ func (s *Service) deProvision(ctx context.Context, cs key.Changeset, modules []*
 
 func (s *Service) HandleChangesetPreparing(ctx context.Context, req *schema.Changeset) error {
 	mLogger := log.FromContext(ctx).Changeset(req.Key)
-	mLogger.Infof("Starting deployment for changeset %s", req.Key) //nolint:forbidigo
+	moduleNames := slices.Map(req.Modules, func(m *schema.Module) string {
+		return m.Name
+	})
+	mLogger.Infof("Starting deployment for changeset %s [%s]", req.Key, strings.Join(moduleNames, ",")) //nolint:forbidigo
 	group := errgroup.Group{}
 	// TODO: Block deployments to make sure only one module is modified at a time
 	for _, module := range req.Modules {

--- a/backend/provisioner/service.go
+++ b/backend/provisioner/service.go
@@ -217,6 +217,11 @@ func (s *Service) HandleChangesetCommitted(ctx context.Context, req *schema.Chan
 func (s *Service) HandleChangesetDrained(ctx context.Context, cs key.Changeset) error {
 	logger := log.FromContext(ctx).Changeset(cs)
 	changeset := s.eventSource.ActiveChangesets()[cs]
+
+	moduleNames := slices.Map(changeset.Modules, func(m *schema.Module) string {
+		return m.Name
+	})
+
 	err := s.deProvision(ctx, cs, changeset.RemovingModules)
 	if err != nil {
 		return err
@@ -225,7 +230,7 @@ func (s *Service) HandleChangesetDrained(ctx context.Context, cs key.Changeset) 
 	if err != nil {
 		return fmt.Errorf("error finalizing changeset: %w", err)
 	}
-	logger.Infof("Successfully completed deployment for changeset %s", cs) //nolint:forbidigo
+	logger.Infof("Successfully completed deployment for changeset %s [%s]", cs, strings.Join(moduleNames, ",")) //nolint:forbidigo
 	return nil
 }
 

--- a/cmd/ftl-lease/main.go
+++ b/cmd/ftl-lease/main.go
@@ -27,7 +27,7 @@ func main() {
 		kong.Vars{"version": ftl.FormattedVersion},
 	)
 
-	ctx := log.ContextWithLogger(context.Background(), log.Configure(os.Stderr, cli.LogConfig))
+	ctx := log.ContextWithLogger(context.Background(), log.Configure(os.Stderr, cli.LogConfig).Scope("lease"))
 	err := observability.Init(ctx, false, "", "ftl-lease", ftl.Version, cli.ObservabilityConfig)
 	kctx.FatalIfErrorf(err, "failed to initialize observability")
 

--- a/cmd/ftl-provisioner/main.go
+++ b/cmd/ftl-provisioner/main.go
@@ -37,7 +37,7 @@ func main() {
 	)
 	cli.ProvisionerConfig.SetDefaults()
 
-	logger := log.Configure(os.Stderr, cli.LogConfig)
+	logger := log.Configure(os.Stderr, cli.LogConfig).Scope("provisioner")
 	ctx := log.ContextWithLogger(context.Background(), logger)
 	timelineClient := timeline.NewClient(ctx, cli.ProvisionerConfig.TimelineEndpoint)
 	err := observability.Init(ctx, false, "", "ftl-provisioner", ftl.Version, cli.ObservabilityConfig)

--- a/cmd/ftl-proxy-pg/main.go
+++ b/cmd/ftl-proxy-pg/main.go
@@ -27,7 +27,7 @@ func main() {
 		kong.Vars{"version": ftl.FormattedVersion},
 	)
 
-	ctx := log.ContextWithLogger(context.Background(), log.Configure(os.Stderr, cli.LogConfig))
+	ctx := log.ContextWithLogger(context.Background(), log.Configure(os.Stderr, cli.LogConfig).Scope("proxy-pg"))
 	err := observability.Init(ctx, false, "", "ftl-provisioner", ftl.Version, cli.ObservabilityConfig)
 	kctx.FatalIfErrorf(err, "failed to initialize observability")
 

--- a/cmd/ftl-schema/main.go
+++ b/cmd/ftl-schema/main.go
@@ -32,7 +32,7 @@ func main() {
 		},
 	)
 
-	ctx := log.ContextWithLogger(context.Background(), log.Configure(os.Stderr, cli.LogConfig))
+	ctx := log.ContextWithLogger(context.Background(), log.Configure(os.Stderr, cli.LogConfig).Scope("schema"))
 	err := observability.Init(ctx, false, "", "ftl-controller", ftl.Version, cli.ObservabilityConfig)
 	kctx.FatalIfErrorf(err, "failed to initialize observability")
 

--- a/cmd/ftl-timeline/main.go
+++ b/cmd/ftl-timeline/main.go
@@ -27,7 +27,7 @@ func main() {
 		kong.Vars{"version": ftl.FormattedVersion},
 	)
 
-	ctx := log.ContextWithLogger(context.Background(), log.Configure(os.Stderr, cli.LogConfig))
+	ctx := log.ContextWithLogger(context.Background(), log.Configure(os.Stderr, cli.LogConfig).Scope("timeline"))
 	err := observability.Init(ctx, false, "", "ftl-timeline", ftl.Version, cli.ObservabilityConfig)
 	kctx.FatalIfErrorf(err, "failed to initialize observability")
 

--- a/cmd/ftl/cmd_dev.go
+++ b/cmd/ftl/cmd_dev.go
@@ -106,8 +106,14 @@ func (d *devCmd) Run(
 	// cmdServe will notify this channel when startup commands are complete and the controller is ready
 	controllerReady := make(chan bool, 1)
 	if !d.NoServe {
+		// We don't want to log the server messages directly. We will log them via the timeline
+		// to make sure the experience is consistent with remote deployments.
+		//
+		// The underlying systems will attach a timeline sink to this logger to log events to the timeline.
+		sctx := log.ContextWithLogger(ctx, log.New(log.Trace, log.NewNoopSink()))
+
 		if d.ServeCmd.Stop {
-			err := d.ServeCmd.run(ctx, projConfig, cm, sm, optional.Some(controllerReady), true, bindAllocator, timelineClient, adminClient, buildEngineClient, true, devModeEndpointUpdates)
+			err := d.ServeCmd.run(sctx, projConfig, cm, sm, optional.Some(controllerReady), true, bindAllocator, timelineClient, adminClient, buildEngineClient, true, devModeEndpointUpdates)
 			if err != nil {
 				return fmt.Errorf("failed to stop server: %w", err)
 			}
@@ -115,7 +121,7 @@ func (d *devCmd) Run(
 		}
 
 		g.Go(func() error {
-			err := d.ServeCmd.run(ctx, projConfig, cm, sm, optional.Some(controllerReady), true, bindAllocator, timelineClient, adminClient, buildEngineClient, true, devModeEndpointUpdates)
+			err := d.ServeCmd.run(sctx, projConfig, cm, sm, optional.Some(controllerReady), true, bindAllocator, timelineClient, adminClient, buildEngineClient, true, devModeEndpointUpdates)
 			if err != nil {
 				cancel(fmt.Errorf("dev server failed: %w: %w", context.Canceled, err))
 			} else {

--- a/internal/buildengine/deploy.go
+++ b/internal/buildengine/deploy.go
@@ -335,8 +335,11 @@ func (c *DeployCoordinator) tryDeployFromQueue(ctx context.Context, deployment *
 
 	// No conflicts, lets deploy
 
+	var moduleNames []string
+
 	// Deploy all collected modules
 	for _, module := range deployment.modules {
+		moduleNames = append(moduleNames, module.name)
 		c.engineUpdates <- &buildenginepb.EngineEvent{
 			Event: &buildenginepb.EngineEvent_ModuleDeployStarted{
 				ModuleDeployStarted: &buildenginepb.ModuleDeployStarted{
@@ -383,7 +386,7 @@ func (c *DeployCoordinator) tryDeployFromQueue(ctx context.Context, deployment *
 	if key, ok := (<-keyChan).Get(); ok {
 		logger := log.FromContext(ctx)
 		deployment.changeset = optional.Some(key)
-		logger.Infof("Created changeset %s", key) //nolint:forbidigo
+		logger.Infof("Created changeset %s [%s]", key, strings.Join(moduleNames, ",")) //nolint:forbidigo
 		go func() {
 			stream, err := c.adminClient.StreamChangesetLogs(ctx, connect.NewRequest(&adminpb.StreamChangesetLogsRequest{
 				ChangesetKey: key.String(),

--- a/internal/log/logger.go
+++ b/internal/log/logger.go
@@ -191,3 +191,12 @@ func writerFinalizer(writer *io.PipeWriter) {
 func SetCurrentLevel(l *Logger, level Level) {
 	l.level.Store(level)
 }
+
+// NewNoopSink returns a sink that does nothing.
+func NewNoopSink() Sink {
+	return noopSink{}
+}
+
+type noopSink struct{}
+
+func (noopSink) Log(entry Entry) error { return nil }


### PR DESCRIPTION
Previously, in the dev mode, we were logging events both via the timeline, and directly to stdout. This removes stdout logging so all log events are logged from the timeline.

This also guarantees that the logs look same in local and remote deployments.