### PR TITLE
feat: breaking change detection

### DIFF
--- a/common/schema/change/change.go
+++ b/common/schema/change/change.go
@@ -1,0 +1,141 @@
+package change
+
+import (
+	"fmt"
+
+	"github.com/alecthomas/errors"
+	. "github.com/alecthomas/types/optional"
+
+	"github.com/block/ftl/common/schema"
+	"github.com/block/ftl/common/slices"
+	"github.com/block/ftl/internal/maps"
+)
+
+// Error returned by Validate
+type Error struct {
+	Pos schema.Position
+
+	Err error
+}
+
+func (e Error) Error() string { return fmt.Sprintf("%s: %s", e.Pos, e.Err) }
+func (e Error) Unwrap() error { return e.Err }
+
+// Breaking verifies that a type has not changed in a backwards incompatible way.
+//
+// For data structures, we support the following operations:
+//
+//   - Add new fields.
+//   - Remove optional fields.
+func Breaking(sch Option[*schema.Schema], prev, next schema.Type) error {
+	ms, _ := sch.Get()
+	return validate(ms, map[schema.Kind]bool{}, prev, next)
+}
+
+func validate(s *schema.Schema, seen map[schema.Kind]bool, prev, next schema.Type) error {
+	if prev.Kind() != next.Kind() {
+		return errorf(next, "type changed from %s to %s", prev.Kind(), next.Kind())
+	}
+	switch prev := prev.(type) {
+	case *schema.Ref:
+		if s == nil {
+			return errorf(prev, "schema is not set, cannot resolve reference %s", prev)
+		}
+		// This is a lot of stuff!
+		prevDecl, ok := s.Resolve(prev).Get()
+		if !ok {
+			return errorf(prev, "failed to resolve reference %s", prev)
+		}
+		nextDecl, ok := s.Resolve(next.(*schema.Ref)).Get() //nolint:forcetypeassert
+		if !ok {
+			return errorf(next, "failed to resolve reference %s", next)
+		}
+		nextType, ok := nextDecl.(schema.Type)
+		if !ok {
+			return errorf(next, "resolved reference was %T, not a type", next)
+		}
+		prevType, ok := prevDecl.(schema.Type)
+		if !ok {
+			return errorf(next, "resolved reference was %T, not a type", prev)
+		}
+		return validate(s, seen, prevType, nextType)
+
+	case *schema.Array:
+		next := next.(*schema.Array) //nolint:forcetypeassert
+		return contextf(validate(s, seen, prev.Element, next.Element), "array")
+
+	case *schema.Map:
+		next := next.(*schema.Map) //nolint:forcetypeassert
+		if err := validate(s, seen, prev.Key, next.Key); err != nil {
+			return contextf(err, "map key")
+		}
+		if err := validate(s, seen, prev.Value, next.Value); err != nil {
+			return contextf(err, "map value")
+		}
+		return nil
+
+	case *schema.Optional:
+		next := next.(*schema.Optional) //nolint:forcetypeassert
+		return contextf(validate(s, seen, prev.Type, next.Type), "optional")
+
+	case *schema.Data:
+		// Don't check generated data structures.
+		if _, ok := slices.FindVariant[*schema.MetadataGenerated](prev.Metadata); ok {
+			return nil
+		}
+		next := next.(*schema.Data) //nolint:forcetypeassert
+		return contextf(validateData(s, seen, prev, next), "%s", prev.Name)
+
+	case *schema.Enum:
+		next := next.(*schema.Enum) //nolint:forcetypeassert
+		// TODO: do we allow new enum values to be added? I think that breaks backwards compatibility.
+		if !prev.Equal(next) {
+			return errorf(prev, "enum values changed")
+		}
+		return nil
+
+	case *schema.TypeAlias:
+		next := next.(*schema.TypeAlias) //nolint:forcetypeassert
+		if prev.Name != next.Name {
+			return errorf(prev, "%s: type alias name changed to %s", prev.Name, next.Name)
+		}
+		return contextf(validate(s, seen, prev.Type, next.Type), "typealias %s", prev.Name)
+
+	case *schema.Any, *schema.Bool, *schema.Bytes, *schema.Float, *schema.Int, *schema.String, *schema.Time, *schema.Unit:
+	}
+	return nil
+}
+
+func validateData(s *schema.Schema, seen map[schema.Kind]bool, prev, next *schema.Data) error {
+	if prev.Name != next.Name {
+		return errorf(prev, "data name changed from %s to %s", prev.Name, next.Name)
+	}
+	prevf := maps.FromSlice(prev.Fields, func(f *schema.Field) (string, *schema.Field) { return f.Name, f })
+	nextf := maps.FromSlice(next.Fields, func(f *schema.Field) (string, *schema.Field) { return f.Name, f })
+	for name, prevField := range prevf {
+		nextField, ok := nextf[name]
+		if !ok {
+			return errorf(prevField, "field %s removed", name)
+		}
+		if err := validate(s, seen, prevField.Type, nextField.Type); err != nil {
+			return contextf(err, "%s", name)
+		}
+	}
+	return nil
+}
+
+func contextf(err error, format string, args ...any) error {
+	if err == nil {
+		return nil
+	}
+	cerr, ok := err.(Error) //nolint
+	if !ok {
+		return err
+	}
+
+	return Error{Pos: cerr.Pos, Err: errors.Errorf("%s: %w", fmt.Sprintf(format, args...), cerr.Err)}
+}
+
+func errorf(pos interface{ Position() schema.Position }, format string, args ...any) Error {
+	return Error{Pos: pos.Position(), Err: errors.Errorf(format, args...)}
+}

