### PR TITLE
chore: make previously flaky pubsub test strict again

### DIFF
--- a/backend/runner/pubsub/consumer.go
+++ b/backend/runner/pubsub/consumer.go
@@ -347,7 +347,7 @@ func (c *consumer) ConsumeClaim(session sarama.ConsumerGroupSession, claim saram
 				if errors.As(err, &connectErr) {
 					// Connection error, do not count as an attempt
 					// This can happen when a runner is shutting down. This should never mark the message as consumed.
-					time.Sleep(time.Second)
+					time.Sleep(time.Millisecond * 500)
 					continue
 				}
 				if remainingRetries == 0 {

--- a/backend/runner/pubsub/integration_test.go
+++ b/backend/runner/pubsub/integration_test.go
@@ -113,7 +113,7 @@ func TestConsumerGroupMembership(t *testing.T) {
 		// the group properly.
 		checkGroupMembership("subscriber", "consumeSlow", 1),
 		func(t testing.TB, ic in.TestContext) {
-			assert.True(t, time.Since(*deploymentKilledTime) < 10*time.Second, "make sure old deployment was removed from consumer group fast enough")
+			assert.True(t, time.Since(*deploymentKilledTime) < 3*time.Second, "make sure old deployment was removed from consumer group fast enough (%v)", time.Since(*deploymentKilledTime))
 		},
 
 		// confirm that each message was consumed successfully


### PR DESCRIPTION
closes https://github.com/block/ftl/issues/4831
`TestConsumerGroupMembership` tries to make sure that runners de-register themselves from redpanda on shutdown.
That test was flakey though, and so the duration was made more leniant. But that meant the test didn't really check anything as the new timeout was longer than redpandas timeout, so if our runners didn't notify redpanda the test would still pass.

A recent fix to how we handle shutdowns while consuming may have fixed the flakiness, so we can make the test strict again.
Please revert this PR if the test remains flakey...
