### PR TITLE
fix: better maven output

### DIFF
--- a/jvm-runtime/ftl-runtime/common/build-parent/pom.xml
+++ b/jvm-runtime/ftl-runtime/common/build-parent/pom.xml
@@ -74,6 +74,7 @@
                 <configuration>
                     <compilerArgs>
                         <arg>-parameters</arg>
+                        <arg>-proc:full</arg>
                     </compilerArgs>
                 </configuration>
             </plugin>

--- a/jvm-runtime/plugin/common/commands.go
+++ b/jvm-runtime/plugin/common/commands.go
@@ -104,7 +104,7 @@ func (CmdService) GetModuleConfigDefaults(ctx context.Context, req *connect.Requ
 	buildGradleKts := filepath.Join(dir, "build.gradle.kts")
 	if fileExists(pom) {
 		defaults.LanguageConfig.Fields["build-tool"] = structpb.NewStringValue(JavaBuildToolMaven)
-		defaults.DevModeBuild = ptr("mvn -Dquarkus.console.enabled=false -q clean quarkus:dev")
+		defaults.DevModeBuild = ptr("mvn -Dquarkus.console.enabled=false clean quarkus:dev")
 		defaults.Build = ptr("mvn -B clean package")
 		defaults.DeployDir = "target"
 		defaults.Watch = append(defaults.Watch, "pom.xml")

--- a/jvm-runtime/plugin/common/java_plugin_test.go
+++ b/jvm-runtime/plugin/common/java_plugin_test.go
@@ -31,7 +31,7 @@ func TestJavaConfigDefaults(t *testing.T) {
 			dir:      "testdata/kotlin/echo",
 			expected: moduleconfig.CustomDefaults{
 				Build:        optional.Some("mvn -B clean package"),
-				DevModeBuild: optional.Some("mvn -Dquarkus.console.enabled=false -q clean quarkus:dev"),
+				DevModeBuild: optional.Some("mvn -Dquarkus.console.enabled=false clean quarkus:dev"),
 				DeployDir:    "target",
 				LanguageConfig: map[string]any{
 					"build-tool": "maven",
@@ -51,7 +51,7 @@ func TestJavaConfigDefaults(t *testing.T) {
 			dir:      "testdata/kotlin/external",
 			expected: moduleconfig.CustomDefaults{
 				Build:        optional.Some("mvn -B clean package"),
-				DevModeBuild: optional.Some("mvn -Dquarkus.console.enabled=false -q clean quarkus:dev"),
+				DevModeBuild: optional.Some("mvn -Dquarkus.console.enabled=false clean quarkus:dev"),
 				DeployDir:    "target",
 				LanguageConfig: map[string]any{
 					"build-tool": "maven",


### PR DESCRIPTION
- Don't run with -q by default, so all info can be logged
- Log normal maven output at debug level, so it is not visible by default but can easily be retrieved
- Dump full maven output if startup fails
- Return error output to the build engine

fixes: #5066