### PR TITLE
fix: add positions to more go build errors

### DIFF
--- a/common/builderrors/builderrors.go
+++ b/common/builderrors/builderrors.go
@@ -10,7 +10,6 @@ import (
 
 type Position struct {
 	Filename    string
-	Offset      int
 	StartColumn int
 	EndColumn   int
 	Line        int
@@ -77,21 +76,21 @@ func Errorf(pos Position, format string, args ...any) Error {
 	return makeError(ERROR, pos, format, args...)
 }
 
-func Wrapf(pos Position, endColumn int, err error, format string, args ...any) Error {
+// Wrapf wraps an error with a new message and adds position if no existing position exists.
+func Wrapf(err error, pos Position, format string, args ...any) Error {
 	if format == "" {
 		format = "%s"
 	} else {
 		format += ": %s"
 	}
 	// Propagate existing error position if available
-	var newPos Position
+	newPos := pos
 	if perr := (Error{}); errors.As(err, &perr) {
 		if existingPos, ok := perr.Pos.Get(); ok {
 			newPos = existingPos
 		}
 		args = append(args, perr.Msg)
 	} else {
-		newPos = pos
 		args = append(args, err)
 	}
 	return makeError(ERROR, newPos, format, args...)

--- a/common/schema/parser.go
+++ b/common/schema/parser.go
@@ -84,7 +84,6 @@ func (p Position) ToErrorPos() builderrors.Position {
 func (p Position) ToErrorPosWithEnd(endColumn int) builderrors.Position {
 	return builderrors.Position{
 		Filename:    p.Filename,
-		Offset:      p.Offset,
 		Line:        p.Line,
 		StartColumn: p.Column,
 		EndColumn:   endColumn,

--- a/go-runtime/compile/build.go
+++ b/go-runtime/compile/build.go
@@ -2,6 +2,7 @@ package compile
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -440,6 +441,10 @@ func (s *OngoingState) reset() {
 }
 
 func buildErrorFromError(err error) builderrors.Error {
+	var buildErr builderrors.Error
+	if errors.As(err, &buildErr) {
+		return buildErr
+	}
 	return builderrors.Error{
 		Type:  builderrors.FTL,
 		Msg:   err.Error(),

--- a/go-runtime/compile/build.go
+++ b/go-runtime/compile/build.go
@@ -1977,7 +1977,7 @@ func addImports(existingImports map[string]string, newTypes ...nativeType) map[s
 	return imports
 }
 
-func wrapErrWithPos(err error, pos schema.Position, format string, args ...any) error {
+func wrapErrWithPos(err error, pos schema.Position, format string) error {
 	if err == nil {
 		return nil
 	}
@@ -1985,5 +1985,5 @@ func wrapErrWithPos(err error, pos schema.Position, format string, args ...any) 
 	if pos == zero {
 		return err
 	}
-	return builderrors.Wrapf(err, pos.ToErrorPos(), format, args...)
+	return builderrors.Wrapf(err, pos.ToErrorPos(), format)
 }

--- a/go-runtime/compile/build.go
+++ b/go-runtime/compile/build.go
@@ -1121,10 +1121,12 @@ func (b *mainDeploymentContextBuilder) visitingMainModule(moduleName string) boo
 	return moduleName == b.mainModule.Name
 }
 
-func (b *mainDeploymentContextBuilder) processSumType(module *schema.Module, enum *schema.Enum) (goSumType, error) {
+func (b *mainDeploymentContextBuilder) processSumType(module *schema.Module, enum *schema.Enum) (out goSumType, err error) {
+	defer func() {
+		err = wrapErrWithPos(err, enum.Pos, "")
+	}()
 	moduleName := module.Name
 	var nt nativeType
-	var err error
 	if !b.visitingMainModule(moduleName) {
 		nt, err = nativeTypeFromQualifiedName("ftl/" + moduleName + "." + enum.Name)
 	} else if nn, ok := b.nativeNames[enum]; ok {
@@ -1144,15 +1146,15 @@ func (b *mainDeploymentContextBuilder) processSumType(module *schema.Module, enu
 		} else if nn, ok := b.nativeNames[v]; ok {
 			vnt, err = b.getNativeType(nn)
 		} else {
-			return goSumType{}, fmt.Errorf("missing native name for enum variant %s", enum.Name)
+			return goSumType{}, wrapErrWithPos(fmt.Errorf("missing native name for enum variant %s", enum.Name), v.Pos, "")
 		}
 		if err != nil {
-			return goSumType{}, err
+			return goSumType{}, wrapErrWithPos(err, v.Pos, "")
 		}
 
 		typ, err := b.getGoSchemaType(v.Value.(*schema.TypeValue).Value)
 		if err != nil {
-			return goSumType{}, err
+			return goSumType{}, wrapErrWithPos(err, v.Pos, "")
 		}
 		variants = append(variants, goSumTypeVariant{
 			Type:       typ,
@@ -1261,7 +1263,10 @@ func (b *mainDeploymentContextBuilder) getVerbResource(verb *schema.Verb, param 
 	}
 }
 
-func (b *mainDeploymentContextBuilder) processConfig(moduleName string, ref *schema.Ref, config *schema.Config) (goConfigHandle, error) {
+func (b *mainDeploymentContextBuilder) processConfig(moduleName string, ref *schema.Ref, config *schema.Config) (out goConfigHandle, err error) {
+	defer func() {
+		err = wrapErrWithPos(err, config.Pos, "")
+	}()
 	nn, ok := b.nativeNames[ref]
 	if !ok {
 		return goConfigHandle{}, fmt.Errorf("missing native name for config %s.%s", moduleName, config.Name)
@@ -1284,7 +1289,10 @@ func (b *mainDeploymentContextBuilder) processConfig(moduleName string, ref *sch
 	}, nil
 }
 
-func (b *mainDeploymentContextBuilder) processSecret(moduleName string, ref *schema.Ref, secret *schema.Secret) (goSecretHandle, error) {
+func (b *mainDeploymentContextBuilder) processSecret(moduleName string, ref *schema.Ref, secret *schema.Secret) (out goSecretHandle, err error) {
+	defer func() {
+		err = wrapErrWithPos(err, secret.Pos, "")
+	}()
 	nn, ok := b.nativeNames[ref]
 	if !ok {
 		return goSecretHandle{}, fmt.Errorf("missing native name for secret %s.%s", moduleName, secret.Name)
@@ -1320,7 +1328,10 @@ func (b *mainDeploymentContextBuilder) processDatabase(moduleName string, db *sc
 	}, nil
 }
 
-func (b *mainDeploymentContextBuilder) processTopic(moduleName string, ref *schema.Ref, topic *schema.Topic) (goTopicHandle, error) {
+func (b *mainDeploymentContextBuilder) processTopic(moduleName string, ref *schema.Ref, topic *schema.Topic) (out goTopicHandle, err error) {
+	defer func() {
+		err = wrapErrWithPos(err, topic.Pos, "")
+	}()
 	nn, ok := b.nativeNames[ref]
 	if !ok {
 		return goTopicHandle{}, fmt.Errorf("missing native name for topic %s.%s", moduleName, topic.Name)
@@ -1362,18 +1373,18 @@ func (b *mainDeploymentContextBuilder) processTopic(moduleName string, ref *sche
 	}, nil
 }
 
-func (b *mainDeploymentContextBuilder) getGoVerb(nativeName string, verb *schema.Verb, resources ...verbResource) (goVerb, error) {
+func (b *mainDeploymentContextBuilder) getGoVerb(nativeName string, verb *schema.Verb, resources ...verbResource) (out goVerb, err error) {
 	nt, err := b.getNativeType(nativeName)
 	if err != nil {
-		return goVerb{}, err
+		return goVerb{}, wrapErrWithPos(err, verb.Pos, "")
 	}
 	req, err := b.getGoSchemaType(verb.Request)
 	if err != nil {
-		return goVerb{}, err
+		return goVerb{}, wrapErrWithPos(err, verb.Pos, "could not parse request type")
 	}
 	resp, err := b.getGoSchemaType(verb.Response)
 	if err != nil {
-		return goVerb{}, err
+		return goVerb{}, wrapErrWithPos(err, verb.Pos, "could not parse response type")
 	}
 	return goVerb{
 		Name:       verb.Name,
@@ -1384,7 +1395,12 @@ func (b *mainDeploymentContextBuilder) getGoVerb(nativeName string, verb *schema
 	}, nil
 }
 
-func (b *mainDeploymentContextBuilder) getGoSchemaType(typ schema.Type) (goSchemaType, error) {
+func (b *mainDeploymentContextBuilder) getGoSchemaType(typ schema.Type) (out goSchemaType, err error) {
+	defer func() {
+		if typ != nil {
+			err = wrapErrWithPos(err, typ.Position(), "")
+		}
+	}()
 	typeName, err := genTypeWithNativeNames(nil, typ, b.nativeNames)
 	if err != nil {
 		return goSchemaType{}, err
@@ -1959,4 +1975,15 @@ func addImports(existingImports map[string]string, newTypes ...nativeType) map[s
 		}
 	}
 	return imports
+}
+
+func wrapErrWithPos(err error, pos schema.Position, format string, args ...any) error {
+	if err == nil {
+		return nil
+	}
+	var zero = schema.Position{}
+	if pos == zero {
+		return err
+	}
+	return builderrors.Wrapf(err, pos.ToErrorPos(), format, args...)
 }

--- a/go-runtime/schema/common/common.go
+++ b/go-runtime/schema/common/common.go
@@ -367,7 +367,7 @@ func extractType(pass *analysis.Pass, node ast.Node) optional.Option[schema.Type
 		default:
 			return optional.None[schema.Type]()
 		}
-		return optional.Some[schema.Type](t)
+		return optional.Some(t)
 	}
 
 	return optional.None[schema.Type]()

--- a/go-runtime/schema/extract.go
+++ b/go-runtime/schema/extract.go
@@ -484,7 +484,6 @@ func goQualifiedNameForWidenedType(obj types.Object, metadata []schema.Metadata)
 func toErrorPos(pos token.Position, end token.Position) builderrors.Position {
 	return builderrors.Position{
 		Filename:    pos.Filename,
-		Offset:      pos.Offset,
 		Line:        pos.Line,
 		StartColumn: pos.Column,
 		EndColumn:   end.Column,


### PR DESCRIPTION
This module code:
```go
//ftl:verb
func Verb(ctx context.Context, req struct{}) (TimeResponse, error) {
	return TimeResponse{Time: time.Now()}, nil
}
```
Would previously give this build error which lacks any information of where to find the bad code:
`error:time:build: Build failed: unsupported type <nil>`

We now try and attach the best position available to errors that occur in various places of `build/compile.go`, so now we get this error:
`error:time:build: Build failed: /Users/mtoohey/Code/ftl/examples/go/time/time.go:30:1: could not parse request type: unsupported type <nil>`

At this point in the code the verb's request type does not have any position information so it is given the position of the verb instead (ie column 1).