### PR TITLE
fix: don't skip os.Exit(code)

### DIFF
--- a/cmd/ftl/main.go
+++ b/cmd/ftl/main.go
@@ -228,7 +228,7 @@ func createKongApplication(cli any, csm *currentStatusManager) *kong.Kong {
 			if sm, ok := csm.statusManager.Get(); ok {
 				sm.Close()
 			}
-			signal.Ignore(syscall.SIGINT) // We don't want to die with the process group, as that prevents os.Exit from executing.
+			signal.Ignore(syscall.SIGINT)                       // We don't want to die with the process group, as that prevents os.Exit from executing.
 			_ = syscall.Kill(-syscall.Getpid(), syscall.SIGINT) //nolint:forcetypeassert,errcheck // best effort
 			os.Exit(code)
 		},


### PR DESCRIPTION
Killing the process group with SIGINT resulted in the main process terminating with an exit code of 0, regardless of the real exit code. This change ignores SIGINT just prior to killing the process group.

```
~/dev/ftl $ ftl status
Usage: ftl <command> [flags]
Run "ftl --help" for more information.

ftl: error: unexpected argument status
~/dev/ftl $ echo $?
0
```

After:

```
~/dev/ftl $ ftl status
Usage: ftl <command> [flags]
Run "ftl --help" for more information.

ftl: error: unexpected argument status
~/dev/ftl $ echo $?
80
```