### PR TITLE
fix: use light blue for debugging output.

### DIFF
--- a/internal/log/plain.go
+++ b/internal/log/plain.go
@@ -59,7 +59,7 @@ var (
 	})
 	levelColours = map[Level]string{
 		Trace: "\x1b[90m", // Dark gray
-		Debug: "\x1b[34m", // Blue
+		Debug: "\x1b[94m", // Light Blue
 		Info:  "\x1b[37m", // White
 		Warn:  "\x1b[33m", // Yellow
 		Error: "\x1b[31m", // Red


### PR DESCRIPTION
Dark blue is not very readable on black background

Before: 
<img width="682" alt="Screenshot 2025-04-17 at 4 10 24 pm" src="https://github.com/user-attachments/assets/137ea0f1-f55a-470b-9191-80bbd048ed82" />

After: 
<img width="548" alt="Screenshot 2025-04-17 at 4 18 02 pm" src="https://github.com/user-attachments/assets/a8f39a6e-7ab7-4ff6-b3ab-ede886210045" />

And after with white background:
<img width="584" alt="Screenshot 2025-04-17 at 4 18 28 pm" src="https://github.com/user-attachments/assets/83bb4baa-7405-4da8-b051-0cd0079e8740" />
