### PR TITLE
fix: TestPubSub was slow

### DIFF
--- a/backend/runner/pubsub/testdata/kotlin/publisher/src/main/kotlin/xyz/block/ftl/java/test/publisher/Publisher.kt
+++ b/backend/runner/pubsub/testdata/kotlin/publisher/src/main/kotlin/xyz/block/ftl/java/test/publisher/Publisher.kt
@@ -60,6 +60,6 @@ class Publisher {
 
     @Subscription(topic = LocalTopic::class, from = FromOffset.LATEST)
     fun local(event: PubSubEvent) {
-        Log.infof("Consuing from local %s", event.time)
+        Log.infof("Consuming from local %s", event.time)
     }
 }


### PR DESCRIPTION
fixes https://github.com/block/ftl/issues/5163

Cause: After loading RedPanda in CI, the first consumer group can take longer to claim partitions than other times.
This caused the first pubsub test to fail (`TestPubSub/java`). After all three languages were attempted, we would then retry all 3, which would succeed. This doubled the time it took to run this test.

Fix: We already had a delay to wait for consumers to be read in the test. Increasing that delay should fix this annoying issue.