### PR TITLE
chore: switch "database calls" to "database uses"

### DIFF
--- a/common/schema/edges_test.go
+++ b/common/schema/edges_test.go
@@ -27,7 +27,7 @@ module a {
     verb empty(Unit) Unit
     verb postEvent(Event) Unit
     verb getUsers([String]) [a.User]
-	    +database calls a.db
+	    +database uses a.db
 
     export verb inboundWithExternalTypes(builtin.HttpRequest<Unit, b.Location, Unit>) builtin.HttpResponse<b.Address, String>
         +ingress http GET /todo/external/{name}
@@ -62,7 +62,7 @@ module c {
         +calls c.end
     verb end(Unit) a.User
         +calls c.start
-    
+
 
 	enum Color: String {
 		Red = "Red"

--- a/common/schema/metadatadatabases.go
+++ b/common/schema/metadatadatabases.go
@@ -9,7 +9,7 @@ import (
 type MetadataDatabases struct {
 	Pos Position `parser:"" protobuf:"1,optional"`
 
-	Calls []*Ref `parser:"'+' 'database' 'calls' @@ (',' @@)*" protobuf:"2"`
+	Calls []*Ref `parser:"'+' 'database' 'uses' @@ (',' @@)*" protobuf:"2"`
 }
 
 var _ Metadata = (*MetadataDatabases)(nil)
@@ -18,7 +18,7 @@ func (m *MetadataDatabases) Append(call *Ref)   { m.Calls = append(m.Calls, call
 func (m *MetadataDatabases) Position() Position { return m.Pos }
 func (m *MetadataDatabases) String() string {
 	out := &strings.Builder{}
-	fmt.Fprint(out, "+database calls ")
+	fmt.Fprint(out, "+database uses ")
 	w := 6
 	for i, call := range m.Calls {
 		if i > 0 {

--- a/common/schema/schema_test.go
+++ b/common/schema/schema_test.go
@@ -69,7 +69,7 @@ module todo {
       +ingress http GET /todo/destroy/{name}
 
   verb insert(todo.InsertRequest) todo.InsertResponse
-      +database calls todo.testdb
+      +database uses todo.testdb
       +sql query exec "INSERT INTO requests (name) VALUES (?)"
 	  +generated
 
@@ -264,7 +264,6 @@ Module
 
 func TestParserRoundTrip(t *testing.T) {
 	input := testSchema.String()
-	fmt.Printf("Input schema:\n%s\n", input)
 	actual, err := ParseString("", input)
 	assert.NoError(t, err, "%s", testSchema.String())
 	actual, err = actual.Validate()
@@ -831,7 +830,7 @@ module todo {
   export verb destroy(builtin.HttpRequest<Unit, todo.DestroyRequest, Unit>) builtin.HttpResponse<todo.DestroyResponse, String>
   	+ingress http GET /todo/destroy/{name}
   verb insert(todo.InsertRequest) todo.InsertResponse
-  	+database calls todo.testdb +sql query exec "INSERT INTO requests (name) VALUES (?)" +generated
+  	+database uses todo.testdb +sql query exec "INSERT INTO requests (name) VALUES (?)" +generated
   verb scheduled(Unit) Unit
     +cron */10 * * 1-10,11-31 * * *
   verb twiceADay(Unit) Unit


### PR DESCRIPTION
"calls" just seemed a little odd, gramatically.