### PR TITLE
fix: remove weird (and incorrect debug print)

### DIFF
--- a/backend/cron/service.go
+++ b/backend/cron/service.go
@@ -122,7 +122,6 @@ func Start(ctx context.Context, config Config, eventSource *schemaeventsource.Ev
 				return fmt.Errorf("cron service stopped: %w", ctx.Err())
 
 			case change := <-events:
-				logger.Debugf("Received cron event %+x", change)
 				if err := updateCronJobs(ctx, cronJobs, change, timelineClient); err != nil {
 					logger.Errorf(err, "Failed to update cron jobs")
 					continue


### PR DESCRIPTION
```
debug:cron: Received cron event &{2f2f204275696c742d696e20747970657320666f722046544c2e0a6275696c74696e206d6f64756c65206275696c74696e207b0a20202f2f20436174636852657175657374206973206120726571756573742073747275637475726520666f722063617463682076657262732e0a20206578706f72742064617461204361746368526571756573743c5265713e207b0a2020202076657262206275696c74696e2e5265660a2020202072657175657374205265710a20202020726571756573745479706520537472696e670a202020206572726f7220537472696e670a20207d0a0a20206578706f7274206461746120456d707479207b0a20207d0a0a20202f2f204661696c65644576656e74206973207573656420696e2064656164206c657474657220746f706963732e0a20206578706f72742064617461204661696c65644576656e743c4576656e743e207b0a202020206576656e74204576656e740a202020206572726f7220537472696e670a20207d0a0a20202f2f2048545450207265717565737420737472756374757265207573656420666f72204854545020696e67726573732076657262732e0a20206578706f727420646174612048747470526571756573743c426f64792c20506174682c2051756572793e207b0a202020206d6574686f6420537472696e670a202020207061746820537472696e670a2020202070617468506172616d657465727320506174680a2020202071756572792051756572790a2020202068656164657273207b537472696e673a205b537472696e675d7d0a20202020626f647920426f64790a20207d0a0a20202f2f204854545020726573706f6e736520737472756374757265207573656420666f72204854545020696e67726573732076657262732e0a20206578706f727420646174612048747470526573706f6e73653c426f64792c204572726f723e207b0a2020202073746174757320496e740a2020202068656164657273207b537472696e673a205b537472696e675d7d0a202020202f2f204569746865722022626f647922206f7220226572726f7222206d7573742062652070726573656e742c206e6f7420626f74682e0a20202020626f647920426f64793f0a202020206572726f72204572726f723f0a20207d0a0a20202f2f2041207265666572656e636520746f2061206465636c61726174696f6e20696e2074686520736368656d612e0a20206578706f7274206461746120526566207b0a202020206d6f64756c6520537472696e670a202020206e616d6520537472696e670a20207d0a7d0a []}
```

When printed correctly, this prints out the builtin module, so I'm not sure what the intent was.