### PR TITLE
fix: add position to sql verbs and data types

### DIFF
--- a/common/schema/metadatagenerated.go
+++ b/common/schema/metadatagenerated.go
@@ -7,7 +7,7 @@ type MetadataGenerated struct {
 	Pos Position `parser:"'+' 'generated'" protobuf:"1,optional"`
 }
 
-var _ Metadata = (*MetadataSQLMigration)(nil)
+var _ Metadata = (*MetadataGenerated)(nil)
 
 func (*MetadataGenerated) schemaMetadata()          {}
 func (m *MetadataGenerated) schemaChildren() []Node { return nil }

--- a/internal/sql/sql.go
+++ b/internal/sql/sql.go
@@ -290,7 +290,7 @@ func populatePositions(m *schema.Module, cfg ConfigContext) error {
 			continue
 		}
 		verb.Pos = pos
-		schema.Visit(verb, func(n schema.Node, next func() error) error {
+		_ = schema.Visit(verb, func(n schema.Node, next func() error) error { //nolint:errcheck
 			ref, ok := n.(*schema.Ref)
 			if !ok {
 				return next()

--- a/internal/sql/sql.go
+++ b/internal/sql/sql.go
@@ -22,7 +22,7 @@ import (
 	"github.com/block/ftl/internal/moduleconfig"
 )
 
-var queryNameRegex = regexp.MustCompile(`^-- name: ([^ ]+)`)
+var queryNameRegex = regexp.MustCompile(`^-- name: ([A-Za-z0-9_]+)`)
 
 type ConfigContext struct {
 	Dir         string

--- a/internal/sql/sql_test.go
+++ b/internal/sql/sql_test.go
@@ -48,6 +48,10 @@ func TestAddDatabaseDeclsToSchema(t *testing.T) {
 			&schema.Database{Name: "mysqldb", Type: schema.MySQLDatabaseType},
 			&schema.Database{Name: "psqldb", Type: schema.PostgresDatabaseType},
 			&schema.Data{
+				Pos: schema.Position{
+					Filename: filepath.Join(tmpDir, "db/mysql/mysqldb/queries/queries.sql"),
+					Line:     4,
+				},
 				Name: "CreateRequestMySqlQuery",
 				Fields: []*schema.Field{
 					{
@@ -66,6 +70,10 @@ func TestAddDatabaseDeclsToSchema(t *testing.T) {
 				},
 			},
 			&schema.Data{
+				Pos: schema.Position{
+					Filename: filepath.Join(tmpDir, "db/postgres/psqldb/queries/queries.sql"),
+					Line:     4,
+				},
 				Name: "CreateRequestPsqlQuery",
 				Fields: []*schema.Field{
 					{
@@ -84,6 +92,10 @@ func TestAddDatabaseDeclsToSchema(t *testing.T) {
 				},
 			},
 			&schema.Data{
+				Pos: schema.Position{
+					Filename: filepath.Join(tmpDir, "db/mysql/mysqldb/queries/queries.sql"),
+					Line:     1,
+				},
 				Name: "GetRequestDataMySqlResult",
 				Fields: []*schema.Field{
 					{
@@ -102,6 +114,10 @@ func TestAddDatabaseDeclsToSchema(t *testing.T) {
 				},
 			},
 			&schema.Data{
+				Pos: schema.Position{
+					Filename: filepath.Join(tmpDir, "db/postgres/psqldb/queries/queries.sql"),
+					Line:     1,
+				},
 				Name: "GetRequestDataPsqlResult",
 				Fields: []*schema.Field{
 					{
@@ -120,6 +136,10 @@ func TestAddDatabaseDeclsToSchema(t *testing.T) {
 				},
 			},
 			&schema.Verb{
+				Pos: schema.Position{
+					Filename: filepath.Join(tmpDir, "db/mysql/mysqldb/queries/queries.sql"),
+					Line:     4,
+				},
 				Name:     "createRequestMySql",
 				Request:  &schema.Ref{Module: "test", Name: "CreateRequestMySqlQuery"},
 				Response: &schema.Unit{},
@@ -140,6 +160,10 @@ func TestAddDatabaseDeclsToSchema(t *testing.T) {
 				},
 			},
 			&schema.Verb{
+				Pos: schema.Position{
+					Filename: filepath.Join(tmpDir, "db/postgres/psqldb/queries/queries.sql"),
+					Line:     4,
+				},
 				Name:     "createRequestPsql",
 				Request:  &schema.Ref{Module: "test", Name: "CreateRequestPsqlQuery"},
 				Response: &schema.Unit{},
@@ -160,6 +184,10 @@ func TestAddDatabaseDeclsToSchema(t *testing.T) {
 				},
 			},
 			&schema.Verb{
+				Pos: schema.Position{
+					Filename: filepath.Join(tmpDir, "db/mysql/mysqldb/queries/queries.sql"),
+					Line:     1,
+				},
 				Name:    "getRequestDataMySql",
 				Request: &schema.Unit{},
 				Response: &schema.Array{Element: &schema.Ref{
@@ -183,6 +211,10 @@ func TestAddDatabaseDeclsToSchema(t *testing.T) {
 				},
 			},
 			&schema.Verb{
+				Pos: schema.Position{
+					Filename: filepath.Join(tmpDir, "db/postgres/psqldb/queries/queries.sql"),
+					Line:     1,
+				},
 				Name:    "getRequestDataPsql",
 				Request: &schema.Unit{},
 				Response: &schema.Array{Element: &schema.Ref{


### PR DESCRIPTION
- sqlc does not provide enough information for us to get a position of a verb in the source sql file.
- Instead we read in the sql files and try to match `-- name: <name>` lines with the names of the verbs.