### PR TITLE
fix: improve go error if req type is Unit

### DIFF
--- a/go-runtime/schema/schema_integration_test.go
+++ b/go-runtime/schema/schema_integration_test.go
@@ -554,7 +554,7 @@ func testErrorReporting(t *testing.T) {
 		`33:69: unsupported response type "ftl/failing.Response"`,
 		`38:22-27: first parameter must be of type context.Context but is ftl/failing.Request`,
 		`38:53: unsupported response type "ftl/failing.Response"`,
-		`43:43-47: second parameter must not be ftl.Unit`,
+		`43:43-47: second parameter must not be ftl.Unit (verbs without a request type should omit the request parameter)`,
 		`43:59: unsupported response type "ftl/failing.Response"`,
 		`48:1-2: first parameter must be context.Context`,
 		`48:18: unsupported response type "ftl/failing.Response"`,

--- a/go-runtime/schema/verb/analyzer.go
+++ b/go-runtime/schema/verb/analyzer.go
@@ -244,7 +244,7 @@ func checkSignature(
 
 	if params.Len() >= 2 {
 		if params.At(1).Type().String() == common.FtlUnitTypePath {
-			common.TokenErrorf(pass, params.At(1).Pos(), params.At(1).Name(), "second parameter must not be ftl.Unit")
+			common.TokenErrorf(pass, params.At(1).Pos(), params.At(1).Name(), "second parameter must not be ftl.Unit (verbs without a request type should omit the request parameter)")
 		}
 
 		if hasRequest {


### PR DESCRIPTION
This code:
```go
//ftl:verb
func Example(ctx context.Context, nothing ftl.Unit) error { ... }
```
Gives this error:
`second parameter must not be ftl.Unit`

It is not clear what the solution to this is for users that do not know to just leave out the request parameter. Goose would try replacing unit with `struct{}`

It now results in this error:
`second parameter must not be ftl.Unit (verbs without a request type should omit the request parameter)`