### PR TITLE
fix: reset goose session directly and rename file to jsonl

### DIFF
--- a/backend/goose/goose.go
+++ b/backend/goose/goose.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"os/exec" //nolint:depguard
-	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
@@ -38,17 +37,6 @@ type Client struct {
 
 func NewClient() *Client {
 	return &Client{}
-}
-
-func ResetContext(projectRoot string) error {
-	gooseLogsPath := filepath.Join(projectRoot, ".ftl", "goose-logs.json")
-	if err := os.Remove(gooseLogsPath); err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return fmt.Errorf("failed to remove Goose logs: %w", err)
-	}
-	return nil
 }
 
 // Execute runs a Goose command with the given prompt and streams cleaned messages

--- a/cmd/ftl/cmd_dev.go
+++ b/cmd/ftl/cmd_dev.go
@@ -13,7 +13,6 @@ import (
 	"github.com/alecthomas/types/optional"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/block/ftl/backend/goose"
 	"github.com/block/ftl/backend/protos/xyz/block/ftl/admin/v1/adminpbconnect"
 	"github.com/block/ftl/backend/protos/xyz/block/ftl/buildengine/v1/buildenginepbconnect"
 	"github.com/block/ftl/internal/bind"
@@ -65,7 +64,7 @@ func (d *devCmd) Run(
 	log.SetupDebugFileLogging(ctx, projConfig.Root(), maxLogs)
 
 	// Reset Goose context to ensure it doesn't have any stale state from previous runs.
-	if err := goose.ResetContext(projConfig.Root()); err != nil {
+	if err := resetGooseSession(projConfig); err != nil {
 		return fmt.Errorf("failed to reset Goose context: %w", err)
 	}
 

--- a/cmd/ftl/cmd_goose.go
+++ b/cmd/ftl/cmd_goose.go
@@ -14,7 +14,6 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
-	"github.com/block/ftl/backend/goose"
 	"github.com/block/ftl/backend/protos/xyz/block/ftl/admin/v1/adminpbconnect"
 	"github.com/block/ftl/backend/protos/xyz/block/ftl/buildengine/v1/buildenginepbconnect"
 	"github.com/block/ftl/internal/exec"
@@ -36,14 +35,22 @@ type gooseResetCmd struct {
 }
 
 func (c *gooseResetCmd) Run(projectConfig projectconfig.Config) error {
-	if err := goose.ResetContext(projectConfig.Root()); err != nil {
-		return fmt.Errorf("failed to reset Goose context: %w", err)
-	}
-	return nil
+	return resetGooseSession(projectConfig)
 }
 
 func logPath(projectConfig projectconfig.Config) string {
-	return filepath.Join(projectConfig.Root(), ".ftl", "goose-logs.json")
+	return filepath.Join(projectConfig.Root(), ".ftl", "goose-logs.jsonl")
+}
+
+func resetGooseSession(projectConfig projectconfig.Config) error {
+	gooseLogsPath := logPath(projectConfig)
+	if err := os.Remove(gooseLogsPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to remove Goose logs: %w", err)
+	}
+	return nil
 }
 
 type gooseChatCmd struct {


### PR DESCRIPTION
This way we don't have `cmd_goose` calling `backend/goose` and backend/goose calling `ftl goose`.
Moving to `jsonl` file extension to reflect the real data type
