### PR TITLE
fix: reload and rebuild modules when configuration changes

### DIFF
--- a/examples/go/echo/types.ftl.go
+++ b/examples/go/echo/types.ftl.go
@@ -2,20 +2,23 @@
 package echo
 
 import (
-	"context"
-	ftltime "ftl/time"
-	"github.com/block/ftl/common/reflection"
-	"github.com/block/ftl/go-runtime/server"
+    "context"
+    "github.com/block/ftl/common/reflection"
+    "github.com/block/ftl/go-runtime/server"
+    ftltime "ftl/time"
 )
 
+	
 type EchoClient func(context.Context, EchoRequest) (EchoResponse, error)
+	
 
 func init() {
 	reflection.Register(
-
+	
+	
 		reflection.ProvideResourcesForVerb(
-			Echo,
-			server.VerbClient[ftltime.TimeClient, ftltime.TimeRequest, ftltime.TimeResponse](),
+            Echo,
+            server.VerbClient[ftltime.TimeClient, ftltime.TimeRequest, ftltime.TimeResponse](),
 			server.Config[string]("echo", "default"),
 		),
 	)


### PR DESCRIPTION
Fixes #5039

This handles changes to the configuration by reloading and rebuilding modules. It also adds logging to the `BuildAndDeploy` calls so we can better track errors.

https://github.com/user-attachments/assets/950c2b73-85ff-4889-a721-ba64b8788320

