### PR TITLE
feat: MCP reads and writes files and can proactively provide info

### DIFF
--- a/cmd/ftl/goose_instructions.txt
+++ b/cmd/ftl/goose_instructions.txt
@@ -38,15 +38,15 @@ When creating a database module, do so in this order:
 ## Schema
 
 Schema represents all types, functions and resources within an FTL cluster.
-Each of these are bundled together into modules and some of them can be exported so that it is visible to other modules I the cluster.
-FTL extracts the schema for each module from the module code	
+Each of these are bundled together into modules and some of them can be exported so that it is visible to other modules in the cluster.
+FTL extracts the schema for each module from the module code.
 
 The casing can differ in the schema compared to the original code as each language has its own casing expectations. Modules are always lowercase.
-All declarations within a module are lowerCamelCase (eg `examplemodule.getUsers`) except for Type definitions which are UpperCamelCase (eg `examplemodule.ExampleType`)
+All declarations within a module are lowerCamelCase (eg `examplemodule.getUsers`) except for Type definitions which are UpperCamelCase (eg `examplemodule.ExampleType`).
 
 ## Verbs
 
-Verbs are the functional building blocks of FTL. There are 4 kinds of verbs, but any of them can be called verbs. :
+Verbs are the functional building blocks of FTL. There are 4 kinds of verbs, but any of them can be called verbs:
 - has a request and a response type: these are just called verbs
 - has a request type but no response type: sink verb
 - has no request type but has a response type: source verb
@@ -90,5 +90,6 @@ Be proactive about calling this command, it is your job to know the state of the
 - If creating a new module fails because it was not in the expected module directories, create the module in one of the recommended directories, unless the user explicitly told you where to create the module
 - You do not need to activate or install hermit or its packages
 - There is no need to log errors before returning them
+- Use FTL's Read and Write tools instead of the developer text_editor tool when reading or writing FTL module files.
 
 # The user's prompt:

--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 	github.com/radovskyb/watcher v1.0.7
 	github.com/rs/cors v1.11.1
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
+	github.com/sergi/go-diff v1.3.1
 	github.com/sqlc-dev/sqlc v1.28.0
 	github.com/swaggest/jsonschema-go v0.3.73
 	github.com/tidwall/pretty v1.2.1

