### PR TITLE
fix: allow injecting topics with external events

### DIFF
--- a/go-runtime/schema/topic/analyzer.go
+++ b/go-runtime/schema/topic/analyzer.go
@@ -22,13 +22,7 @@ func Extract(pass *analysis.Pass, obj types.Object, node *ast.TypeSpec) optional
 		return optional.None[*schema.Topic]()
 	}
 
-	// extract event type
-	eventTypeExpr, ok := idxListExpr.Indices[0].(*ast.Ident)
-	if !ok {
-		common.Errorf(pass, node, "unsupported topic type")
-		return optional.None[*schema.Topic]()
-	}
-	typ, ok := common.ExtractType(pass, eventTypeExpr).Get()
+	eventType, ok := common.ExtractType(pass, idxListExpr.Indices[0]).Get()
 	if !ok {
 		common.Errorf(pass, node, "unsupported topic type")
 		return optional.None[*schema.Topic]()
@@ -45,7 +39,7 @@ func Extract(pass *analysis.Pass, obj types.Object, node *ast.TypeSpec) optional
 	topic := &schema.Topic{
 		Pos:   common.GoPosToSchemaPos(pass.Fset, node.Pos()),
 		Name:  name,
-		Event: typ,
+		Event: eventType,
 	}
 	partitions := 1
 	if md, ok := common.GetFactForObject[*common.ExtractedMetadata](pass, obj).Get(); ok {


### PR DESCRIPTION
Topics with external event types were causing issues because the event type was not `*ast.Ident`. Fixed by using common `ExtractType` method to extract the event type.