### PR TITLE
chore: wire up OpenAPI spec to /.well-known/service-desc

### DIFF
--- a/backend/ingress/handler.go
+++ b/backend/ingress/handler.go
@@ -25,6 +25,10 @@ func (s *service) handleHTTP(startTime time.Time, sch *schema.Schema, requestKey
 	logger := log.FromContext(r.Context()).Scope(fmt.Sprintf("ingress:%s:%s", r.Method, r.URL.Path))
 	logger.Debugf("Start ingress request")
 
+	if ServeOpenAPI(sch, w, r) {
+		return
+	}
+
 	routeOpt := getIngressRoute(routesForMethod, r.URL.Path)
 	var route *ingressRoute
 	var ok bool


### PR DESCRIPTION
```
~/dev/ftl $ curl -i http://127.0.0.1:8891/.well-known/service-desc
HTTP/1.1 200 OK
Content-Type: application/vnd.oai.openapi+json; version=2.0
Vary: Origin
Date: Thu, 13 Mar 2025 04:14:10 GMT
Content-Length: 1786

{"swagger":"2.0","info":{"description":"API generated from FTL schema","title":"FTL API","version":"1.0.0"},"paths":{"/get/{name}":{"get":{"description":"Example usage of path and query params\ncurl http://localhost:8891/get/wicket?age=10","consumes":["application/json"],"produces":["application/json"],"operationId":"http.get","parameters":[{"name":"name","in":"path","required":true,"schema":{"type":"string"}},{"name":"age","in":"query","schema":{"type":"integer","format":"int64"}}],"responses":{"200":{"description":"Successful response","schema":{"$ref":"#/definitions/http.GetResponse"}},"400":{"description":"Error response","schema":{"$ref":"#/definitions/http.ApiError"}}}}},"/post":{"post":{"description":"Example POST request with a JSON body\ncurl -X POST http://localhost:8891/post -d '{\"name\": \"wicket\", \"age\": 10}'","consumes":["application/json"],"produces":["application/json"],"operationId":"http.post","parameters":[{"name":"body","in":"body","required":true,"schema":{"$ref":"#/definitions/http.PostRequest"}}],"responses":{"200":{"description":"Successful response","schema":{"$ref":"#/definitions/http.PostResponse"}},"400":{"description":"Error response","schema":{"$ref":"#/definitions/http.ApiError"}}}}}},"definitions":{"http.ApiError":{"type":"object","required":["message"],"properties":{"message":{"type":"string"}}},"http.GetResponse":{"type":"object","required":["name"],"properties":{"age":{"type":"integer","format":"int64"},"name":{"type":"string"}}},"http.PostRequest":{"type":"object","required":["name","age"],"properties":{"age":{"type":"integer","format":"int64"},"name":{"type":"string"}}},"http.PostResponse":{"type":"object","required":["name","age"],"properties":{"age":{"type":"integer","format":"int64"},"name":{"type":"string"}}}}}
```