### PR TITLE
chore: speed up tests by deploying in parallel

### DIFF
--- a/backend/runner/pubsub/integration_test.go
+++ b/backend/runner/pubsub/integration_test.go
@@ -29,8 +29,7 @@ func TestRetry(t *testing.T) {
 		in.WithPubSub(),
 		in.CopyModule("publisher"),
 		in.CopyModule("subscriber"),
-		in.Deploy("publisher"),
-		in.Deploy("subscriber"),
+		in.Deploy("publisher", "subscriber"),
 
 		// publish events
 		in.Call("publisher", "publishOneToTopic2", map[string]any{"haystack": "firstCall"}, func(t testing.TB, resp in.Obj) {}),
@@ -51,8 +50,7 @@ func TestExternalPublishRuntimeCheck(t *testing.T) {
 	in.Run(t,
 		in.CopyModule("publisher"),
 		in.CopyModule("subscriber"),
-		in.Deploy("publisher"),
-		in.Deploy("subscriber"),
+		in.Deploy("publisher", "subscriber"),
 
 		in.ExpectError(
 			in.Call("subscriber", "publishToExternalModule", in.Obj{}, func(t testing.TB, resp in.Obj) {}),
@@ -69,8 +67,7 @@ func TestConsumerGroupMembership(t *testing.T) {
 		in.WithPubSub(),
 		in.CopyModule("publisher"),
 		in.CopyModule("subscriber"),
-		in.Deploy("publisher"),
-		in.Deploy("subscriber"),
+		in.Deploy("publisher", "subscriber"),
 
 		// consumer group must now have a member for each partition
 		checkGroupMembership("subscriber", "consumeSlow", 1),

--- a/backend/timeline/integration_test.go
+++ b/backend/timeline/integration_test.go
@@ -29,12 +29,7 @@ func TestTimeline(t *testing.T) {
 		in.CopyModule("publisher"),
 		in.CopyModule("subscriber"),
 		in.CopyModule("ingress"),
-		in.Deploy("cron"),
-		in.Deploy("time"),
-		in.Deploy("echo"),
-		in.Deploy("publisher"),
-		in.Deploy("subscriber"),
-		in.Deploy("ingress"),
+		in.Deploy("cron", "time", "echo", "publisher", "subscriber", "ingress"),
 
 		// Trigger events
 		in.HttpCall(http.MethodGet, "/users/123/posts/456", nil, nil, func(t testing.TB, resp *in.HTTPResponse) {}),

--- a/jvm-runtime/jvm_integration_test.go
+++ b/jvm-runtime/jvm_integration_test.go
@@ -251,7 +251,8 @@ func TestJVMCoreFunctionality(t *testing.T) {
 		in.CopyModuleWithLanguage("gomodule", "go"),
 		in.CopyModuleWithLanguage("javaclient", "java"),
 		in.CopyModuleWithLanguage("kotlinmodule", "kotlin"),
-		in.Deploy("gomodule", "javaclient", "kotlinmodule"),
+		in.Deploy("gomodule"),
+		in.Deploy("javaclient", "kotlinmodule"),
 		in.SubTests(tests...),
 	)
 }

--- a/jvm-runtime/jvm_integration_test.go
+++ b/jvm-runtime/jvm_integration_test.go
@@ -251,9 +251,7 @@ func TestJVMCoreFunctionality(t *testing.T) {
 		in.CopyModuleWithLanguage("gomodule", "go"),
 		in.CopyModuleWithLanguage("javaclient", "java"),
 		in.CopyModuleWithLanguage("kotlinmodule", "kotlin"),
-		in.Deploy("gomodule"),
-		in.Deploy("javaclient"),
-		in.Deploy("kotlinmodule"),
+		in.Deploy("gomodule", "javaclient", "kotlinmodule"),
 		in.SubTests(tests...),
 	)
 }

--- a/smoketest/exemplar_integration_test.go
+++ b/smoketest/exemplar_integration_test.go
@@ -43,9 +43,7 @@ func TestExemplarIntegration(t *testing.T) {
 			fmt.Println(output)
 		}),
 
-		in.Deploy("origin"),
-		in.Deploy("relay"),
-		in.Deploy("pulse"),
+		in.Deploy("origin", "relay", "pulse"),
 
 		in.ExecWithOutput("curl", []string{"-s", "-X", "POST", "http://127.0.0.1:8891/ingress/agent", "-H", "Content-Type: application/json", "-d", fmt.Sprintf(`{"id": %v, "alias": "james", "license_to_kill": true, "hired_at": "2023-10-23T23:20:45.00Z"}`, successAgentId)}, func(output string) {
 			fmt.Printf("output: %s\n", output)

--- a/smoketest/exemplar_smoke_test.go
+++ b/smoketest/exemplar_smoke_test.go
@@ -43,9 +43,7 @@ func TestExemplarSmoke(t *testing.T) {
 			fmt.Println(output)
 		}),
 
-		in.Deploy("origin"),
-		in.Deploy("relay"),
-		in.Deploy("pulse"),
+		in.Deploy("origin", "relay", "pulse"),
 
 		in.ExecWithOutput("curl", []string{"-s", "-X", "POST", "http://127.0.0.1:8891/ingress/agent", "-H", "Content-Type: application/json", "-d", fmt.Sprintf(`{"id": %v, "alias": "james", "license_to_kill": true, "hired_at": "2023-10-23T23:20:45.00Z"}`, successAgentId)}, func(output string) {
 			fmt.Printf("output: %s\n", output)


### PR DESCRIPTION
Building and deploying modules in integration tests take more time than needed if we do them serially.