### PR TITLE
chore: remove registry from .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,3 @@
 engine-strict=true
 shamefully-hoist=true
 update-notifier=false
-registry="https://registry.npmjs.org"


### PR DESCRIPTION
This prevents us from overriding npm registry in our own npmrc files in a corporate environment