### PR TITLE
feat: Add edit cli command to open decls in editors

### DIFF
--- a/cmd/ftl/cmd_edit.go
+++ b/cmd/ftl/cmd_edit.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+
+	errors "github.com/alecthomas/errors"
+
+	"github.com/block/ftl/backend/protos/xyz/block/ftl/admin/v1/adminpbconnect"
+	"github.com/block/ftl/backend/protos/xyz/block/ftl/buildengine/v1/buildenginepbconnect"
+	"github.com/block/ftl/common/reflection"
+	"github.com/block/ftl/common/schema"
+	"github.com/block/ftl/internal/devstate"
+	"github.com/block/ftl/internal/editor"
+	"github.com/block/ftl/internal/projectconfig"
+)
+
+type editCmd struct {
+	Ref    reflection.Ref `arg:"" help:"Language of the module to create." placeholder:"MODULE.ITEM" predictor:"decls"`
+	Editor string         `arg:"" help:"Editor to open the file with." enum:"${supportedEditors}"`
+}
+
+func (editCmd) Completions() map[string][]string {
+	return map[string][]string{
+		"Editor": editor.SupportedEditors,
+	}
+}
+
+func (i editCmd) Run(ctx context.Context, buildEngineClient buildenginepbconnect.BuildEngineServiceClient, adminClient adminpbconnect.AdminServiceClient, pc projectconfig.Config) error {
+	state, err := devstate.WaitForDevState(ctx, buildEngineClient, adminClient, false)
+	if err != nil {
+		return errors.Wrapf(err, "could not get dev state; is FTL running?")
+	}
+
+	odecl, _ := state.Schema.ResolveWithModule(&schema.Ref{Module: i.Ref.Module, Name: i.Ref.Name})
+	decl, ok := odecl.Get()
+	if !ok {
+		return errors.Errorf("could not find %q", i.Ref)
+	}
+	if decl.Position().Filename == "" {
+		return errors.Errorf("could not find file of %q", i.Ref)
+	}
+
+	err = editor.OpenFileInEditor(ctx, i.Editor, decl.Position(), pc.Root())
+	if err != nil {
+		return errors.Wrapf(err, "failed to open %s in %s", i.Ref, i.Editor)
+	}
+	return nil
+}

--- a/cmd/ftl/main.go
+++ b/cmd/ftl/main.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"runtime/trace"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/alecthomas/atomic"
@@ -29,6 +30,7 @@ import (
 	"github.com/block/ftl/internal/configuration"
 	"github.com/block/ftl/internal/configuration/manager"
 	"github.com/block/ftl/internal/configuration/providers"
+	"github.com/block/ftl/internal/editor"
 	"github.com/block/ftl/internal/log"
 	_ "github.com/block/ftl/internal/prodinit" // Set GOMAXPROCS to match Linux container CPU quota.
 	"github.com/block/ftl/internal/profiles"
@@ -66,6 +68,7 @@ type SharedCLI struct {
 	Goose     gooseCmd     `cmd:"" help:"Run a goose command."`
 	Mysql     mySQLCmd     `cmd:"" help:"Manage MySQL databases."`
 	Postgres  postgresCmd  `cmd:"" help:"Manage PostgreSQL databases."`
+	Edit      editCmd      `cmd:"" help:"Edit a declaration in an IDE."`
 }
 
 type BuildAndDeploy struct {
@@ -218,11 +221,12 @@ func createKongApplication(cli any, csm *currentStatusManager) *kong.Kong {
 			return &kong.Group{Key: node.Name, Title: "Command flags:"}
 		}),
 		kong.Vars{
-			"version": ftl.FormattedVersion,
-			"os":      runtime.GOOS,
-			"arch":    runtime.GOARCH,
-			"numcpu":  strconv.Itoa(runtime.NumCPU()),
-			"gitroot": gitRoot,
+			"version":          ftl.FormattedVersion,
+			"os":               runtime.GOOS,
+			"arch":             runtime.GOARCH,
+			"numcpu":           strconv.Itoa(runtime.NumCPU()),
+			"gitroot":          gitRoot,
+			"supportedEditors": strings.Join(editor.SupportedEditors, ","),
 		},
 		kong.Exit(func(code int) {
 			if sm, ok := csm.statusManager.Get(); ok {

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -1,0 +1,76 @@
+package editor
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	errors "github.com/alecthomas/errors"
+
+	"github.com/block/ftl/common/schema"
+	"github.com/block/ftl/internal/exec"
+	"github.com/block/ftl/internal/log"
+)
+
+const (
+	VSCode   = "vscode"
+	IntelliJ = "intellij"
+	Cursor   = "cursor"
+	Zed      = "zed"
+)
+
+var SupportedEditors = []string{VSCode, IntelliJ, Cursor, Zed}
+
+// OpenFileInEditor opens the given file path at the specified position in the selected editor.
+func OpenFileInEditor(ctx context.Context, editor string, pos schema.Position, projectRoot string) error {
+	executable, args, workDir, err := getEditorCmdArgs(editor, pos, projectRoot)
+	if err != nil {
+		return err
+	}
+
+	err = exec.Command(ctx, log.Debug, workDir, executable, args...).RunBuffered(ctx)
+	if err != nil {
+		return errors.Wrapf(err, "could not open file in %s: ensure the '%s' shell command is installed and configured correctly", editor, executable)
+	}
+	return nil
+}
+
+func getEditorCmdArgs(editor string, pos schema.Position, projectRoot string) (executable string, args []string, workDir string, err error) {
+	switch editor {
+	case VSCode:
+		executable = "code"
+		path := formatPathWithPosition(pos, true)
+		args = []string{projectRoot, "--goto", path}
+		workDir = "."
+
+	case IntelliJ:
+		executable = "idea"
+		args = []string{projectRoot, "--line", strconv.Itoa(pos.Line), "--column", strconv.Itoa(pos.Column), pos.Filename}
+		workDir = "."
+
+	case Cursor:
+		executable = "cursor"
+		path := formatPathWithPosition(pos, true)
+		args = []string{projectRoot, "--goto", path}
+		workDir = "."
+
+	case Zed:
+		executable = "zed"
+		path := formatPathWithPosition(pos, true)
+		args = []string{path}
+		workDir = projectRoot
+
+	default:
+		err = errors.Errorf("unsupported editor %q, expected one of %s", editor, strings.Join(SupportedEditors, ", "))
+	}
+	return
+}
+
+func formatPathWithPosition(pos schema.Position, includeColumn bool) string {
+	path := pos.Filename + ":" + fmt.Sprint(pos.Line)
+	if includeColumn && pos.Column > 0 {
+		path += ":" + fmt.Sprint(pos.Column)
+	}
+	return path
+}

--- a/internal/terminal/predictors.go
+++ b/internal/terminal/predictors.go
@@ -11,6 +11,7 @@ import (
 
 func Predictors(view *schemaeventsource.View) map[string]complete.Predictor {
 	return map[string]complete.Predictor{
+		"decls":         &declPredictor[schema.Decl]{view: *view},
 		"verbs":         &declPredictor[*schema.Verb]{view: *view},
 		"configs":       &declPredictor[*schema.Config]{view: *view},
 		"secrets":       &declPredictor[*schema.Secret]{view: *view},


### PR DESCRIPTION
Currently supporting `vscode`, `cursor`, `intelliji`, `zed`.