### PR TITLE
fix: reduce time it takes for engine to idle

### DIFF
--- a/internal/buildengine/engine.go
+++ b/internal/buildengine/engine.go
@@ -768,7 +768,7 @@ func (e *Engine) watchForEventsToPublish(ctx context.Context, hasInitialModules 
 		}
 		if !idle && isIdle(moduleStates) {
 			endTime = time.Now()
-			becomeIdleTimer = time.After(time.Second * 2)
+			becomeIdleTimer = time.After(time.Millisecond * 500)
 		}
 	}
 }


### PR DESCRIPTION
This speeds up goose a lot as it doesnt need to wait as long to know that all modules are finished building