### PR TITLE
refactor: simplify clirpc.Invoke

### DIFF
--- a/internal/clirpc/clirpc.go
+++ b/internal/clirpc/clirpc.go
@@ -2,9 +2,7 @@
 package clirpc
 
 import (
-	"bytes"
 	"context"
-	"encoding/binary"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,79 +10,19 @@ import (
 )
 
 func Invoke(ctx context.Context, handler http.Handler, path, command string, req io.Reader, resp io.Writer) error {
-	grpcBody, err := wrapGRPC(req)
-	if err != nil {
-		return fmt.Errorf("failed to read request: %w", err)
-	}
-	hreq, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://localhost"+path+command, grpcBody)
+	hreq, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://localhost"+path+command, req)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
-	hreq.Header.Set("Content-Type", "application/grpc")
+	hreq.Header.Set("Content-Type", "application/proto")
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, hreq)
 	if w.Code != http.StatusOK {
 		return fmt.Errorf("unexpected status code: %d: %s", w.Code, w.Body.String())
 	}
-	unwrappedResp, err := unwrapGRPC(w.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read response: %w", err)
-	}
-	_, err = io.Copy(resp, unwrappedResp)
+	_, err = io.Copy(resp, w.Body)
 	if err != nil {
 		return fmt.Errorf("failed to write response: %w", err)
 	}
 	return nil
-}
-
-// wrapGRPC wraps a proto message for gRPC transport.
-func wrapGRPC(req io.Reader) (io.Reader, error) {
-	messageBytes, err := io.ReadAll(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal Protobuf message: %w", err)
-	}
-
-	buf := &bytes.Buffer{}
-	// Write the 1-byte flag (0 for uncompressed)
-	if err := buf.WriteByte(0); err != nil {
-		return nil, fmt.Errorf("failed to write flag: %w", err)
-	}
-	// Write the 4-byte length prefix (big-endian)
-	length := len(messageBytes)
-	if length > int(^uint32(0)) {
-		return nil, fmt.Errorf("message size exceeds maximum length: %d bytes", length)
-	}
-	if err := binary.Write(buf, binary.BigEndian, uint32(length)); err != nil {
-		return nil, fmt.Errorf("failed to write length prefix: %w", err)
-	}
-	if _, err := buf.Write(messageBytes); err != nil {
-		return nil, fmt.Errorf("failed to write message: %w", err)
-	}
-	return buf, nil
-}
-
-// unwrapGRPC unwraps a gRPC response to the inner proto message.
-func unwrapGRPC(resp io.Reader) (io.Reader, error) {
-	// Read the 1-byte flag (0 for uncompressed)
-	flag := make([]byte, 1)
-	if _, err := resp.Read(flag); err != nil {
-		return nil, fmt.Errorf("failed to read flag: %w", err)
-	}
-	if flag[0] != 0 {
-		return nil, fmt.Errorf("unsupported compression flag: %d", flag[0])
-	}
-
-	// Read the 4-byte length prefix (big-endian)
-	lengthBytes := make([]byte, 4)
-	if _, err := resp.Read(lengthBytes); err != nil {
-		return nil, fmt.Errorf("failed to read length prefix: %w", err)
-	}
-	length := binary.BigEndian.Uint32(lengthBytes)
-
-	// Read the message
-	messageBytes := make([]byte, length)
-	if _, err := resp.Read(messageBytes); err != nil {
-		return nil, fmt.Errorf("failed to read message: %w", err)
-	}
-	return bytes.NewReader(messageBytes), nil
 }


### PR DESCRIPTION
Connect [supports application/proto](https://connectrpc.com/docs/protocol) via standard HTTP, so rather than try to emulate gRPC we just use this.