### PR TITLE
chore: remove unused config entry

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,12 +1,7 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-  inheritConfig: true,
-  inheritConfigStrict: true,
   labels: [
     'run-all',
-  ],
-  allowedCommands: [
-    'pnpm install',
   ],
   extends: [
     'config:recommended',


### PR DESCRIPTION
```
🐚 ~/dev/ftl $ npx --yes --package renovate -- renovate-config-validator --strict
 INFO: Validating .github/renovate.json5
 WARN: Found errors in configuration
       "file": ".github/renovate.json5",
       "warnings": [
         {
           "topic": "Configuration Error",
           "message": "The \"allowedCommands\" option is a global option reserved only for Renovate's global configuration and cannot be configured within a repository's config file."
         }
       ]
```