--- a/internal/mcp/cli.go
+++ b/internal/mcp/cli.go
@@ -237,7 +237,7 @@ func ToolFromCLI(serverCtx context.Context, k *kong.Kong, projectConfig projectc
 			annotateTextContent(mcp.NewTextContent(cliResult), []mcp.Role{mcp.RoleAssistant}, 1.0),
 		}
 		if config.AutoReadFilePaths {
-			content = append(content, autoReadFilePaths(serverCtx, projectConfig, cliResult)...)
+			content = append(content, autoReadFilePaths(projectConfig, cliResult)...)
 		}
 		if config.IncludeStatus {
 			if statusContent, err := statusContent(serverCtx, buildEngineClient, adminClient); err == nil {
@@ -367,7 +367,7 @@ func statusContent(ctx context.Context, buildEngineClient buildenginepbconnect.B
 	return annotateTextContent(mcp.NewTextContent(string(statusJSON)), []mcp.Role{mcp.RoleAssistant}, 1.0), nil
 }
 
-func autoReadFilePaths(ctx context.Context, projectConfig projectconfig.Config, cliOutput string) []mcp.Content {
+func autoReadFilePaths(projectConfig projectconfig.Config, cliOutput string) []mcp.Content {
 	var contents []mcp.Content
 	root := projectConfig.Root()
 	for _, word := range strings.Fields(cliOutput) {

--- a/internal/mcp/readwrite.go
+++ b/internal/mcp/readwrite.go
@@ -1,0 +1,195 @@
+package mcp
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/block/ftl/backend/protos/xyz/block/ftl/admin/v1/adminpbconnect"
+	"github.com/block/ftl/backend/protos/xyz/block/ftl/buildengine/v1/buildenginepbconnect"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/sergi/go-diff/diffmatchpatch"
+)
+
+type readResult struct {
+	Explanation            string `json:"explanation,omitempty"`
+	FileContent            string `json:"fileContent"`
+	WriteVerificationToken string `json:"writeVerificationToken"`
+}
+
+func ReadTool() (tool mcp.Tool, handler server.ToolHandlerFunc) {
+	return mcp.NewTool(
+			"Read",
+			mcp.WithDescription(`Read a text file within an FTL module. This is better than other ways of reading these files as it can be used safely with FTL's Write tool with the verification token that this tool returns.
+				Make sure you read every file before you overwrite it so you do not accidentally alter data or code.`),
+			mcp.WithString("path", mcp.Description("Path to the file to read")),
+		), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			path, ok := request.Params.Arguments["path"].(string)
+			if !ok {
+				return nil, fmt.Errorf("path is required")
+			}
+			fileContent, err := os.ReadFile(path)
+			if err != nil {
+				return nil, fmt.Errorf("could not read file: %w", err)
+			}
+			token, err := tokenForFileContent(fileContent)
+			if err != nil {
+				return nil, fmt.Errorf("could not generate verification token: %w", err)
+			}
+			return newReadResult(fileContent, token, false, "")
+		}
+}
+
+func newReadResult(fileContent []byte, token string, isError bool, explanation string) (*mcp.CallToolResult, error) {
+	readResult := &readResult{
+		FileContent:            string(fileContent),
+		WriteVerificationToken: token,
+		Explanation:            explanation,
+	}
+	outputBytes, err := json.Marshal(readResult)
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal read result: %w", err)
+	}
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			annotateTextContent(mcp.NewTextContent(string(outputBytes)), []mcp.Role{mcp.RoleAssistant}, 1.0),
+		},
+		IsError: isError,
+	}, nil
+}
+
+type writeResult struct {
+	StatusExplanation    string       `json:"statusExplanation,omitempty"`
+	Status               statusOutput `json:"status,omitempty"`
+	TokenExplanation     string       `json:"tokenExplanation,omitempty"`
+	NewVerificationToken string       `json:"newVerificationToken"`
+}
+
+func WriteTool(serverCtx context.Context, buildEngineClient buildenginepbconnect.BuildEngineServiceClient,
+	adminClient adminpbconnect.AdminServiceClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+	return mcp.NewTool(
+			"Write",
+			mcp.WithDescription(`Write a file withiin an FTL module. This is better than other ways of writing these files as it also prevents writing files in the wrong places and returns the FTL status after the change.
+			Be careful with existing files! This is a full overwrite, so you must include everything - not just sections you are modifying.`),
+			mcp.WithString("path", mcp.Description("Path to the file to write")),
+			mcp.WithString("content", mcp.Description("Data to write to the file")),
+			mcp.WithString("verificationToken", mcp.Description(`Obtained by the Read tool to verify that the existing content of the file has been read and understood before being replaced. Not required for new files.`)),
+		), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			path, ok := request.Params.Arguments["path"].(string)
+			if !ok {
+				return nil, fmt.Errorf("path is required")
+			}
+			fileContent, ok := request.Params.Arguments["content"].(string)
+			if !ok {
+				return nil, fmt.Errorf("content is required")
+			}
+			// TODO: validate if path is allowed
+
+			originalContent, err := os.ReadFile(path)
+			if err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					originalContent = []byte{}
+				} else {
+					return nil, fmt.Errorf("could access existing file: %w", err)
+				}
+			}
+			if len(originalContent) > 0 {
+				token, err := tokenForFileContent(originalContent)
+				if err != nil {
+					return nil, fmt.Errorf("could not generate verification token: %w", err)
+				}
+				expectedToken, ok := request.Params.Arguments["verificationToken"].(string)
+				if !ok || expectedToken != token {
+					// File was not read (or file has changed). Return an error response with an explanation and the original content
+					return newReadResult(originalContent, token, true, `The file was not read before it was written or it has changed since it was last read.
+		The file has been read and provided here. Make sure you understand the existing content before using the Write tool so you do not accidentally alter data or code that you did not mean to change.`)
+				}
+
+			}
+			if err := os.WriteFile(path, []byte(fileContent), 0600); err != nil {
+				return nil, fmt.Errorf("could not write file: %w", err)
+			}
+			var userResult mcp.TextContent
+			if len(originalContent) == 0 {
+				userResult = annotateTextContent(mcp.NewTextContent("### "+path+"\n```\n"+fileContent+"\n```"), []mcp.Role{mcp.RoleUser}, 0.2)
+			} else {
+				userResult = annotateTextContent(mcp.NewTextContent(diff(path, string(originalContent), fileContent)), []mcp.Role{mcp.RoleUser}, 0.2)
+			}
+
+			content := []mcp.Content{
+				userResult,
+			}
+
+			assistantResult := writeResult{}
+			assistantResult.NewVerificationToken, err = tokenForFileContent([]byte(fileContent))
+			if err == nil {
+				assistantResult.TokenExplanation = "The file has been updated. A new verification token is provided if you need to update the file again."
+			}
+
+			if status, err := getStatusOutput(serverCtx, buildEngineClient, adminClient); err == nil {
+				assistantResult.StatusExplanation = "The FTL status after the change is also provided."
+				assistantResult.Status = status
+			}
+			assistantResultJSON, err := json.Marshal(assistantResult)
+			if err != nil {
+				return nil, fmt.Errorf("could not marshal assistant result: %w", err)
+			}
+			content = append(content, annotateTextContent(mcp.NewTextContent(string(assistantResultJSON)), []mcp.Role{mcp.RoleAssistant}, 1.0))
+			return &mcp.CallToolResult{
+				Content: content,
+				IsError: false,
+			}, nil
+		}
+}
+
+func diff(path, original, new string) string {
+	dmp := diffmatchpatch.New()
+	diffs := dmp.DiffMain(string(original), new, false)
+	diffs = dmp.DiffCleanupSemantic(diffs)
+	includedLines := 10
+	for i, d := range diffs {
+		if d.Type != diffmatchpatch.DiffEqual {
+			continue
+		}
+		lines := strings.Split(d.Text, "\n")
+		if i == 0 {
+			// First diff
+			if len(diffs) == 1 {
+				return "### " + path + "\nNo changes were made."
+			}
+			if len(lines) > includedLines+1 {
+				lines = append([]string{"<...>"}, lines[len(lines)-1-includedLines:]...)
+			}
+		} else if i == len(diffs)-1 {
+			// Last diff
+			if len(lines) > includedLines+1 {
+				lines = append(lines[:includedLines], "<...>")
+			}
+		} else {
+			// Middle diff
+			if len(lines) > includedLines*2+1 {
+				originalLines := slices.Clone(lines)
+				lines = append(lines[:includedLines], "<...>")
+				lines = append(lines, originalLines[len(originalLines)-1-includedLines:]...)
+			}
+		}
+		d.Text = strings.Join(lines, "\n")
+		diffs[i] = d
+	}
+	return "###" + path + "\n\n" + dmp.DiffPrettyText(diffs) + "\n"
+
+}
+
+func tokenForFileContent(content []byte) (string, error) {
+	hasher := sha256.New()
+	if _, err := hasher.Write(content); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", hasher.Sum(nil)), nil
+}

