### PR TITLE
fix: `ftl dev` handles build engine initiation error

### DIFF
--- a/cmd/ftl/cmd_dev.go
+++ b/cmd/ftl/cmd_dev.go
@@ -108,6 +108,9 @@ func (d *devCmd) Run(
 
 	opts := []buildengine.Option{buildengine.Parallelism(d.Build.Parallelism), buildengine.BuildEnv(d.Build.BuildEnv), buildengine.WithDevMode(devModeEndpointUpdates), buildengine.WithStartTime(startTime)}
 	engine, err := buildengine.New(ctx, deployClient, schemaEventSource, projConfig, d.Build.Dirs, false, opts...)
+	if err != nil {
+		return errors.WithStack(err)
+	}
 
 	// cmdServe will notify this channel when startup commands are complete and the controller is ready
 	controllerReady := make(chan bool, 1)
@@ -138,10 +141,6 @@ func (d *devCmd) Run(
 		case <-controllerReady:
 		}
 		starting.Close()
-
-		if err != nil {
-			return errors.WithStack(err)
-		}
 
 		return errors.WithStack(engine.Dev(ctx, d.Watch))
 	})


### PR DESCRIPTION
Looks like this PR moved the engine code but not the error handling code: https://github.com/block/ftl/pull/5125