### PR TITLE
fix: JSON validation now properly handles non-integer values

### DIFF
--- a/common/schema/jsonvalidate.go
+++ b/common/schema/jsonvalidate.go
@@ -64,8 +64,13 @@ func validateJSONValue(fieldType Type, path path, value any, sch *Schema, opts *
 
 	case *Int:
 		switch value := value.(type) {
-		case int64, float64:
+		case int64:
 			typeMatches = true
+		case float64:
+			// Check if the float64 is a whole number
+			if value == float64(int64(value)) {
+				typeMatches = true
+			}
 		case string:
 			if _, err := strconv.ParseInt(value, 10, 64); err == nil {
 				typeMatches = true

--- a/common/schema/jsonvalidate_test.go
+++ b/common/schema/jsonvalidate_test.go
@@ -188,6 +188,17 @@ module echo {
 			input: `{"name": "juho", "age": 123, "weight": 0.045}`,
 		},
 		{
+			name:  "valid integer as float",
+			ref:   &Ref{Module: "echo", Name: "echo"},
+			input: `{"name": "juho", "age": 123.0, "weight": 0.045}`,
+		},
+		{
+			name:    "invalid float for integer",
+			ref:     &Ref{Module: "echo", Name: "echo"},
+			input:   `{"name": "juho", "age": 123.5, "weight": 0.045}`,
+			wantErr: "age has wrong type, expected Int found float64",
+		},
+		{
 			name:    "invalid input",
 			ref:     &Ref{Module: "echo", Name: "echo"},
 			input:   `{"name": "juho", "age": 123, "weight": "too much"}`,


### PR DESCRIPTION
Issue #4863: JSON validation now properly checks that float values used as integers are whole numbers. This prevents the internal server error that occurred when passing non-whole numbers (e.g., 1.5) to integer fields.

- Accepts: integers (123) and whole number floats (123.0)
- Rejects: non-whole number floats (123.5) with proper validation error
- Added test cases to verify this behavior