### PR TITLE
fix: implement a ftl logs command to allow streaming of logs from modules

### DIFF
--- a/backend/timeline/filters_test.go
+++ b/backend/timeline/filters_test.go
@@ -1,0 +1,66 @@
+package timeline
+
+import (
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+	timelinepb "github.com/block/ftl/backend/protos/xyz/block/ftl/timeline/v1"
+	schemapb "github.com/block/ftl/common/protos/xyz/block/ftl/schema/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestFilterModule_Multiple(t *testing.T) {
+	// Create test events
+	event1 := &timelinepb.Event{
+		Entry: &timelinepb.Event_Call{
+			Call: &timelinepb.CallEvent{
+				DestinationVerbRef: &schemapb.Ref{Module: "module1", Name: "verb1"},
+			},
+		},
+	}
+	event2 := &timelinepb.Event{
+		Entry: &timelinepb.Event_Log{
+			Log: &timelinepb.LogEvent{
+				Attributes: map[string]string{"module": "module2", "verb": "verb2"},
+			},
+		},
+	}
+	event3 := &timelinepb.Event{
+		Entry: &timelinepb.Event_Call{
+			Call: &timelinepb.CallEvent{
+				DestinationVerbRef: &schemapb.Ref{Module: "module3", Name: "verb3"},
+			},
+		},
+	}
+
+	// Create multiple module filters
+	filters := []*timelinepb.TimelineQuery_ModuleFilter{
+		{Module: "module1", Verb: proto.String("verb1")},
+		{Module: "module2", Verb: proto.String("verb2")},
+	}
+
+	filter := FilterModule(filters)
+
+	// Test that events matching either filter pass through
+	assert.True(t, filter(event1), "event1 should match first filter")
+	assert.True(t, filter(event2), "event2 should match second filter")
+	assert.False(t, filter(event3), "event3 should not match any filter")
+
+	// Test with one filter having no verb specified
+	filters = []*timelinepb.TimelineQuery_ModuleFilter{
+		{
+			Module: "module1",
+		},
+		{
+			Module: "module2",
+			Verb:   proto.String("verb2"),
+		},
+	}
+
+	filter = FilterModule(filters)
+
+	// Test that module1 matches regardless of verb
+	assert.True(t, filter(event1), "event1 should match first filter (any verb)")
+	assert.True(t, filter(event2), "event2 should match second filter")
+	assert.False(t, filter(event3), "event3 should not match any filter")
+}

--- a/cmd/ftl/cmd_logs.go
+++ b/cmd/ftl/cmd_logs.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"connectrpc.com/connect"
+
 	adminpb "github.com/block/ftl/backend/protos/xyz/block/ftl/admin/v1"
 	"github.com/block/ftl/backend/protos/xyz/block/ftl/admin/v1/adminpbconnect"
 	timelinepb "github.com/block/ftl/backend/protos/xyz/block/ftl/timeline/v1"

--- a/cmd/ftl/cmd_logs.go
+++ b/cmd/ftl/cmd_logs.go
@@ -1,5 +1,86 @@
 package main
 
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"connectrpc.com/connect"
+	adminpb "github.com/block/ftl/backend/protos/xyz/block/ftl/admin/v1"
+	"github.com/block/ftl/backend/protos/xyz/block/ftl/admin/v1/adminpbconnect"
+	timelinepb "github.com/block/ftl/backend/protos/xyz/block/ftl/timeline/v1"
+	"github.com/block/ftl/internal/log"
+)
+
 type logsCmd struct {
-	Level logsSetLevelCmd `cmd:"" help:"Set the current log level"`
+	Follow  bool     `help:"Specify if the logs should be streamed" short:"f"`
+	Modules []string `arg:"" optional:"" help:"Module names to get logs from. Can be 'module' or 'module:verb' format"`
+}
+
+func parseModuleVerb(arg string) (module string, verb string) {
+	parts := strings.SplitN(arg, ":", 2)
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return arg, ""
+}
+
+func (cmd *logsCmd) Run(ctx context.Context, client adminpbconnect.AdminServiceClient) error {
+	logger := log.FromContext(ctx)
+
+	query := &timelinepb.TimelineQuery{
+		Order: timelinepb.TimelineQuery_ORDER_ASC,
+		Limit: 10,
+	}
+
+	// Add module filters if modules are specified
+	if len(cmd.Modules) > 0 {
+		for _, moduleArg := range cmd.Modules {
+			module, verb := parseModuleVerb(moduleArg)
+			var verbPtr *string
+			if verb != "" {
+				verbPtr = &verb
+			}
+			query.Filters = append(query.Filters, &timelinepb.TimelineQuery_Filter{
+				Filter: &timelinepb.TimelineQuery_Filter_Module{
+					Module: &timelinepb.TimelineQuery_ModuleFilter{
+						Module: module,
+						Verb:   verbPtr,
+					},
+				},
+			})
+		}
+	}
+
+	// Stream logs from the server
+	stream, err := client.StreamLogs(ctx, connect.NewRequest(&adminpb.StreamLogsRequest{
+		Query: query,
+	}))
+	if err != nil {
+		return fmt.Errorf("failed to stream logs: %w", err)
+	}
+
+	for stream.Receive() {
+		msg := stream.Msg()
+		for _, logEvent := range msg.Logs {
+			logger.Log(log.Entry{
+				Level:      log.Level(logEvent.LogLevel),
+				Message:    logEvent.Message,
+				Attributes: logEvent.Attributes,
+				Time:       logEvent.Timestamp.AsTime(),
+			})
+		}
+
+		if !cmd.Follow {
+			break
+		}
+	}
+
+	if err := stream.Err(); err != nil && errors.Is(err, io.EOF) {
+		return fmt.Errorf("error receiving logs: %w", err)
+	}
+
+	return nil
 }

--- a/cmd/ftl/main.go
+++ b/cmd/ftl/main.go
@@ -90,6 +90,7 @@ type CLI struct {
 	Dev         devCmd                    `cmd:"" help:"Develop FTL modules. Will start the FTL cluster, build and deploy all modules found in the specified directories, and watch for changes."`
 	Serve       serveCmd                  `cmd:"" help:"Start the FTL server."`
 	Completion  kongcompletion.Completion `cmd:"" help:"Outputs shell code for initialising tab completions."`
+	Logs        logsCmd                   `cmd:"" help:"View logs from FTL modules."`
 
 	// Specify the 1Password vault to access secrets from.
 	Vault string `name:"opvault" help:"1Password vault to be used for secrets. The name of the 1Password item will be the <ref> and the secret will be stored in the password field." placeholder:"VAULT"`
@@ -107,7 +108,9 @@ type InteractiveCLI struct {
 // DevModeCLI is the embedded CLI when running in dev mode.
 type DevModeCLI struct {
 	SharedCLI
-	Logs logsCmd `cmd:"" help:"Log commands."`
+	Logs struct {
+		Level logsSetLevelCmd `cmd:"" help:"Set the current log level"`
+	} `cmd:"" help:"Log commands."`
 }
 
 var cli CLI

--- a/internal/channels/notifier_test.go
+++ b/internal/channels/notifier_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-func TestBroadcaster(t *testing.T) {
+func TestNotifier(t *testing.T) {
 	t.Run("broadcasts messages to all subscribers", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 		defer cancel()


### PR DESCRIPTION
For now, it streams all logs from the start, and only streaming is supported. Will add a limit of how much logs to read as a follow-up, as well just returning latest logs.

Also, timeline does scan all events on every update to the event stream. Will look at fixing this as aa follow-up as well