### PR TITLE
fix: allow kong to set flags based on env

### DIFF
--- a/cmd/ftl/cmd_mysql.go
+++ b/cmd/ftl/cmd_mysql.go
@@ -10,6 +10,6 @@ type newMySQLCmd struct {
 }
 
 func (c *newMySQLCmd) BeforeApply() error { //nolint:unparam
-	c.Datasource = newNewSQLCmd("mysql")
+	c.Datasource.engine = "mysql"
 	return nil
 }

--- a/cmd/ftl/cmd_postgres.go
+++ b/cmd/ftl/cmd_postgres.go
@@ -10,6 +10,6 @@ type newPostgresCmd struct {
 }
 
 func (c *newPostgresCmd) BeforeApply() error { //nolint:unparam
-	c.Datasource = newNewSQLCmd("postgres")
+	c.Datasource.engine = "postgres"
 	return nil
 }

--- a/cmd/ftl/cmd_sql_new.go
+++ b/cmd/ftl/cmd_sql_new.go
@@ -22,10 +22,6 @@ type newSQLCmd struct {
 	DevDirs []string `help:"Module directories that FTL Dev is discovering modules in" env:"FTL_DEV_DIRS" hidden:""`
 }
 
-func newNewSQLCmd(engine string) newSQLCmd {
-	return newSQLCmd{engine: engine}
-}
-
 func (i newSQLCmd) Run(ctx context.Context, projectConfig projectconfig.Config) error {
 	var searchDirs []string
 	if len(i.DevDirs) > 0 {


### PR DESCRIPTION
Setting the sub command struct value broke Kong's defaulting for env values.
Updated the logic to just update the field we care about, which fixes the issue.


Previously:
```
ftl dev somedir <-- a dir with a users module
ftl mysql new users.db
```
This would fail because the `ftl mysql new` command did not know where the modules could be found (passed as a env var)