### PR TITLE
fix: don't clear `ftl dev` from terminal

### DIFF
--- a/internal/terminal/interactive.go
+++ b/internal/terminal/interactive.go
@@ -92,6 +92,7 @@ func (r *interactiveConsole) run(ctx context.Context, executor CommandExecutor) 
 	ok := false
 	if tsm, ok = sm.(*terminalStatusManager); ok {
 		tsm.statusLock.Lock()
+		_, _ = fmt.Fprintln(tsm.old) //nolint:errcheck
 		tsm.clearStatusMessages()
 		tsm.consoleRefresh = r.l.Refresh
 		tsm.recalculateLines()


### PR DESCRIPTION
Fixes #5208

BEFORE:
![Screenshot 2025-04-25 at 11 58 46 AM](https://github.com/user-attachments/assets/b8cc90b4-9159-41c9-9c2e-2f9587795539)

AFTER:
![Screenshot 2025-04-25 at 12 10 54 PM](https://github.com/user-attachments/assets/d8d47fad-dbd3-4eb2-bed5-deb6822d4e13)

Warp is still ok too:
![Screenshot 2025-04-25 at 12 13 10 PM](https://github.com/user-attachments/assets/f25a984f-6a4e-427a-881e-ca188069f5af)
