### PR TITLE
chore: add realm to deployment key

### DIFF
--- a/backend/controller/state/controllerstate_test.go
+++ b/backend/controller/state/controllerstate_test.go
@@ -23,7 +23,7 @@ func TestRunnerState(t *testing.T) {
 	create := time.Now()
 	endpoint := "http://localhost:8080"
 	module := "test"
-	deploymentKey := key.NewDeploymentKey(module)
+	deploymentKey := key.NewDeploymentKey("test", module)
 
 	err = cs.Publish(ctx, &state.RunnerRegisteredEvent{
 		Key:        runnerkey,

--- a/backend/cron/service_test.go
+++ b/backend/cron/service_test.go
@@ -41,7 +41,7 @@ func TestCron(t *testing.T) {
 		Name: "echo",
 		Runtime: &schema.ModuleRuntime{
 			Deployment: &schema.ModuleRuntimeDeployment{
-				DeploymentKey: key.NewDeploymentKey("echo"),
+				DeploymentKey: key.NewDeploymentKey("test", "echo"),
 			},
 		},
 		Decls: []schema.Decl{

--- a/backend/ingress/handler_test.go
+++ b/backend/ingress/handler_test.go
@@ -113,7 +113,7 @@ func TestIngress(t *testing.T) {
 				Name: "test",
 				Runtime: &schema.ModuleRuntime{
 					Deployment: &schema.ModuleRuntimeDeployment{
-						DeploymentKey: key.NewDeploymentKey("test"),
+						DeploymentKey: key.NewDeploymentKey("test", "test"),
 					},
 					Runner: &schema.ModuleRuntimeRunner{
 						Endpoint: "http://localhost:8080",

--- a/backend/provisioner/deployment_test.go
+++ b/backend/provisioner/deployment_test.go
@@ -48,7 +48,7 @@ func TestDeployment_Progress(t *testing.T) {
 		dpl := registry.CreateDeployment(ctx, key.NewChangesetKey(), &schema.Module{
 			Name: "testModule",
 			Runtime: &schema.ModuleRuntime{
-				Deployment: &schema.ModuleRuntimeDeployment{DeploymentKey: key.NewDeploymentKey("test-module")},
+				Deployment: &schema.ModuleRuntimeDeployment{DeploymentKey: key.NewDeploymentKey("test", "testModule")},
 			},
 			Decls: []schema.Decl{
 				&schema.Database{Name: "a", Type: "mysql"},

--- a/backend/provisioner/dev_provisioner.go
+++ b/backend/provisioner/dev_provisioner.go
@@ -147,9 +147,9 @@ func establishMySQLDB(ctx context.Context, mysqlDSN string, dbName string, mysql
 	}, nil
 }
 
-func ProvisionPostgresForTest(ctx context.Context, moduleName string, id string) (string, error) {
+func ProvisionPostgresForTest(ctx context.Context, realm, module, id string) (string, error) {
 	node := &schema.Database{Name: id + "_test"}
-	event, err := provisionPostgres(15432, true)(ctx, key.NewChangesetKey(), key.NewDeploymentKey(moduleName), node, nil)
+	event, err := provisionPostgres(15432, true)(ctx, key.NewChangesetKey(), key.NewDeploymentKey(realm, module), node, nil)
 	if err != nil {
 		return "", err
 	}
@@ -157,9 +157,9 @@ func ProvisionPostgresForTest(ctx context.Context, moduleName string, id string)
 	return event.Element.(*schema.DatabaseRuntime).Connections.Write.(*schema.DSNDatabaseConnector).DSN, nil //nolint:forcetypeassert
 }
 
-func ProvisionMySQLForTest(ctx context.Context, moduleName string, id string) (string, error) {
+func ProvisionMySQLForTest(ctx context.Context, realm, module, id string) (string, error) {
 	node := &schema.Database{Name: id + "_test"}
-	event, err := provisionMysql(13306, true)(ctx, key.NewChangesetKey(), key.NewDeploymentKey(moduleName), node, nil)
+	event, err := provisionMysql(13306, true)(ctx, key.NewChangesetKey(), key.NewDeploymentKey(realm, module), node, nil)
 	if err != nil {
 		return "", err
 	}

--- a/backend/provisioner/scaling/kube_scaling_integration_test.go
+++ b/backend/provisioner/scaling/kube_scaling_integration_test.go
@@ -61,9 +61,9 @@ func runTest(t *testing.T, namespace func(dep string) string, helmArgs ...string
 			assert.NoError(t, err)
 			typesDeployed := false
 			for _, dep := range deps.Items {
-				if strings.HasPrefix(dep.Name, "dpl-echo") {
+				if strings.HasPrefix(dep.Name, "dpl-default-echo") {
 					echoDeployment["name"] = dep.Name
-				} else if strings.HasPrefix(dep.Name, "dpl-types") {
+				} else if strings.HasPrefix(dep.Name, "dpl-default-types") {
 					typesDeployed = true
 				}
 				assert.Equal(t, 1, *dep.Spec.Replicas)
@@ -76,7 +76,7 @@ func runTest(t *testing.T, namespace func(dep string) string, helmArgs ...string
 			deps, err := client.AppsV1().Deployments(namespace("echo")).List(ctx, v1.ListOptions{})
 			assert.NoError(t, err)
 			for _, dep := range deps.Items {
-				if strings.HasPrefix(dep.Name, "dpl-echo") {
+				if strings.HasPrefix(dep.Name, "dpl-default-echo") {
 					assert.Equal(t, 2, *dep.Spec.Replicas)
 				}
 			}
@@ -116,7 +116,7 @@ func runTest(t *testing.T, namespace func(dep string) string, helmArgs ...string
 			deps, err := client.AppsV1().Deployments(namespace("echo")).List(ctx, v1.ListOptions{})
 			assert.NoError(t, err)
 			for _, dep := range deps.Items {
-				if strings.HasPrefix(dep.Name, "dpl-echo") {
+				if strings.HasPrefix(dep.Name, "dpl-default-echo") {
 					// We should have inherited the scaling from the previous deployment
 					assert.Equal(t, 2, *dep.Spec.Replicas)
 				}
@@ -156,7 +156,7 @@ func runTest(t *testing.T, namespace func(dep string) string, helmArgs ...string
 			assert.NoError(t, err)
 			depCount := 0
 			for _, dep := range deps.Items {
-				if strings.HasPrefix(dep.Name, "dpl-echo") {
+				if strings.HasPrefix(dep.Name, "dpl-default-echo") {
 					t.Logf("Found deployment %s", dep.Name)
 					depCount++
 					service, err := client.CoreV1().Services(namespace("echo")).Get(ctx, dep.Name, v1.GetOptions{})
@@ -175,7 +175,7 @@ func runTest(t *testing.T, namespace func(dep string) string, helmArgs ...string
 			assert.NoError(t, err)
 			depCount := 0
 			for _, dep := range deps.Items {
-				if strings.HasPrefix(dep.Name, "dpl-echo") {
+				if strings.HasPrefix(dep.Name, "dpl-default-echo") {
 					t.Logf("Found deployment %s", dep.Name)
 					depCount++
 				}

--- a/backend/runner/pubsub/integration_test.go
+++ b/backend/runner/pubsub/integration_test.go
@@ -99,7 +99,7 @@ func TestConsumerGroupMembership(t *testing.T) {
 				assert.True(t, time.Since(start) < 15*time.Second)
 				ps, err := exec.Capture(ic.Context, ".", "ftl", "ps")
 				assert.NoError(t, err)
-				if strings.Count(string(ps), "dpl-subscriber-") == 1 {
+				if strings.Count(string(ps), "dpl-default-subscriber-") == 1 {
 					// original deployment has ended
 					now := time.Now()
 					deploymentKilledTime = &now

--- a/backend/schemaservice/changesetstate_test.go
+++ b/backend/schemaservice/changesetstate_test.go
@@ -20,7 +20,7 @@ func TestChangesetState(t *testing.T) {
 		Name: "test",
 		Runtime: &schema.ModuleRuntime{
 			Deployment: &schema.ModuleRuntimeDeployment{
-				DeploymentKey: key.NewDeploymentKey("test"),
+				DeploymentKey: key.NewDeploymentKey("test", "test"),
 			},
 		},
 	}

--- a/backend/schemaservice/eventextractor_test.go
+++ b/backend/schemaservice/eventextractor_test.go
@@ -20,7 +20,7 @@ func TestEventExtractor(t *testing.T) {
 
 	// TODO: lots of tests once we have new runtime events
 	empty := ""
-	newKey, err := key.ParseDeploymentKey("dpl-test-sjkfislfjslfae")
+	newKey, err := key.ParseDeploymentKey("dpl-test-test-sjkfislfjslfae")
 	assert.NoError(t, err)
 	tests := []struct {
 		name     string

--- a/backend/schemaservice/schemaservice.go
+++ b/backend/schemaservice/schemaservice.go
@@ -215,7 +215,7 @@ func (s *Service) CreateChangeset(ctx context.Context, req *connect.Request[ftlv
 			}
 		} else {
 			// Allocate a deployment key for the module.
-			out.ModRuntime().ModDeployment().DeploymentKey = key.NewDeploymentKey(m.Name)
+			out.ModRuntime().ModDeployment().DeploymentKey = key.NewDeploymentKey(realmChange.Name, m.Name)
 		}
 		return out, nil
 	})

--- a/backend/schemaservice/state_test.go
+++ b/backend/schemaservice/state_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestSchemaStateMarshalling(t *testing.T) {
-	k := key.NewDeploymentKey("test")
+	k := key.NewDeploymentKey("test", "test")
 	state := SchemaState{
 		deployments: map[string]*schema.Module{
 			"test": {
@@ -32,7 +32,7 @@ func TestSchemaStateMarshalling(t *testing.T) {
 func TestStateMarshallingAfterCommonEvents(t *testing.T) {
 	state := NewSchemaState()
 
-	deploymentKey := key.NewDeploymentKey("test2")
+	deploymentKey := key.NewDeploymentKey("test", "test2")
 	changesetKey := key.NewChangesetKey()
 	ctx := log.ContextWithNewDefaultLogger(context.Background())
 	assert.NoError(t, state.ApplyEvent(ctx, &schema.ChangesetCreatedEvent{

--- a/cmd/go2proto/testdata/model_test.go
+++ b/cmd/go2proto/testdata/model_test.go
@@ -44,7 +44,7 @@ func TestModel(t *testing.T) {
 	data, err := proto.Marshal(pb)
 	assert.NoError(t, err)
 	assert.True(t, bytes.Contains(data, []byte("http://127.0.0.1")), "missing url")
-	assert.True(t, bytes.Contains(data, []byte("dpl-echo-")), "missing deployment key")
+	assert.True(t, bytes.Contains(data, []byte("dpl-test-echo-")), "missing deployment key")
 	assert.True(t, bytes.Contains(data, []byte("bar")), "missing sum type value")
 	out := &testdatapb.Root{}
 	err = proto.Unmarshal(data, out)

--- a/go-runtime/ftl/ftltest/database.go
+++ b/go-runtime/ftl/ftltest/database.go
@@ -43,7 +43,7 @@ func setupTestDatabase(ctx context.Context, state *OptionsState, dbType, dbName 
 	}
 	switch dbType {
 	case "postgres":
-		dsn, err := provisioner.ProvisionPostgresForTest(ctx, moduleGetter(), dbName)
+		dsn, err := provisioner.ProvisionPostgresForTest(ctx, moduleGetter(), "test", dbName)
 		if err != nil {
 			return fmt.Errorf("could not provision database %q: %w", dbName, err)
 		}
@@ -62,7 +62,7 @@ func setupTestDatabase(ctx context.Context, state *OptionsState, dbType, dbName 
 		}
 		state.databases[dbName] = replacementDB
 	case "mysql":
-		dsn, err := provisioner.ProvisionMySQLForTest(ctx, moduleGetter(), dbName)
+		dsn, err := provisioner.ProvisionMySQLForTest(ctx, moduleGetter(), "test", dbName)
 		if err != nil {
 			return fmt.Errorf("could not provision database %q: %w", dbName, err)
 		}

--- a/internal/key/deployment_key_test.go
+++ b/internal/key/deployment_key_test.go
@@ -9,34 +9,32 @@ import (
 func TestDeploymentKey(t *testing.T) {
 	ensureDeterministicRand(t)
 	for _, test := range []struct {
-		key         Deployment
-		str         string
+		keyStr      string
 		expected    Deployment
 		expectedErr string
-	}{
-		{key: NewDeploymentKey("time"),
-			expected: Deployment{
-				Payload: DeploymentPayload{Module: "time"},
-				Suffix:  "17snepfuemu5iab",
-			},
+	}{{
+		keyStr: NewDeploymentKey("test", "time").String(),
+		expected: Deployment{
+			Payload: DeploymentPayload{Realm: "test", Module: "time"},
+			Suffix:  "17snepfuemu5iab",
 		},
-		{key: NewDeploymentKey("time"),
-			expected: Deployment{
-				Payload: DeploymentPayload{Module: "time"},
-				Suffix:  "5g5cadeqxpqe574v",
-			},
+	}, {
+		keyStr: NewDeploymentKey("test", "time").String(),
+		expected: Deployment{
+			Payload: DeploymentPayload{Realm: "test", Module: "time"},
+			Suffix:  "5g5cadeqxpqe574v",
 		},
-		{str: "-0011223344", expectedErr: `expected prefix "dpl" for key "-0011223344"`},
-		{key: NewDeploymentKey("module-with-hyphens"), expected: Deployment{
-			Payload: DeploymentPayload{Module: "module-with-hyphens"},
+	}, {
+		keyStr:      "-0011223344",
+		expectedErr: `expected prefix "dpl" for key "-0011223344"`,
+	}, {
+		keyStr: NewDeploymentKey("test", "module_without_hyphens").String(),
+		expected: Deployment{
+			Payload: DeploymentPayload{Realm: "test", Module: "module_without_hyphens"},
 			Suffix:  "59gwlv6lkyexwxf1",
-		},
-		},
+		}},
 	} {
-		keyStr := test.str
-		if keyStr == "" {
-			keyStr = test.key.String()
-		}
+		keyStr := test.keyStr
 		t.Run(keyStr, func(t *testing.T) {
 			decoded, err := ParseDeploymentKey(keyStr)
 			if test.expectedErr != "" {

--- a/internal/routing/routing_test.go
+++ b/internal/routing/routing_test.go
@@ -22,7 +22,7 @@ func TestRouting(t *testing.T) {
 		Name: "time",
 		Runtime: &schema.ModuleRuntime{
 			Deployment: &schema.ModuleRuntimeDeployment{
-				DeploymentKey: deploymentKey(t, "dpl-time-sjkfislfjslfas"),
+				DeploymentKey: deploymentKey(t, "dpl-default-time-sjkfislfjslfas"),
 			},
 			Runner: &schema.ModuleRuntimeRunner{
 				Endpoint: "http://time.ftl",
@@ -39,7 +39,7 @@ func TestRouting(t *testing.T) {
 		Name: "echo",
 		Runtime: &schema.ModuleRuntime{
 			Deployment: &schema.ModuleRuntimeDeployment{
-				DeploymentKey: deploymentKey(t, "dpl-echo-sjkfiaslfjslfs"),
+				DeploymentKey: deploymentKey(t, "dpl-default-echo-sjkfiaslfjslfs"),
 			},
 			Runner: &schema.ModuleRuntimeRunner{
 				Endpoint: "http://echo.ftl",

--- a/internal/schema/schemaeventsource/schemaeventsource_test.go
+++ b/internal/schema/schemaeventsource/schemaeventsource_test.go
@@ -95,9 +95,9 @@ func TestSchemaEventSource(t *testing.T) {
 			},
 		},
 	}
-	time1.ModRuntime().ModDeployment().DeploymentKey = key.NewDeploymentKey("time")
-	echo1.ModRuntime().ModDeployment().DeploymentKey = key.NewDeploymentKey("echo")
-	time2.ModRuntime().ModDeployment().DeploymentKey = key.NewDeploymentKey("time")
+	time1.ModRuntime().ModDeployment().DeploymentKey = key.NewDeploymentKey("test", "time")
+	echo1.ModRuntime().ModDeployment().DeploymentKey = key.NewDeploymentKey("test", "echo")
+	time2.ModRuntime().ModDeployment().DeploymentKey = key.NewDeploymentKey("test", "time")
 	time1.ModRuntime().ModDeployment().State = schema.DeploymentStateCanonical
 	echo1.ModRuntime().ModDeployment().State = schema.DeploymentStateCanonical
 	time2.ModRuntime().ModDeployment().State = schema.DeploymentStateCanonical


### PR DESCRIPTION
This will enable us to propagate the realm name with deployments.
For now, the realm defaults to "default" everywhere, but next we will propagate that from the project config properly and store to state