### PR TITLE
fix: duplicate commands in cli output

### DIFF
--- a/examples/go/time/types.ftl.go
+++ b/examples/go/time/types.ftl.go
@@ -7,12 +7,19 @@ import (
 	"github.com/block/ftl/go-runtime/server"
 )
 
+type HelloClient func(context.Context, string) (string, error)
+
 type InternalClient func(context.Context, TimeRequest) (TimeResponse, error)
 
 type TimeClient func(context.Context, TimeRequest) (TimeResponse, error)
 
 func init() {
 	reflection.Register(
+
+		reflection.ProvideResourcesForVerb(
+			Hello,
+			server.Config[string]("time", "greeting"),
+		),
 
 		reflection.ProvideResourcesForVerb(
 			Internal,

--- a/internal/terminal/interactive.go
+++ b/internal/terminal/interactive.go
@@ -103,7 +103,6 @@ func (r *interactiveConsole) run(ctx context.Context, executor CommandExecutor) 
 	for {
 		line, err := l.Readline()
 		if errors.Is(err, readline.ErrInterrupt) {
-
 			if len(line) == 0 {
 				break
 			}
@@ -118,7 +117,9 @@ func (r *interactiveConsole) run(ctx context.Context, executor CommandExecutor) 
 			return nil
 		}
 		if tsm != nil {
-			tsm.consoleNewline(line)
+			tsm.statusLock.Lock()
+			tsm.clearStatusMessages()
+			tsm.statusLock.Unlock()
 		}
 		line = strings.TrimSpace(line)
 		if line == "" {
@@ -147,8 +148,8 @@ func (r *interactiveConsole) run(ctx context.Context, executor CommandExecutor) 
 		if tsm != nil {
 			if len(args) > 0 && args[0] == "goose" {
 				tsm.consoleNewline("👤 " + strings.Join(args[1:], " "))
-			} else {
-				tsm.consoleNewline("> " + line)
+			} else if r.currentLineCallback != nil {
+				tsm.consoleNewline("❯ " + line)
 			}
 		}
 		if err := executor(ctx, k, args, func(i int) {


### PR DESCRIPTION
Fixes #4900

Sending `ftl --help`:
```
❯ ftl --help
Usage: ftl <command> [flags]

FTL is a platform for building distributed systems that are safe to operate,
easy to reason about, and fast to iterate and develop on.
```

Starting interactive `ftl` then sending `--help`
```
❯ ftl
❯ --help
Usage: ftl <command> [flags]

FTL is a platform for building distributed systems that are safe to operate,
easy to reason about, and fast to iterate and develop on.
```

Starting interactive `ftl dev` then sending `--help`
```
info:echo:build: Module built (1.69s)
info:build-engine: All modules deployed in 16.40s, watching for changes...
❯ --help
Usage: ftl <command> [flags]

FTL is a platform for building distributed systems that are safe to operate,
easy to reason about, and fast to iterate and develop on.
```