--- a/internal/mcp/readwrite.go
+++ b/internal/mcp/readwrite.go
@@ -128,7 +128,7 @@ func WriteTool(serverCtx context.Context, buildEngineClient buildenginepbconnect
 			}
 			defer os.Remove(tmpFile.Name()) // Delete the temp file if we error.
 			defer tmpFile.Close()
-			if _, err := tmpFile.Write([]byte(fileContent)); err != nil {
+			if _, err := tmpFile.WriteString(fileContent); err != nil {
 				return nil, fmt.Errorf("could not write to tmp file for %s: %w", path, err)
 			}
 			if err := os.Rename(tmpFile.Name(), path); err != nil {
@@ -168,9 +168,9 @@ func WriteTool(serverCtx context.Context, buildEngineClient buildenginepbconnect
 		}
 }
 
-func prettyDiff(path, original, new string) string {
+func prettyDiff(path, original, latest string) string {
 	dmp := diffmatchpatch.New()
-	diffs := dmp.DiffMain(original, new, false)
+	diffs := dmp.DiffMain(original, latest, false)
 	diffs = dmp.DiffCleanupSemantic(diffs)
 	includedLines := 10
 	for i, d := range diffs {

--- a/internal/mcp/readwrite.go
+++ b/internal/mcp/readwrite.go
@@ -125,7 +125,7 @@ func WriteTool(serverCtx context.Context, buildEngineClient buildenginepbconnect
 			if len(originalContent) == 0 {
 				userResult = annotateTextContent(mcp.NewTextContent("### "+path+"\n```\n"+fileContent+"\n```"), []mcp.Role{mcp.RoleUser}, 0.2)
 			} else {
-				userResult = annotateTextContent(mcp.NewTextContent(diff(path, string(originalContent), fileContent)), []mcp.Role{mcp.RoleUser}, 0.2)
+				userResult = annotateTextContent(mcp.NewTextContent(prettyDiff(path, string(originalContent), fileContent)), []mcp.Role{mcp.RoleUser}, 0.2)
 			}
 
 			content := []mcp.Content{
@@ -154,9 +154,9 @@ func WriteTool(serverCtx context.Context, buildEngineClient buildenginepbconnect
 		}
 }
 
-func diff(path, original, new string) string {
+func prettyDiff(path, original, new string) string {
 	dmp := diffmatchpatch.New()
-	diffs := dmp.DiffMain(string(original), new, false)
+	diffs := dmp.DiffMain(original, new, false)
 	diffs = dmp.DiffCleanupSemantic(diffs)
 	includedLines := 10
 	for i, d := range diffs {
@@ -195,7 +195,7 @@ func diff(path, original, new string) string {
 func tokenForFileContent(content []byte) (string, error) {
 	hasher := sha256.New()
 	if _, err := hasher.Write(content); err != nil {
-		return "", err
+		return "", fmt.Errorf("could not hash file content: %w", err)
 	}
 	return fmt.Sprintf("%x", hasher.Sum(nil)), nil
 }

--- a/internal/mcp/readwrite.go
+++ b/internal/mcp/readwrite.go
@@ -43,7 +43,12 @@ func ReadTool() (tool mcp.Tool, handler server.ToolHandlerFunc) {
 			if err != nil {
 				return nil, fmt.Errorf("could not generate verification token: %w", err)
 			}
-			return newReadResult(fileContent, token, false, "")
+			readResult, err := newReadResult(fileContent, token, false, "")
+			if err != nil {
+				return nil, fmt.Errorf("could not create read result: %w", err)
+			}
+			readResult.Content = append(readResult.Content, annotateTextContent(mcp.NewTextContent("Read contents of "+path), []mcp.Role{mcp.RoleUser}, 0.3))
+			return readResult, nil
 		}
 }
 

--- a/internal/mcp/readwrite.go
+++ b/internal/mcp/readwrite.go
@@ -10,11 +10,12 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/block/ftl/backend/protos/xyz/block/ftl/admin/v1/adminpbconnect"
-	"github.com/block/ftl/backend/protos/xyz/block/ftl/buildengine/v1/buildenginepbconnect"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/sergi/go-diff/diffmatchpatch"
+
+	"github.com/block/ftl/backend/protos/xyz/block/ftl/admin/v1/adminpbconnect"
+	"github.com/block/ftl/backend/protos/xyz/block/ftl/buildengine/v1/buildenginepbconnect"
 )
 
 type readResult struct {

--- a/internal/mcp/utils.go
+++ b/internal/mcp/utils.go
@@ -1,0 +1,14 @@
+package mcp
+
+import "github.com/mark3labs/mcp-go/mcp"
+
+func annotateTextContent(r mcp.TextContent, audience []mcp.Role, priority float64) mcp.TextContent {
+	r.Annotations = &struct {
+		Audience []mcp.Role `json:"audience,omitempty"`
+		Priority float64    `json:"priority,omitempty"`
+	}{
+		Audience: audience,
+		Priority: priority,
+	}
+	return r
+}


### PR DESCRIPTION
Aims:
- Goose takes a lot of time between each action taken. Often we know the thing goose should find out next, so we should just proactively gather that info for goose to avoid needless back and forth with goose
- Goose is given hints as to what is in code files via the schema. Sometimes goose is confident enough to overwrite those files without actually **reading** those files first... which means it just makes up the parts of the file it wasn't trying to change. We want some level of guarantee that goose reads a file before writing the file.

Changes:
- Added Read and Write MCP tools for FTL, which we tell Goose to use instead of the general `develop` tools included with Goose.
    - Read tool returns the content as well as a verification token (just a hash of the content)
    - Write tool requires a verification token to make sure the content has been read and understood before being altered.
        - If a verification token is not provided, or it doesnt match the content on disk, the Write fails, but we also return a read response (ie the new content and a new token)
        - If the write succeeds we also provide a new token to avoid having to call the Read tool again (useful when going back and forth fixing issues).
- MCP tools can also include the result of the FTL Status tool to avoid additional back and forths with goose.
    - eg: writing a file, or creating a module, will wait for the new build to finish and report to goose the latest schema / build errors.
- MCP tools can also have detection of files that should be read and provided to goose ahead of time.
    - For tools this is enabled for, any output is checked for file paths within the project.
    - FTL will invoke the Read tool for each of these files and provide it to goose without being asked.
    - This speeds up some workflows with goose and also helps goose do the right thing.
    - eg: when creating a new mysql database, FTL will automatically read in the initial migration file with the token that can be used to write to that file. Same for creating new migrations.
- We're now better at what info we provide goose vs what we show the user.
    - Write tool: we display a diff to the user to make it obvious what changed. This is not fed into the LLM so it doesnt waste tokens
    - Read tool: we don't print the whole file into the console (it was hard to follow along with what goose was doing when this happened). Not sure what we should print here though, currently it just prints the file name being read.
    - All this info we are proactively providing to goose does not show up to the user.