### PR TITLE
fix: connection errors do not count as a consumption attempt

### DIFF
--- a/backend/runner/pubsub/consumer.go
+++ b/backend/runner/pubsub/consumer.go
@@ -331,6 +331,13 @@ func (c *consumer) ConsumeClaim(session sarama.ConsumerGroupSession, claim saram
 				if err == nil {
 					break
 				}
+				var connectErr *connect.Error
+				if errors.As(err, &connectErr) {
+					// Connection error, do not count as an attempt
+					// This can happen when a runner is shutting down. This should never mark the message as consumed.
+					time.Sleep(time.Second)
+					continue
+				}
 				select {
 				case <-ctx.Done():
 					// Do not commit the message if we did not succeed and the context is done.


### PR DESCRIPTION
fixes https://github.com/block/ftl/issues/4822
Confirmed that killing FTL could cause progress consumer group offsets. It is a very hard edge case to reproduce though.
Steps:
- Call to verb fails due to a `connect.Error` while the pubsub context is not yet cancelled.
- Consumer marks the offset
- Sarama library then tries to sync the offset to kafka/redpanda. This usually never actually completes which is why we don't see this happen in practice a lot.

Was not able to make an integration test that would fail for this.