### PR TITLE
refactor: remove all usages of `projectconfig.DefaultConfigPath`

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -274,7 +274,6 @@ test-integration *test:
 # Run integration test(s)
 integration-tests *test:
   #!/bin/bash
-  echo "$PATH"
   retry 3 /bin/bash -c "go test -fullpath -count 1 -v -tags integration -run '^({{test}})$' -p 1 $(find . -type f -name '*_test.go' -print0 | xargs -0 grep -r -l {{test}} | xargs grep -l '//go:build integration' | xargs -I {} dirname './{}' | tr '\n' ' ')"
 
 # Alias for infrastructure-tests

--- a/cmd/ftl/cmd_serve.go
+++ b/cmd/ftl/cmd_serve.go
@@ -161,7 +161,7 @@ func (s *serveCommonConfig) run(
 	}
 
 	if s.EnableGrafana && !bool(s.ObservabilityConfig.ExportOTEL) {
-		if err := dev.SetupGrafana(ctx, s.GrafanaImage); err != nil {
+		if err := dev.SetupGrafana(ctx, projConfig, s.GrafanaImage); err != nil {
 			logger.Errorf(err, "Failed to setup grafana image")
 		} else {
 			logger.Infof("Grafana started at http://localhost:3000")
@@ -174,7 +174,7 @@ func (s *serveCommonConfig) run(
 		return errors.Wrap(err, "observability init failed")
 	}
 	// Bring up the image registry we use to store deployment content
-	if err := dev.SetupRegistry(ctx, s.RegistryImage, s.RegistryPort); err != nil {
+	if err := dev.SetupRegistry(ctx, projConfig, s.RegistryImage, s.RegistryPort); err != nil {
 		return errors.Wrap(err, "registry init failed")
 	}
 	storage, err := artefacts.NewOCIRegistryStorage(ctx, artefacts.RegistryConfig{
@@ -253,7 +253,7 @@ func (s *serveCommonConfig) run(
 	provisionerRegistry := &provisioner.ProvisionerRegistry{
 		Bindings: []*provisioner.ProvisionerBinding{
 			{
-				Provisioner: provisioner.NewDevProvisioner(s.DBPort, s.MysqlPort, s.Recreate),
+				Provisioner: provisioner.NewDevProvisioner(projConfig, s.DBPort, s.MysqlPort, s.Recreate),
 				Types: []schema.ResourceType{
 					schema.ResourceTypeMysql,
 					schema.ResourceTypePostgres,

--- a/go-runtime/ftl/ftltest/database.go
+++ b/go-runtime/ftl/ftltest/database.go
@@ -13,28 +13,22 @@ import (
 
 // WithDatabase sets up a database for testing by appending "_test" to the DSN and emptying all tables
 func WithDatabase[T any]() Option {
-	return Option{
-		rank: other,
-		apply: func(ctx context.Context, state *OptionsState) error {
-			db := reflection.GetDatabase[T]()
-			return errors.WithStack(setupTestDatabase(ctx, state, db.DBType, db.Name))
-		},
+	return func(ctx context.Context, state *OptionsState) error {
+		db := reflection.GetDatabase[T]()
+		return errors.WithStack(setupTestDatabase(ctx, state, db.DBType, db.Name))
 	}
 }
 
 // WithAllDatabases sets up all databases in the module for testing by appending "_test" to the DSN and emptying all tables
 func WithAllDatabases() Option {
-	return Option{
-		rank: other,
-		apply: func(ctx context.Context, state *OptionsState) error {
-			dbs := reflection.GetAllDatabases()
-			for _, db := range dbs {
-				if err := setupTestDatabase(ctx, state, db.DBType, db.Name); err != nil {
-					return errors.WithStack(err)
-				}
+	return func(ctx context.Context, state *OptionsState) error {
+		dbs := reflection.GetAllDatabases()
+		for _, db := range dbs {
+			if err := setupTestDatabase(ctx, state, db.DBType, db.Name); err != nil {
+				return errors.WithStack(err)
 			}
-			return nil
-		},
+		}
+		return nil
 	}
 }
 
@@ -44,7 +38,7 @@ func setupTestDatabase(ctx context.Context, state *OptionsState, dbType, dbName 
 	}
 	switch dbType {
 	case "postgres":
-		dsn, err := provisioner.ProvisionPostgresForTest(ctx, moduleGetter(), "test", dbName)
+		dsn, err := provisioner.ProvisionPostgresForTest(ctx, state.project, moduleGetter(), "test", dbName)
 		if err != nil {
 			return errors.Wrapf(err, "could not provision database %q", dbName)
 		}
@@ -63,7 +57,7 @@ func setupTestDatabase(ctx context.Context, state *OptionsState, dbType, dbName 
 		}
 		state.databases[dbName] = replacementDB
 	case "mysql":
-		dsn, err := provisioner.ProvisionMySQLForTest(ctx, moduleGetter(), "test", dbName)
+		dsn, err := provisioner.ProvisionMySQLForTest(ctx, state.project, moduleGetter(), "test", dbName)
 		if err != nil {
 			return errors.Wrapf(err, "could not provision database %q", dbName)
 		}
@@ -87,17 +81,14 @@ func setupTestDatabase(ctx context.Context, state *OptionsState, dbType, dbName 
 
 // WithSQLVerbsEnabled enables direct execution of SQL verbs (without mocks). It also sets up any associated databases for tests.
 func WithSQLVerbsEnabled() Option {
-	return Option{
-		rank: other,
-		apply: func(ctx context.Context, state *OptionsState) error {
-			state.allowDirectSQLVerbs = true
-			dbs := reflection.GetQueryVerbDatabases()
-			for _, db := range dbs {
-				if err := setupTestDatabase(ctx, state, db.DBType, db.Name); err != nil {
-					return errors.WithStack(err)
-				}
+	return func(ctx context.Context, state *OptionsState) error {
+		state.allowDirectSQLVerbs = true
+		dbs := reflection.GetQueryVerbDatabases()
+		for _, db := range dbs {
+			if err := setupTestDatabase(ctx, state, db.DBType, db.Name); err != nil {
+				return errors.WithStack(err)
 			}
-			return nil
-		},
+		}
+		return nil
 	}
 }

--- a/go-runtime/ftl/ftltest/ftltest.go
+++ b/go-runtime/ftl/ftltest/ftltest.go
@@ -5,9 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"reflect"
-	"sort"
 	"strings"
 
 	errors "github.com/alecthomas/errors"
@@ -28,7 +26,7 @@ import (
 	"github.com/block/ftl/internal/configuration/providers"
 	"github.com/block/ftl/internal/deploymentcontext"
 	"github.com/block/ftl/internal/log"
-	pc "github.com/block/ftl/internal/projectconfig"
+	"github.com/block/ftl/internal/projectconfig"
 	mcu "github.com/block/ftl/internal/testutils/modulecontext"
 )
 
@@ -36,6 +34,8 @@ import (
 var moduleGetter = reflection.Module
 
 type OptionsState struct {
+	projectConfigPath       optional.Option[string]
+	project                 projectconfig.Config
 	databases               map[string]deploymentcontext.Database
 	mockVerbs               map[schema.RefKey]deploymentcontext.Verb
 	allowDirectVerbBehavior bool
@@ -44,15 +44,7 @@ type OptionsState struct {
 
 type optionRank int
 
-const (
-	profile optionRank = iota
-	other
-)
-
-type Option struct {
-	rank  optionRank
-	apply func(context.Context, *OptionsState) error
-}
+type Option func(context.Context, *OptionsState) error
 
 // Context suitable for use in testing FTL verbs with provided options
 func Context(options ...Option) context.Context {
@@ -69,16 +61,18 @@ func newContext(ctx context.Context, module string, options ...Option) context.C
 
 	ctx = contextWithFakeFTL(ctx, options...)
 
-	sort.Slice(options, func(i, j int) bool {
-		return options[i].rank < options[j].rank
-	})
-
 	for _, option := range options {
-		err := option.apply(ctx, state)
+		err := option(ctx, state)
 		if err != nil {
 			panic(fmt.Sprintf("error applying option: %v", err))
 		}
 	}
+
+	project, err := loadProjectConfig(ctx, state.projectConfigPath)
+	if err != nil {
+		panic(fmt.Sprintf("error loading project config: %v", err))
+	}
+	state.project = project
 
 	if state.allowDirectSQLVerbs {
 		querySvc, err := query.New(ctx, &schema.Module{Name: module}, xsync.NewMapOf[string, string]())
@@ -131,61 +125,47 @@ func WithDefaultProjectFile() Option {
 //		// ... other options
 //	)
 func WithProjectFile(path string) Option {
-	// Convert to absolute path immediately in case working directory changes
-	var preprocessingErr error
-	if path == "" {
-		var ok bool
-		path, ok = pc.DefaultConfigPath().Get()
-		if !ok {
-			preprocessingErr = errors.Errorf("could not find default project file in $FTL_CONFIG or git")
+	return func(ctx context.Context, state *OptionsState) error {
+		state.projectConfigPath = optional.Some(path)
+		return nil
+	}
+}
+
+func loadProjectConfig(ctx context.Context, path optional.Option[string]) (projectconfig.Config, error) {
+	projectConfig, err := projectconfig.Load(ctx, path)
+	if err != nil {
+		return projectconfig.Config{}, errors.Wrap(err, "project")
+	}
+	cm, err := cf.NewDefaultConfigurationManagerFromConfig(ctx, providers.NewDefaultConfigRegistry(), projectConfig)
+	if err != nil {
+		return projectconfig.Config{}, errors.Wrap(err, "could not set up configs")
+	}
+	configs, err := cm.MapForModule(ctx, moduleGetter())
+	if err != nil {
+		return projectconfig.Config{}, errors.Wrap(err, "could not read configs")
+	}
+
+	fftl := internal.FromContext(ctx).(*fakeFTL) //nolint:forcetypeassert
+	for name, data := range configs {
+		if err := fftl.setConfig(name, json.RawMessage(data)); err != nil {
+			return projectconfig.Config{}, errors.WithStack(err)
 		}
 	}
-	return Option{
-		rank: profile,
-		apply: func(ctx context.Context, state *OptionsState) error {
-			if preprocessingErr != nil {
-				return errors.WithStack(preprocessingErr)
-			}
-			if _, err := os.Stat(path); err != nil {
-				return errors.Wrap(err, "error accessing project file")
-			}
-			projectConfig, err := pc.Load(ctx, optional.Some(path))
-			if err != nil {
-				return errors.Wrap(err, "project")
-			}
-			cm, err := cf.NewDefaultConfigurationManagerFromConfig(ctx, providers.NewDefaultConfigRegistry(), projectConfig)
-			if err != nil {
-				return errors.Wrap(err, "could not set up configs")
-			}
-			configs, err := cm.MapForModule(ctx, moduleGetter())
-			if err != nil {
-				return errors.Wrap(err, "could not read configs")
-			}
 
-			fftl := internal.FromContext(ctx).(*fakeFTL) //nolint:forcetypeassert
-			for name, data := range configs {
-				if err := fftl.setConfig(name, json.RawMessage(data)); err != nil {
-					return errors.WithStack(err)
-				}
-			}
-
-			sm, err := cf.NewDefaultSecretsManagerFromConfig(ctx, providers.NewDefaultSecretsRegistry(), projectConfig)
-			if err != nil {
-				return errors.Wrap(err, "could not set up secrets")
-			}
-			secrets, err := sm.MapForModule(ctx, moduleGetter())
-			if err != nil {
-				return errors.Wrap(err, "could not read secrets")
-			}
-			for name, data := range secrets {
-				if err := fftl.setSecret(name, json.RawMessage(data)); err != nil {
-					return errors.WithStack(err)
-				}
-			}
-			return nil
-		},
+	sm, err := cf.NewDefaultSecretsManagerFromConfig(ctx, providers.NewDefaultSecretsRegistry(), projectConfig)
+	if err != nil {
+		return projectconfig.Config{}, errors.Wrap(err, "could not set up secrets")
 	}
-
+	secrets, err := sm.MapForModule(ctx, moduleGetter())
+	if err != nil {
+		return projectconfig.Config{}, errors.Wrap(err, "could not read secrets")
+	}
+	for name, data := range secrets {
+		if err := fftl.setSecret(name, json.RawMessage(data)); err != nil {
+			return projectconfig.Config{}, errors.WithStack(err)
+		}
+	}
+	return projectConfig, nil
 }
 
 // WithConfig sets a configuration for the current module
@@ -197,18 +177,15 @@ func WithProjectFile(path string) Option {
 //		// ... other options
 //	)
 func WithConfig[T ftl.ConfigType](config ftl.Config[T], value T) Option {
-	return Option{
-		rank: other,
-		apply: func(ctx context.Context, state *OptionsState) error {
-			if config.Module != moduleGetter() {
-				return errors.Errorf("config %v does not match current module %s", config.Module, moduleGetter())
-			}
-			fftl := internal.FromContext(ctx).(*fakeFTL) //nolint:forcetypeassert
-			if err := fftl.setConfig(config.Name, value); err != nil {
-				return errors.WithStack(err)
-			}
-			return nil
-		},
+	return func(ctx context.Context, state *OptionsState) error {
+		if config.Module != moduleGetter() {
+			return errors.Errorf("config %v does not match current module %s", config.Module, moduleGetter())
+		}
+		fftl := internal.FromContext(ctx).(*fakeFTL) //nolint:forcetypeassert
+		if err := fftl.setConfig(config.Name, value); err != nil {
+			return errors.WithStack(err)
+		}
+		return nil
 	}
 }
 
@@ -221,18 +198,15 @@ func WithConfig[T ftl.ConfigType](config ftl.Config[T], value T) Option {
 //		// ... other options
 //	)
 func WithSecret[T ftl.SecretType](secret ftl.Secret[T], value T) Option {
-	return Option{
-		rank: other,
-		apply: func(ctx context.Context, state *OptionsState) error {
-			if secret.Module != moduleGetter() {
-				return errors.Errorf("secret %v does not match current module %s", secret.Module, moduleGetter())
-			}
-			fftl := internal.FromContext(ctx).(*fakeFTL) //nolint:forcetypeassert
-			if err := fftl.setSecret(secret.Name, value); err != nil {
-				return errors.WithStack(err)
-			}
-			return nil
-		},
+	return func(ctx context.Context, state *OptionsState) error {
+		if secret.Module != moduleGetter() {
+			return errors.Errorf("secret %v does not match current module %s", secret.Module, moduleGetter())
+		}
+		fftl := internal.FromContext(ctx).(*fakeFTL) //nolint:forcetypeassert
+		if err := fftl.setSecret(secret.Name, value); err != nil {
+			return errors.WithStack(err)
+		}
+		return nil
 	}
 }
 
@@ -247,19 +221,16 @@ func WithSecret[T ftl.SecretType](secret ftl.Secret[T], value T) Option {
 //		// ... other options
 //	)
 func WhenVerb[VerbClient, Req, Resp any](fake ftl.Verb[Req, Resp]) Option {
-	return Option{
-		rank: other,
-		apply: func(ctx context.Context, state *OptionsState) error {
-			ref := reflection.ClientRef[VerbClient]()
-			state.mockVerbs[schema.RefKey(ref)] = func(ctx context.Context, req any) (resp any, err error) {
-				request, ok := req.(Req)
-				if !ok {
-					return nil, errors.Errorf("invalid request type %T for %v, expected %v", req, ref, reflect.TypeFor[Req]())
-				}
-				return errors.WithStack2(fake(ctx, request))
+	return func(ctx context.Context, state *OptionsState) error {
+		ref := reflection.ClientRef[VerbClient]()
+		state.mockVerbs[schema.RefKey(ref)] = func(ctx context.Context, req any) (resp any, err error) {
+			request, ok := req.(Req)
+			if !ok {
+				return nil, errors.Errorf("invalid request type %T for %v, expected %v", req, ref, reflect.TypeFor[Req]())
 			}
-			return nil
-		},
+			return errors.WithStack2(fake(ctx, request))
+		}
+		return nil
 	}
 }
 
@@ -274,15 +245,12 @@ func WhenVerb[VerbClient, Req, Resp any](fake ftl.Verb[Req, Resp]) Option {
 //		// ... other options
 //	)
 func WhenSource[SourceClient, Resp any](fake ftl.Source[Resp]) Option {
-	return Option{
-		rank: other,
-		apply: func(ctx context.Context, state *OptionsState) error {
-			ref := reflection.ClientRef[SourceClient]()
-			state.mockVerbs[schema.RefKey(ref)] = func(ctx context.Context, req any) (resp any, err error) {
-				return errors.WithStack2(fake(ctx))
-			}
-			return nil
-		},
+	return func(ctx context.Context, state *OptionsState) error {
+		ref := reflection.ClientRef[SourceClient]()
+		state.mockVerbs[schema.RefKey(ref)] = func(ctx context.Context, req any) (resp any, err error) {
+			return errors.WithStack2(fake(ctx))
+		}
+		return nil
 	}
 }
 
@@ -297,19 +265,16 @@ func WhenSource[SourceClient, Resp any](fake ftl.Source[Resp]) Option {
 //		// ... other options
 //	)
 func WhenSink[SinkClient, Req any](fake ftl.Sink[Req]) Option {
-	return Option{
-		rank: other,
-		apply: func(ctx context.Context, state *OptionsState) error {
-			ref := reflection.ClientRef[SinkClient]()
-			state.mockVerbs[schema.RefKey(ref)] = func(ctx context.Context, req any) (resp any, err error) {
-				request, ok := req.(Req)
-				if !ok {
-					return nil, errors.Errorf("invalid request type %T for %v, expected %v", req, ref, reflect.TypeFor[Req]())
-				}
-				return ftl.Unit{}, errors.WithStack(fake(ctx, request))
+	return func(ctx context.Context, state *OptionsState) error {
+		ref := reflection.ClientRef[SinkClient]()
+		state.mockVerbs[schema.RefKey(ref)] = func(ctx context.Context, req any) (resp any, err error) {
+			request, ok := req.(Req)
+			if !ok {
+				return nil, errors.Errorf("invalid request type %T for %v, expected %v", req, ref, reflect.TypeFor[Req]())
 			}
-			return nil
-		},
+			return ftl.Unit{}, errors.WithStack(fake(ctx, request))
+		}
+		return nil
 	}
 }
 
@@ -323,15 +288,12 @@ func WhenSink[SinkClient, Req any](fake ftl.Sink[Req]) Option {
 //		}),
 //	)
 func WhenEmpty[EmptyClient any](fake ftl.Empty) Option {
-	return Option{
-		rank: other,
-		apply: func(ctx context.Context, state *OptionsState) error {
-			ref := reflection.ClientRef[EmptyClient]()
-			state.mockVerbs[schema.RefKey(ref)] = func(ctx context.Context, req any) (resp any, err error) {
-				return ftl.Unit{}, errors.WithStack(fake(ctx))
-			}
-			return nil
-		},
+	return func(ctx context.Context, state *OptionsState) error {
+		ref := reflection.ClientRef[EmptyClient]()
+		state.mockVerbs[schema.RefKey(ref)] = func(ctx context.Context, req any) (resp any, err error) {
+			return ftl.Unit{}, errors.WithStack(fake(ctx))
+		}
+		return nil
 	}
 }
 
@@ -339,12 +301,9 @@ func WhenEmpty[EmptyClient any](fake ftl.Empty) Option {
 //
 // Any overrides provided by calling WhenVerb(...) will take precedence
 func WithCallsAllowedWithinModule() Option {
-	return Option{
-		rank: other,
-		apply: func(ctx context.Context, state *OptionsState) error {
-			state.allowDirectVerbBehavior = true
-			return nil
-		},
+	return func(ctx context.Context, state *OptionsState) error {
+		state.allowDirectVerbBehavior = true
+		return nil
 	}
 }
 
@@ -359,13 +318,10 @@ func WithCallsAllowedWithinModule() Option {
 //		// ... other options
 //	)
 func WhenMap[T, U any](mapper *ftl.MapHandle[T, U], fake func(context.Context) (U, error)) Option {
-	return Option{
-		rank: other,
-		apply: func(ctx context.Context, state *OptionsState) error {
-			fftl := internal.FromContext(ctx).(*fakeFTL) //nolint:forcetypeassert
-			addMapMock(fftl, mapper, fake)
-			return nil
-		},
+	return func(ctx context.Context, state *OptionsState) error {
+		fftl := internal.FromContext(ctx).(*fakeFTL) //nolint:forcetypeassert
+		addMapMock(fftl, mapper, fake)
+		return nil
 	}
 }
 
@@ -374,13 +330,10 @@ func WhenMap[T, U any](mapper *ftl.MapHandle[T, U], fake func(context.Context) (
 //
 // Any overrides provided by calling WhenMap(...) will take precedence.
 func WithMapsAllowed() Option {
-	return Option{
-		rank: other,
-		apply: func(ctx context.Context, state *OptionsState) error {
-			fftl := internal.FromContext(ctx).(*fakeFTL) //nolint:forcetypeassert
-			fftl.startAllowingMapCalls()
-			return nil
-		},
+	return func(ctx context.Context, state *OptionsState) error {
+		fftl := internal.FromContext(ctx).(*fakeFTL) //nolint:forcetypeassert
+		fftl.startAllowingMapCalls()
+		return nil
 	}
 }
 

--- a/internal/config/asm_integration_test.go
+++ b/internal/config/asm_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/block/ftl/internal/config"
 	"github.com/block/ftl/internal/container"
 	"github.com/block/ftl/internal/log"
+	"github.com/block/ftl/internal/projectconfig"
 )
 
 //go:embed testdata/docker-compose.yml
@@ -22,7 +23,9 @@ var composeYAML string
 
 func TestASMIntegration(t *testing.T) {
 	ctx := log.ContextWithNewDefaultLogger(context.TODO())
-	down, err := container.ComposeUp(ctx, "asm", composeYAML, optional.None[string]())
+	project, err := projectconfig.Load(ctx, optional.None[string]())
+	assert.NoError(t, err)
+	down, err := container.ComposeUp(ctx, project, "asm", composeYAML, optional.None[string]())
 	assert.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, down()) })
 

--- a/internal/configuration/routers/projectconfig_router_test.go
+++ b/internal/configuration/routers/projectconfig_router_test.go
@@ -15,28 +15,7 @@ import (
 	"github.com/block/ftl/internal/configuration/providers"
 	"github.com/block/ftl/internal/configuration/routers"
 	"github.com/block/ftl/internal/log"
-	"github.com/block/ftl/internal/projectconfig"
 )
-
-func TestSet(t *testing.T) {
-	defaultPath, ok := projectconfig.DefaultConfigPath().Get()
-	assert.True(t, ok)
-	origConfigBytes, err := os.ReadFile(defaultPath)
-	assert.NoError(t, err)
-
-	config := filepath.Join(t.TempDir(), "ftl-project.toml")
-	existing, err := os.ReadFile("testdata/ftl-project.toml")
-	assert.NoError(t, err)
-	err = os.WriteFile(config, existing, 0600)
-	assert.NoError(t, err)
-
-	setAndAssert(t, "echo", config)
-	setAndAssert(t, "echooo", config)
-
-	// Restore the original config file.
-	err = os.WriteFile(defaultPath, origConfigBytes, 0600)
-	assert.NoError(t, err)
-}
 
 func TestGetGlobal(t *testing.T) {
 	config := filepath.Join(t.TempDir(), "ftl-project.toml")

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -360,17 +360,11 @@ func PollContainerHealth(ctx context.Context, containerName string, timeout time
 // reading from disk. The project file will not be included in the release build.
 //
 // The "down" function can be optionally called to stop the containers.
-func ComposeUp(ctx context.Context, name, composeYAML string, profile optional.Option[string], envars ...string) (down func() error, err error) {
+func ComposeUp(ctx context.Context, project projectconfig.Config, name, composeYAML string, profile optional.Option[string], envars ...string) (down func() error, err error) {
 	logger := log.FromContext(ctx).Scope(name)
 	ctx = log.ContextWithLogger(ctx, logger)
 
-	// A flock is used to provent Docker compose getting confused, which happens when we call `docker compose up`
-	// multiple times simultaneously for the same services.
-	projCfg, ok := projectconfig.DefaultConfigPath().Get()
-	if !ok {
-		return nil, errors.Errorf("failed to get project config path")
-	}
-	dir := filepath.Join(filepath.Dir(projCfg), ".ftl")
+	dir := filepath.Join(project.Root(), ".ftl")
 	err = os.MkdirAll(dir, 0700)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create directory")

--- a/internal/dev/grafana.go
+++ b/internal/dev/grafana.go
@@ -8,13 +8,14 @@ import (
 	"github.com/alecthomas/types/optional"
 
 	"github.com/block/ftl/internal/container"
+	"github.com/block/ftl/internal/projectconfig"
 )
 
 //go:embed docker-compose.grafana.yml
 var grafanaDockerCompose string
 
-func SetupGrafana(ctx context.Context, image string) error {
-	_, err := container.ComposeUp(ctx, "grafana", grafanaDockerCompose, optional.None[string]())
+func SetupGrafana(ctx context.Context, project projectconfig.Config, image string) error {
+	_, err := container.ComposeUp(ctx, project, "grafana", grafanaDockerCompose, optional.None[string]())
 	if err != nil {
 		return errors.Wrap(err, "could not start grafana")
 	}

--- a/internal/dev/redpanda.go
+++ b/internal/dev/redpanda.go
@@ -10,6 +10,7 @@ import (
 	"github.com/alecthomas/types/optional"
 
 	"github.com/block/ftl/internal/container"
+	"github.com/block/ftl/internal/projectconfig"
 )
 
 //go:embed docker-compose.redpanda.yml
@@ -19,7 +20,7 @@ var redpandaDockerCompose string
 var redPandaLock = &sync.Mutex{}
 var redPandaRunning bool
 
-func SetUpRedPanda(ctx context.Context) error {
+func SetUpRedPanda(ctx context.Context, project projectconfig.Config) error {
 	redPandaLock.Lock()
 	defer redPandaLock.Unlock()
 
@@ -31,7 +32,7 @@ func SetUpRedPanda(ctx context.Context) error {
 		// include console except in CI
 		profile = optional.Some[string]("console")
 	}
-	_, err := container.ComposeUp(ctx, "redpanda", redpandaDockerCompose, profile)
+	_, err := container.ComposeUp(ctx, project, "redpanda", redpandaDockerCompose, profile)
 	if err != nil {
 		return errors.Wrap(err, "could not start redpanda")
 	}

--- a/internal/dev/registry.go
+++ b/internal/dev/registry.go
@@ -12,13 +12,14 @@ import (
 	"github.com/alecthomas/types/optional"
 
 	"github.com/block/ftl/internal/container"
+	"github.com/block/ftl/internal/projectconfig"
 )
 
 //go:embed docker-compose.registry.yml
 var registryDockerCompose string
 
-func SetupRegistry(ctx context.Context, image string, port int) error {
-	_, err := container.ComposeUp(ctx, "registry", registryDockerCompose, optional.None[string](),
+func SetupRegistry(ctx context.Context, project projectconfig.Config, image string, port int) error {
+	_, err := container.ComposeUp(ctx, project, "registry", registryDockerCompose, optional.None[string](),
 		"FTL_REGISTRY_IMAGE="+image,
 		"FTL_REGISTRY_PORT="+strconv.Itoa(port))
 	if err != nil {

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -84,7 +84,7 @@ func (c *Cmd) RunStderrError(ctx context.Context) error {
 	c.Cmd.Stderr = errorBuffer.WriterAt(ctx, c.level)
 
 	if err := c.Run(); err != nil {
-		return errors.WithStack(errors.New(strings.TrimSpace(string(errorBuffer.Bytes()))))
+		return errors.Wrap(err, c.String()+": "+strings.TrimSpace(string(errorBuffer.Bytes())))
 	}
 
 	return nil
@@ -99,7 +99,7 @@ func (c *Cmd) Capture(ctx context.Context) ([]byte, error) {
 	c.Stderr = errorBuffer.WriterAt(ctx, c.level)
 
 	if err := c.Run(); err != nil {
-		return nil, errors.WithStack(errors.New(strings.TrimSpace(string(errorBuffer.Bytes()))))
+		return nil, errors.Wrap(err, c.String()+": "+strings.TrimSpace(string(errorBuffer.Bytes())))
 	}
 
 	return outBuffer.Bytes(), nil
@@ -112,3 +112,5 @@ func (c *Cmd) Kill(signal syscall.Signal) error {
 	}
 	return errors.WithStack(syscall.Kill(c.Process.Pid, signal))
 }
+
+func (c *Cmd) String() string { return shellquote.Join(c.Args...) }

--- a/internal/pgproxy/pgproxy_test.go
+++ b/internal/pgproxy/pgproxy_test.go
@@ -13,14 +13,18 @@ import (
 	"github.com/block/ftl/internal/dev"
 	"github.com/block/ftl/internal/log"
 	"github.com/block/ftl/internal/pgproxy"
+	"github.com/block/ftl/internal/projectconfig"
 )
 
 func TestPgProxy(t *testing.T) {
 	ctx := log.ContextWithNewDefaultLogger(context.Background())
 	client, proxy := net.Pipe()
 
+	project, err := projectconfig.Load(ctx, optional.None[string]())
+	assert.NoError(t, err)
+
 	dsn := dev.PostgresDSN(ctx, 0)
-	err := dev.SetupPostgres(ctx, optional.None[string](), 0, false)
+	err = dev.SetupPostgres(ctx, project, optional.None[string](), 0, false)
 	assert.NoError(t, err)
 
 	frontend := pgproto3.NewFrontend(client, client)

--- a/internal/projectconfig/projectconfig.go
+++ b/internal/projectconfig/projectconfig.go
@@ -96,12 +96,12 @@ func (c Config) AbsModuleDirs() []string {
 	return absDirs
 }
 
-// DefaultConfigPath returns the absolute default path for the project config file, if possible.
+// defaultConfigPath returns the absolute default path for the project config file, if possible.
 //
 // The default path is determined by the FTL_CONFIG environment variable, if set, or by the presence of a Git
 // repository. If the Git repository is found, the default path is the root of the repository with the filename
 // "ftl-project.toml".
-func DefaultConfigPath() optional.Option[string] {
+func defaultConfigPath() optional.Option[string] {
 	if envar, ok := os.LookupEnv("FTL_CONFIG"); ok {
 		absPath, err := filepath.Abs(envar)
 		if err != nil {
@@ -160,7 +160,7 @@ func Load(ctx context.Context, configPath optional.Option[string]) (Config, erro
 	var path string
 	var ok bool
 	if path, ok = configPath.Get(); !ok {
-		maybePath, ok := DefaultConfigPath().Get()
+		maybePath, ok := defaultConfigPath().Get()
 		if !ok {
 			return Config{}, nil
 		}


### PR DESCRIPTION
This entails injecting `projectconfig.Config` through parameters everywhere. Also simplified ftl-test options.