### PR TITLE
fix: show trace url as a link in terminal

### DIFF
--- a/cmd/ftl/cmd_call.go
+++ b/cmd/ftl/cmd_call.go
@@ -96,7 +96,8 @@ func callVerb(
 			if cmd != nil && cmd.ConsoleEndpoint != nil {
 				consoleURL = cmd.ConsoleEndpoint.String()
 			}
-			fmt.Printf("Trace URL: %s/traces/%s\n", consoleURL, requestKey)
+			traceURL := fmt.Sprintf("%s/traces/%s", consoleURL, requestKey)
+			fmt.Printf("Trace URL: \x1b]8;;%s\x07%s\x1b]8;;\x07\u001b[0m\n", traceURL, traceURL)
 			fmt.Println()
 		}
 	}


### PR DESCRIPTION
Uses escape codes to encode trace URL as a hyperlink (based on: https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda)
A better fix would be to detect if the terminal emulator supports this escape sequence if out the hyperlink on the request key line itself.

In iTerm2:
<img width="569" alt="Screenshot 2025-04-03 at 9 37 12 am" src="https://github.com/user-attachments/assets/5d9b12c4-98c0-4284-a9be-c9c53b53030b" />

In Mac Terminal (fallbacks to just text):
<img width="725" alt="Screenshot 2025-04-03 at 9 37 29 am" src="https://github.com/user-attachments/assets/16047235-451b-4503-b92d-f1449ca7d59e" />
