### PR TITLE
fix: prevent injecting external topics

### DIFF
--- a/go-runtime/compile/build.go
+++ b/go-runtime/compile/build.go
@@ -1268,9 +1268,6 @@ func (b *mainDeploymentContextBuilder) getVerbResource(verb *schema.Verb, param 
 			return goTopicHandle{}, fmt.Errorf("%s.%s uses %s topic handle, but %s is not a topic",
 				b.mainModule.Name, verb.Name, ref, ref)
 		}
-		if ref.Module != b.mainModule.Name {
-			return goTopicHandle{}, builderrors.Errorf(param.Ref.Pos.ToErrorPos(), "external topic %s can not be injected because publishing to external topics is not allowed", ref)
-		}
 		return b.processTopic(ref.Module, ref, topic)
 	case *schema.MetadataConfig:
 		cfg, ok := resolved.(*schema.Config)

--- a/go-runtime/compile/build.go
+++ b/go-runtime/compile/build.go
@@ -1268,6 +1268,9 @@ func (b *mainDeploymentContextBuilder) getVerbResource(verb *schema.Verb, param 
 			return goTopicHandle{}, fmt.Errorf("%s.%s uses %s topic handle, but %s is not a topic",
 				b.mainModule.Name, verb.Name, ref, ref)
 		}
+		if ref.Module != b.mainModule.Name {
+			return goTopicHandle{}, builderrors.Errorf(param.Ref.Pos.ToErrorPos(), "external topic %s can not be injected because publishing to external topics is not allowed", ref)
+		}
 		return b.processTopic(ref.Module, ref, topic)
 	case *schema.MetadataConfig:
 		cfg, ok := resolved.(*schema.Config)

--- a/go-runtime/schema/call/analyzer.go
+++ b/go-runtime/schema/call/analyzer.go
@@ -75,11 +75,6 @@ func validateCallExpr(pass *analysis.Pass, node *ast.CallExpr) {
 	if lhsPkgPath == "" || !aliased {
 		return
 	}
-
-	if selExpr.Sel.Name == "Publish" && isTopicHandleType(pass.TypesInfo.TypeOf(selExpr.X)) &&
-		!common.IsPathInModule(pass.Pkg, lhsPkgPath) {
-		common.Errorf(pass, node, "can not publish directly to topics in other modules")
-	}
 }
 
 func isTopicHandleType(typ types.Type) bool {

--- a/go-runtime/schema/schema_integration_test.go
+++ b/go-runtime/schema/schema_integration_test.go
@@ -578,7 +578,7 @@ func testErrorReporting(t *testing.T) {
 		`140:6-45: enum discriminator "TypeEnum3" cannot contain exported methods`,
 		`143:6-35: enum discriminator "NoMethodsTypeEnum" must define at least one method`,
 		`155:3-14: unexpected token "d"`,
-		`162:2-49: can not publish directly to topics in other modules`,
+		`161:38-62: could not inject external topic "pubsub.publicBroadcast" because publishing directly to external topics is not allowed`,
 		`168:2-12: struct field unexported must be exported by starting with an uppercase letter`,
 		`172:6: unsupported type "ftl/failing/child.BadChildStruct" for field "child"`,
 		`177:6: duplicate data declaration for "failing.Redeclared"; already declared at "27:6"`,

--- a/go-runtime/schema/verb/analyzer.go
+++ b/go-runtime/schema/verb/analyzer.go
@@ -88,6 +88,10 @@ func Extract(pass *analysis.Pass, node *ast.FuncDecl, obj types.Object) optional
 			case common.VerbResourceTypeDatabaseHandle:
 				verb.AddDatabase(r.ref)
 			case common.VerbResourceTypeTopicHandle:
+				if currentModule, err := common.FtlModuleFromGoPackage(pass.Pkg.Path()); err == nil && r.ref.Module != currentModule {
+					common.Errorf(pass, param, "could not inject external topic %q because publishing directly to external topics is not allowed", r.ref)
+					continue
+				}
 				verb.AddTopicPublish(r.ref)
 			case common.VerbResourceTypeConfig:
 				verb.AddConfig(r.ref)


### PR DESCRIPTION
Previously we looked for `topic.Publish(...)` calls to detect if a module tried to publish to an external topic.
Now that we use injection for resources, we can instead check if a topic resource is from a different module.

When injecting an external topic I was getting a seemingly unrelated error that was not obvious that it was because it was not allowed (something about a partition mapper couldn't be found).