--- a/common/schema/change/change_test.go
+++ b/common/schema/change/change_test.go
@@ -1,0 +1,92 @@
+package change
+
+import (
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+	. "github.com/alecthomas/types/optional"
+
+	"github.com/block/ftl/common/schema"
+)
+
+func TestBreaking(t *testing.T) {
+	tests := []struct {
+		name       string
+		prev, next string
+		breaking   string
+	}{
+		{
+			name:     "TypeChange",
+			prev:     "String",
+			next:     "Int",
+			breaking: "previous.schema:1:1: type changed from string to int",
+		},
+		{
+			name: "NoTypeChange",
+			prev: "String",
+			next: "String",
+		},
+		{
+			name:     "DataRename",
+			prev:     `data Request {}`,
+			next:     `data Response {}`,
+			breaking: `previous.schema:1:1: Request: data name changed from Request to Response`,
+		},
+		{
+			name: "FieldTypeChange",
+			prev: `data Request {
+				name String
+				age Int
+			}`,
+			next: `data Request {
+				name String
+				age Time
+			}`,
+			breaking: `previous.schema:3:9: Request: age: type changed from int to time`,
+		},
+		{
+			name: "FieldRemoved",
+			prev: `data Request {
+				name String
+				age Int
+			}`,
+			next: `data Request {
+				name String
+				born Time
+			}`,
+			breaking: `previous.schema:3:5: Request: field age removed`,
+		},
+		{
+			name:     "ArrayElementTypeChange",
+			prev:     `[String]`,
+			next:     `[Int]`,
+			breaking: `previous.schema:1:2: array: type changed from string to int`,
+		},
+		{
+			name:     "TypeAliasRenamed",
+			prev:     `typealias A Int`,
+			next:     `typealias B Int`,
+			breaking: `previous.schema:1:1: A: type alias name changed to B`,
+		},
+		{
+			name:     "TypeAliasChanged",
+			prev:     `typealias A Int`,
+			next:     `typealias A String`,
+			breaking: `previous.schema:1:13: typealias A: type changed from int to string`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prev, err := schema.ParseType("previous.schema", tt.prev)
+			assert.NoError(t, err)
+			next, err := schema.ParseType("previous.schema", tt.next)
+			assert.NoError(t, err)
+			err = Breaking(None[*schema.Schema](), prev, next)
+			if tt.breaking != "" {
+				assert.EqualError(t, err, tt.breaking)
+			} else {
+				assert.NoError(t, err, "expected no error")
+			}
+		})
+	}
+}

--- a/common/schema/data.go
+++ b/common/schema/data.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/block/ftl/common/reflect"
 	"github.com/block/ftl/common/slices"
+	"github.com/block/ftl/internal/maps"
 )
 
 // A Data structure.
@@ -41,15 +42,13 @@ func (d *Data) Equal(other Type) bool {
 	if len(d.TypeParameters) != len(o.TypeParameters) {
 		return false
 	}
-	if len(d.Metadata) != len(o.Metadata) {
-		return false
-	}
 	if len(d.Fields) != len(o.Fields) {
 		return false
 	}
-	for _, f := range d.Fields {
-		fo := o.FieldByName(f.Name)
-		if fo == nil || f.Name != fo.Name || !f.Type.Equal(fo.Type) {
+	ourFields := maps.FromSlice(d.Fields, func(f *Field) (string, *Field) { return f.Name, f })
+	otherFields := maps.FromSlice(o.Fields, func(f *Field) (string, *Field) { return f.Name, f })
+	for name, field := range ourFields {
+		if otherField, ok := otherFields[name]; !ok || !field.Type.Equal(otherField.Type) {
 			return false
 		}
 	}

--- a/common/schema/field.go
+++ b/common/schema/field.go
@@ -7,7 +7,6 @@ import (
 	"github.com/alecthomas/types/optional"
 )
 
-//protobuf:15 Type
 type Field struct {
 	Pos Position `parser:"" protobuf:"1,optional"`
 

--- a/common/schema/parser.go
+++ b/common/schema/parser.go
@@ -16,7 +16,7 @@ var (
 	declUnion            = []Decl{&Data{}, &Verb{}, &Database{}, &Enum{}, &TypeAlias{}, &Config{}, &Secret{}, &Topic{}}
 	nonOptionalTypeUnion = []Type{
 		&Int{}, &Float{}, &String{}, &Bytes{}, &Bool{}, &Time{}, &Array{},
-		&Map{}, &Any{}, &Unit{},
+		&Map{}, &Any{}, &Unit{}, &Data{}, &TypeAlias{},
 		// Note: any types resolved by identifier (eg. "Any", "Unit", etc.) must
 		// be prior to Ref.
 		&Ref{},


### PR DESCRIPTION
This is intended for use with external API boundaries, including values that are being persisted to storage.

Currently this disallows:

- Removing (or renaming) fields in data structures.
- Changing a type.
- Adding or removing enum values - adding is disallowed because a consumer that doesn't expect the new value will fail. Not ideal.