### PR TITLE
fix: do not log from timeline in dev mode

### DIFF
--- a/cmd/ftl/cmd_build.go
+++ b/cmd/ftl/cmd_build.go
@@ -44,6 +44,7 @@ func (b *buildCmd) Run(
 		projConfig,
 		b.Dirs,
 		b.UpdatesEndpoint,
+		false,
 		buildengine.BuildEnv(b.BuildEnv),
 		buildengine.Parallelism(b.Parallelism),
 	)

--- a/cmd/ftl/cmd_deploy.go
+++ b/cmd/ftl/cmd_deploy.go
@@ -37,7 +37,7 @@ func (d *deployCmd) Run(
 		defer cancel(fmt.Errorf("stopping deploy: %w", context.Canceled))
 	}
 	engine, err := buildengine.New(
-		ctx, adminClient, schemaSource, projConfig, d.Build.Dirs, d.Build.UpdatesEndpoint,
+		ctx, adminClient, schemaSource, projConfig, d.Build.Dirs, d.Build.UpdatesEndpoint, true,
 		buildengine.BuildEnv(d.Build.BuildEnv),
 		buildengine.Parallelism(d.Build.Parallelism),
 	)

--- a/internal/buildengine/engine.go
+++ b/internal/buildengine/engine.go
@@ -159,6 +159,7 @@ func New(
 	projectConfig projectconfig.Config,
 	moduleDirs []string,
 	updatesEndpoint *url.URL,
+	logChanges bool,
 	options ...Option,
 ) (*Engine, error) {
 	ctx = log.ContextWithLogger(ctx, log.FromContext(ctx).Scope("build-engine"))
@@ -179,7 +180,7 @@ func New(
 		arch:             runtime.GOARCH, // Default to the local env, we attempt to read these from the cluster later
 		os:               runtime.GOOS,
 	}
-	e.deployCoordinator = NewDeployCoordinator(ctx, adminClient, schemaSource, e, rawEngineUpdates)
+	e.deployCoordinator = NewDeployCoordinator(ctx, adminClient, schemaSource, e, rawEngineUpdates, logChanges)
 	for _, option := range options {
 		option(e)
 	}

--- a/internal/buildengine/engine_test.go
+++ b/internal/buildengine/engine_test.go
@@ -31,7 +31,7 @@ func TestGraph(t *testing.T) {
 
 	endpoint, err := url.Parse("http://localhost:8900")
 	assert.NoError(t, err)
-	engine, err := buildengine.New(ctx, nil, schemaeventsource.NewUnattached(), projConfig, []string{"testdata/alpha", "testdata/other", "testdata/another"}, endpoint)
+	engine, err := buildengine.New(ctx, nil, schemaeventsource.NewUnattached(), projConfig, []string{"testdata/alpha", "testdata/other", "testdata/another"}, endpoint, true)
 	assert.NoError(t, err)
 
 	defer engine.Close()


### PR DESCRIPTION
Getting this working reliably requires a bit more work, so lets just disable it for now and log directly from all submodules.

closes https://github.com/block/ftl/issues/4838