### PR TITLE
fix: no failed to stream changeset logs error if the ctx is cancelled

### DIFF
--- a/internal/buildengine/deploy.go
+++ b/internal/buildengine/deploy.go
@@ -425,6 +425,9 @@ func (c *DeployCoordinator) runChangeLogger(ctx context.Context, key key.Changes
 			},
 		},
 	}))
+	if errors.Is(err, context.Canceled) {
+		return
+	}
 	if err != nil {
 		logger.Errorf(err, "failed to stream changeset logs")
 		return


### PR DESCRIPTION
Removes occasional
```
error:build-engine: failed to stream changeset logs: canceled: context canceled
```