### PR TITLE
fix: spacing, resizing, and overflow on status

### DIFF
--- a/go-runtime/server/workload.go
+++ b/go-runtime/server/workload.go
@@ -8,10 +8,12 @@ import (
 	"strings"
 
 	"github.com/block/ftl/go-runtime/ftl"
+	"github.com/block/ftl/internal/log"
 )
 
 func addWorkloadIdentity(ctx context.Context, metadata http.Header) (context.Context, error) {
-	fmt.Printf("Request map: %v\n", metadata)
+	logger := log.FromContext(ctx)
+	logger.Tracef("Request map: %v\n", metadata)
 	clientcert := metadata["X-Forwarded-Client-Cert"]
 	if len(clientcert) == 0 {
 		return ctx, nil


### PR DESCRIPTION
- Add truncating of really long module names if the window can handle it.

![Screenshot 2025-04-02 at 8 44 21 AM](https://github.com/user-attachments/assets/f3512adc-5b2e-4ee8-ad36-577d4151cdb3)
![Screenshot 2025-04-02 at 8 44 26 AM](https://github.com/user-attachments/assets/516b951c-9c2e-4943-bcea-f3c092d72fff)
![Screenshot 2025-04-02 at 8 44 33 AM](https://github.com/user-attachments/assets/06d2c74f-62d8-4512-b900-568a92e42b80)
