### PR TITLE
refactor: remove all usages of `projectconfig.DefaultConfigPath`

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -274,7 +274,6 @@ test-integration *test:
 # Run integration test(s)
 integration-tests *test:
   #!/bin/bash
-  echo "$PATH"
   retry 3 /bin/bash -c "go test -fullpath -count 1 -v -tags integration -run '^({{test}})$' -p 1 $(find . -type f -name '*_test.go' -print0 | xargs -0 grep -r -l {{test}} | xargs grep -l '//go:build integration' | xargs -I {} dirname './{}' | tr '\n' ' ')"
 
 # Alias for infrastructure-tests

--- a/backend/admin/testdata/go/dischema/go.mod
+++ b/backend/admin/testdata/go/dischema/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/XSAM/otelsql v0.38.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/kong v1.10.0 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect

--- a/backend/admin/testdata/go/dischema/go.sum
+++ b/backend/admin/testdata/go/dischema/go.sum
@@ -24,8 +24,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
 github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=

--- a/backend/admin/testdata/go/resetsub/go.mod
+++ b/backend/admin/testdata/go/resetsub/go.mod
@@ -12,7 +12,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect

--- a/backend/admin/testdata/go/resetsub/go.sum
+++ b/backend/admin/testdata/go/resetsub/go.sum
@@ -18,8 +18,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/backend/console/testdata/go/console/go.mod
+++ b/backend/console/testdata/go/console/go.mod
@@ -12,7 +12,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect

--- a/backend/console/testdata/go/console/go.sum
+++ b/backend/console/testdata/go/console/go.sum
@@ -18,8 +18,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/backend/controller/leases/testdata/go/leases/go.mod
+++ b/backend/controller/leases/testdata/go/leases/go.mod
@@ -6,7 +6,7 @@ replace github.com/block/ftl => ./../../../../../..
 
 require (
 	github.com/alecthomas/assert/v2 v2.11.0
-	github.com/alecthomas/errors v0.7.0
+	github.com/alecthomas/errors v0.8.2
 	github.com/block/ftl v0.0.0-00010101000000-000000000000
 	golang.org/x/sync v0.13.0
 )

--- a/backend/controller/leases/testdata/go/leases/go.sum
+++ b/backend/controller/leases/testdata/go/leases/go.sum
@@ -24,8 +24,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
 github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=

--- a/backend/controller/sql/testdata/go/database/go.mod
+++ b/backend/controller/sql/testdata/go/database/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/XSAM/otelsql v0.38.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/kong v1.10.0 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/repr v0.4.0 // indirect

--- a/backend/controller/sql/testdata/go/database/go.sum
+++ b/backend/controller/sql/testdata/go/database/go.sum
@@ -24,8 +24,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
 github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=

--- a/backend/controller/sql/testdata/go/mysql/go.mod
+++ b/backend/controller/sql/testdata/go/mysql/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/XSAM/otelsql v0.38.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/kong v1.10.0 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/repr v0.4.0 // indirect

--- a/backend/controller/sql/testdata/go/mysql/go.sum
+++ b/backend/controller/sql/testdata/go/mysql/go.sum
@@ -24,8 +24,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
 github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=

--- a/backend/cron/testdata/go/cron/go.mod
+++ b/backend/cron/testdata/go/cron/go.mod
@@ -14,7 +14,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect

--- a/backend/cron/testdata/go/cron/go.sum
+++ b/backend/cron/testdata/go/cron/go.sum
@@ -18,8 +18,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/backend/ingress/testdata/go/httpingress/go.mod
+++ b/backend/ingress/testdata/go/httpingress/go.mod
@@ -12,7 +12,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect

--- a/backend/ingress/testdata/go/httpingress/go.sum
+++ b/backend/ingress/testdata/go/httpingress/go.sum
@@ -18,8 +18,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/backend/provisioner/scaling/testdata/go/echo/go.mod
+++ b/backend/provisioner/scaling/testdata/go/echo/go.mod
@@ -14,7 +14,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect

--- a/backend/provisioner/scaling/testdata/go/echo/go.sum
+++ b/backend/provisioner/scaling/testdata/go/echo/go.sum
@@ -18,8 +18,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/backend/provisioner/scaling/testdata/go/types/go.mod
+++ b/backend/provisioner/scaling/testdata/go/types/go.mod
@@ -7,7 +7,7 @@ replace github.com/block/ftl => ./../../../../../..
 require github.com/block/ftl v0.0.0-00010101000000-000000000000
 
 require (
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/deckarep/golang-set/v2 v2.8.0 // indirect

--- a/backend/provisioner/scaling/testdata/go/types/go.sum
+++ b/backend/provisioner/scaling/testdata/go/types/go.sum
@@ -1,7 +1,7 @@
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/backend/provisioner/testdata/go/echo/go.mod
+++ b/backend/provisioner/testdata/go/echo/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/XSAM/otelsql v0.38.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/kong v1.10.0 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect

--- a/backend/provisioner/testdata/go/echo/go.sum
+++ b/backend/provisioner/testdata/go/echo/go.sum
@@ -24,8 +24,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
 github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=

--- a/backend/provisioner/testdata/go/egress/go.mod
+++ b/backend/provisioner/testdata/go/egress/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/XSAM/otelsql v0.38.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/kong v1.10.0 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect

--- a/backend/provisioner/testdata/go/egress/go.sum
+++ b/backend/provisioner/testdata/go/egress/go.sum
@@ -24,8 +24,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
 github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=

--- a/backend/runner/proxy/testdata/go/echo/go.mod
+++ b/backend/runner/proxy/testdata/go/echo/go.mod
@@ -12,7 +12,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect

--- a/backend/runner/proxy/testdata/go/echo/go.sum
+++ b/backend/runner/proxy/testdata/go/echo/go.sum
@@ -18,8 +18,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/backend/runner/pubsub/testdata/go/publisher/go.mod
+++ b/backend/runner/pubsub/testdata/go/publisher/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/XSAM/otelsql v0.38.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/kong v1.10.0 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect

--- a/backend/runner/pubsub/testdata/go/publisher/go.sum
+++ b/backend/runner/pubsub/testdata/go/publisher/go.sum
@@ -24,8 +24,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
 github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=

--- a/backend/runner/pubsub/testdata/go/subscriber/go.mod
+++ b/backend/runner/pubsub/testdata/go/subscriber/go.mod
@@ -12,7 +12,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect

--- a/backend/runner/pubsub/testdata/go/subscriber/go.sum
+++ b/backend/runner/pubsub/testdata/go/subscriber/go.sum
@@ -18,8 +18,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/backend/timeline/testdata/go/cron/go.mod
+++ b/backend/timeline/testdata/go/cron/go.mod
@@ -14,7 +14,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect

--- a/backend/timeline/testdata/go/cron/go.sum
+++ b/backend/timeline/testdata/go/cron/go.sum
@@ -18,8 +18,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/backend/timeline/testdata/go/echo/go.mod
+++ b/backend/timeline/testdata/go/echo/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/XSAM/otelsql v0.38.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/kong v1.10.0 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect

--- a/backend/timeline/testdata/go/echo/go.sum
+++ b/backend/timeline/testdata/go/echo/go.sum
@@ -24,8 +24,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
 github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=

--- a/backend/timeline/testdata/go/ingress/go.mod
+++ b/backend/timeline/testdata/go/ingress/go.mod
@@ -14,7 +14,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect

--- a/backend/timeline/testdata/go/ingress/go.sum
+++ b/backend/timeline/testdata/go/ingress/go.sum
@@ -18,8 +18,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/backend/timeline/testdata/go/publisher/go.mod
+++ b/backend/timeline/testdata/go/publisher/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/XSAM/otelsql v0.38.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/kong v1.10.0 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect

--- a/backend/timeline/testdata/go/publisher/go.sum
+++ b/backend/timeline/testdata/go/publisher/go.sum
@@ -24,8 +24,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
 github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=

--- a/backend/timeline/testdata/go/subscriber/go.mod
+++ b/backend/timeline/testdata/go/subscriber/go.mod
@@ -14,7 +14,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect

--- a/backend/timeline/testdata/go/subscriber/go.sum
+++ b/backend/timeline/testdata/go/subscriber/go.sum
@@ -18,8 +18,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/backend/timeline/testdata/go/time/go.mod
+++ b/backend/timeline/testdata/go/time/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/XSAM/otelsql v0.38.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/kong v1.10.0 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect

--- a/backend/timeline/testdata/go/time/go.sum
+++ b/backend/timeline/testdata/go/time/go.sum
@@ -24,8 +24,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
 github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=

--- a/cmd/ftl/cmd_serve.go
+++ b/cmd/ftl/cmd_serve.go
@@ -161,7 +161,7 @@ func (s *serveCommonConfig) run(
 	}
 
 	if s.EnableGrafana && !bool(s.ObservabilityConfig.ExportOTEL) {
-		if err := dev.SetupGrafana(ctx, s.GrafanaImage); err != nil {
+		if err := dev.SetupGrafana(ctx, projConfig, s.GrafanaImage); err != nil {
 			logger.Errorf(err, "Failed to setup grafana image")
 		} else {
 			logger.Infof("Grafana started at http://localhost:3000")
@@ -174,7 +174,7 @@ func (s *serveCommonConfig) run(
 		return errors.Wrap(err, "observability init failed")
 	}
 	// Bring up the image registry we use to store deployment content
-	if err := dev.SetupRegistry(ctx, s.RegistryImage, s.RegistryPort); err != nil {
+	if err := dev.SetupRegistry(ctx, projConfig, s.RegistryImage, s.RegistryPort); err != nil {
 		return errors.Wrap(err, "registry init failed")
 	}
 	storage, err := artefacts.NewOCIRegistryStorage(ctx, artefacts.RegistryConfig{
@@ -253,7 +253,7 @@ func (s *serveCommonConfig) run(
 	provisionerRegistry := &provisioner.ProvisionerRegistry{
 		Bindings: []*provisioner.ProvisionerBinding{
 			{
-				Provisioner: provisioner.NewDevProvisioner(s.DBPort, s.MysqlPort, s.Recreate),
+				Provisioner: provisioner.NewDevProvisioner(projConfig, s.DBPort, s.MysqlPort, s.Recreate),
 				Types: []schema.ResourceType{
 					schema.ResourceTypeMysql,
 					schema.ResourceTypePostgres,

--- a/cmd/ftl/testdata/go/time/go.mod
+++ b/cmd/ftl/testdata/go/time/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/XSAM/otelsql v0.38.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/kong v1.10.0 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect

--- a/cmd/ftl/testdata/go/time/go.sum
+++ b/cmd/ftl/testdata/go/time/go.sum
@@ -24,8 +24,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
 github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=

--- a/common/internal/tests/testdata/go/omitempty/go.mod
+++ b/common/internal/tests/testdata/go/omitempty/go.mod
@@ -12,7 +12,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect

--- a/common/internal/tests/testdata/go/omitempty/go.sum
+++ b/common/internal/tests/testdata/go/omitempty/go.sum
@@ -18,8 +18,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/common/internal/tests/testdata/go/runtimereflection/go.mod
+++ b/common/internal/tests/testdata/go/runtimereflection/go.mod
@@ -15,7 +15,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/repr v0.4.0 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect

--- a/common/internal/tests/testdata/go/runtimereflection/go.sum
+++ b/common/internal/tests/testdata/go/runtimereflection/go.sum
@@ -18,8 +18,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/examples/go/cron/go.mod
+++ b/examples/go/cron/go.mod
@@ -14,7 +14,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect

--- a/examples/go/cron/go.sum
+++ b/examples/go/cron/go.sum
@@ -18,8 +18,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/examples/go/echo/go.mod
+++ b/examples/go/echo/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 replace github.com/block/ftl => ../../..
 
 require (
-	github.com/alecthomas/errors v0.7.0
+	github.com/alecthomas/errors v0.8.2
 	github.com/block/ftl v0.0.0-00010101000000-000000000000
 )
 

--- a/examples/go/echo/go.sum
+++ b/examples/go/echo/go.sum
@@ -24,8 +24,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
 github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=

--- a/examples/go/http/go.mod
+++ b/examples/go/http/go.mod
@@ -14,7 +14,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect

--- a/examples/go/http/go.sum
+++ b/examples/go/http/go.sum
@@ -18,8 +18,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/examples/go/mysql/go.mod
+++ b/examples/go/mysql/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/alecthomas/assert/v2 v2.11.0
-	github.com/alecthomas/errors v0.7.0
+	github.com/alecthomas/errors v0.8.2
 	github.com/alecthomas/types v0.19.0
 	github.com/block/ftl v0.189.0
 )

--- a/examples/go/mysql/go.sum
+++ b/examples/go/mysql/go.sum
@@ -24,8 +24,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
 github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=

--- a/examples/go/postgres/go.mod
+++ b/examples/go/postgres/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/alecthomas/assert/v2 v2.11.0
-	github.com/alecthomas/errors v0.7.0
+	github.com/alecthomas/errors v0.8.2
 	github.com/block/ftl v0.189.0
 )
 

--- a/examples/go/postgres/go.sum
+++ b/examples/go/postgres/go.sum
@@ -24,8 +24,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
 github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=

--- a/examples/go/pubsub/go.mod
+++ b/examples/go/pubsub/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 replace github.com/block/ftl => ../../..
 
 require (
-	github.com/alecthomas/errors v0.7.0
+	github.com/alecthomas/errors v0.8.2
 	github.com/block/ftl v0.0.0-00010101000000-000000000000
 	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394
 )

--- a/examples/go/pubsub/go.sum
+++ b/examples/go/pubsub/go.sum
@@ -24,8 +24,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
 github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=

--- a/examples/go/time/go.mod
+++ b/examples/go/time/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 replace github.com/block/ftl => ../../..
 
 require (
-	github.com/alecthomas/errors v0.7.0
+	github.com/alecthomas/errors v0.8.2
 	github.com/block/ftl v0.0.0-00010101000000-000000000000
 )
 

--- a/examples/go/time/go.sum
+++ b/examples/go/time/go.sum
@@ -24,8 +24,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
 github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=

--- a/go-runtime/compile/testdata/go/echo/go.mod
+++ b/go-runtime/compile/testdata/go/echo/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/XSAM/otelsql v0.38.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/kong v1.10.0 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect

--- a/go-runtime/compile/testdata/go/echo/go.sum
+++ b/go-runtime/compile/testdata/go/echo/go.sum
@@ -24,8 +24,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
 github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=

--- a/go-runtime/compile/testdata/go/external/go.mod
+++ b/go-runtime/compile/testdata/go/external/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require github.com/block/ftl v0.206.1
 
 require (
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/deckarep/golang-set/v2 v2.8.0 // indirect

--- a/go-runtime/compile/testdata/go/external/go.sum
+++ b/go-runtime/compile/testdata/go/external/go.sum
@@ -1,7 +1,7 @@
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/go-runtime/compile/testdata/go/missingqueries/go.mod
+++ b/go-runtime/compile/testdata/go/missingqueries/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/XSAM/otelsql v0.38.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/kong v1.10.0 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.36.3 // indirect

--- a/go-runtime/compile/testdata/go/missingqueries/go.sum
+++ b/go-runtime/compile/testdata/go/missingqueries/go.sum
@@ -24,8 +24,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
 github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=

--- a/go-runtime/compile/testdata/go/notexportedverb/go.mod
+++ b/go-runtime/compile/testdata/go/notexportedverb/go.mod
@@ -12,7 +12,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect

--- a/go-runtime/compile/testdata/go/notexportedverb/go.sum
+++ b/go-runtime/compile/testdata/go/notexportedverb/go.sum
@@ -18,8 +18,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/go-runtime/compile/testdata/go/one/go.mod
+++ b/go-runtime/compile/testdata/go/one/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/XSAM/otelsql v0.38.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/kong v1.10.0 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect

--- a/go-runtime/compile/testdata/go/one/go.sum
+++ b/go-runtime/compile/testdata/go/one/go.sum
@@ -24,8 +24,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
 github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=

--- a/go-runtime/compile/testdata/go/time/go.mod
+++ b/go-runtime/compile/testdata/go/time/go.mod
@@ -7,7 +7,7 @@ replace github.com/block/ftl => ../../../../..
 require github.com/block/ftl v0.0.0-00010101000000-000000000000
 
 require (
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/deckarep/golang-set/v2 v2.8.0 // indirect

--- a/go-runtime/compile/testdata/go/time/go.sum
+++ b/go-runtime/compile/testdata/go/time/go.sum
@@ -1,7 +1,7 @@
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/go-runtime/compile/testdata/go/two/go.mod
+++ b/go-runtime/compile/testdata/go/two/go.mod
@@ -7,7 +7,7 @@ replace github.com/block/ftl => ../../../../..
 require github.com/block/ftl v0.0.0-00010101000000-000000000000
 
 require (
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/deckarep/golang-set/v2 v2.8.0 // indirect

--- a/go-runtime/compile/testdata/go/two/go.sum
+++ b/go-runtime/compile/testdata/go/two/go.sum
@@ -1,7 +1,7 @@
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/go-runtime/compile/testdata/go/undefinedverb/go.mod
+++ b/go-runtime/compile/testdata/go/undefinedverb/go.mod
@@ -12,7 +12,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect

--- a/go-runtime/compile/testdata/go/undefinedverb/go.sum
+++ b/go-runtime/compile/testdata/go/undefinedverb/go.sum
@@ -18,8 +18,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/go-runtime/ftl/ftltest/database.go
+++ b/go-runtime/ftl/ftltest/database.go
@@ -13,38 +13,27 @@ import (
 
 // WithDatabase sets up a database for testing by appending "_test" to the DSN and emptying all tables
 func WithDatabase[T any]() Option {
-	return Option{
-		rank: other,
-		apply: func(ctx context.Context, state *OptionsState) error {
-			db := reflection.GetDatabase[T]()
-			return errors.WithStack(setupTestDatabase(ctx, state, db.DBType, db.Name))
-		},
+	return func(ctx context.Context, state *testOptions) error {
+		state.databases = append(state.databases, reflection.GetDatabase[T]().ReflectedDatabase)
+		return nil
 	}
 }
 
 // WithAllDatabases sets up all databases in the module for testing by appending "_test" to the DSN and emptying all tables
 func WithAllDatabases() Option {
-	return Option{
-		rank: other,
-		apply: func(ctx context.Context, state *OptionsState) error {
-			dbs := reflection.GetAllDatabases()
-			for _, db := range dbs {
-				if err := setupTestDatabase(ctx, state, db.DBType, db.Name); err != nil {
-					return errors.WithStack(err)
-				}
-			}
-			return nil
-		},
+	return func(ctx context.Context, options *testOptions) error {
+		options.databases = append(options.databases, reflection.GetAllDatabases()...)
+		return nil
 	}
 }
 
-func setupTestDatabase(ctx context.Context, state *OptionsState, dbType, dbName string) error {
+func setupTestDatabase(ctx context.Context, state *State, dbType, dbName string) error {
 	if _, ok := state.databases[dbName]; ok {
 		return nil
 	}
 	switch dbType {
 	case "postgres":
-		dsn, err := provisioner.ProvisionPostgresForTest(ctx, moduleGetter(), "test", dbName)
+		dsn, err := provisioner.ProvisionPostgresForTest(ctx, state.project, moduleGetter(), "test", dbName)
 		if err != nil {
 			return errors.Wrapf(err, "could not provision database %q", dbName)
 		}
@@ -63,7 +52,7 @@ func setupTestDatabase(ctx context.Context, state *OptionsState, dbType, dbName 
 		}
 		state.databases[dbName] = replacementDB
 	case "mysql":
-		dsn, err := provisioner.ProvisionMySQLForTest(ctx, moduleGetter(), "test", dbName)
+		dsn, err := provisioner.ProvisionMySQLForTest(ctx, state.project, moduleGetter(), "test", dbName)
 		if err != nil {
 			return errors.Wrapf(err, "could not provision database %q", dbName)
 		}
@@ -87,17 +76,8 @@ func setupTestDatabase(ctx context.Context, state *OptionsState, dbType, dbName 
 
 // WithSQLVerbsEnabled enables direct execution of SQL verbs (without mocks). It also sets up any associated databases for tests.
 func WithSQLVerbsEnabled() Option {
-	return Option{
-		rank: other,
-		apply: func(ctx context.Context, state *OptionsState) error {
-			state.allowDirectSQLVerbs = true
-			dbs := reflection.GetQueryVerbDatabases()
-			for _, db := range dbs {
-				if err := setupTestDatabase(ctx, state, db.DBType, db.Name); err != nil {
-					return errors.WithStack(err)
-				}
-			}
-			return nil
-		},
+	return func(ctx context.Context, state *testOptions) error {
+		state.allowDirectSQLVerbs = true
+		return nil
 	}
 }

--- a/go-runtime/ftl/ftltest/testdata/go/outer/go.mod
+++ b/go-runtime/ftl/ftltest/testdata/go/outer/go.mod
@@ -10,7 +10,7 @@ require (
 )
 
 require (
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/repr v0.4.0 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect

--- a/go-runtime/ftl/ftltest/testdata/go/outer/go.sum
+++ b/go-runtime/ftl/ftltest/testdata/go/outer/go.sum
@@ -1,7 +1,7 @@
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/go-runtime/ftl/ftltest/testdata/go/pubsub/go.mod
+++ b/go-runtime/ftl/ftltest/testdata/go/pubsub/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/XSAM/otelsql v0.38.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/kong v1.10.0 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect

--- a/go-runtime/ftl/ftltest/testdata/go/pubsub/go.sum
+++ b/go-runtime/ftl/ftltest/testdata/go/pubsub/go.sum
@@ -24,8 +24,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
 github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=

--- a/go-runtime/ftl/ftltest/testdata/go/subscriber/go.mod
+++ b/go-runtime/ftl/ftltest/testdata/go/subscriber/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/XSAM/otelsql v0.38.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/kong v1.10.0 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/repr v0.4.0 // indirect

--- a/go-runtime/ftl/ftltest/testdata/go/subscriber/go.sum
+++ b/go-runtime/ftl/ftltest/testdata/go/subscriber/go.sum
@@ -24,8 +24,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
 github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=

--- a/go-runtime/ftl/ftltest/testdata/go/time/go.mod
+++ b/go-runtime/ftl/ftltest/testdata/go/time/go.mod
@@ -7,7 +7,7 @@ replace github.com/block/ftl => ./../../../../../..
 require github.com/block/ftl v0.0.0-00010101000000-000000000000
 
 require (
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/deckarep/golang-set/v2 v2.8.0 // indirect

--- a/go-runtime/ftl/ftltest/testdata/go/time/go.sum
+++ b/go-runtime/ftl/ftltest/testdata/go/time/go.sum
@@ -1,7 +1,7 @@
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/go-runtime/ftl/ftltest/testdata/go/verbtypes/go.mod
+++ b/go-runtime/ftl/ftltest/testdata/go/verbtypes/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/alecthomas/assert/v2 v2.11.0
-	github.com/alecthomas/errors v0.7.0
+	github.com/alecthomas/errors v0.8.2
 	github.com/block/ftl v0.201.0
 )
 

--- a/go-runtime/ftl/ftltest/testdata/go/verbtypes/go.sum
+++ b/go-runtime/ftl/ftltest/testdata/go/verbtypes/go.sum
@@ -24,8 +24,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
 github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=

--- a/go-runtime/ftl/ftltest/testdata/go/wrapped/go.mod
+++ b/go-runtime/ftl/ftltest/testdata/go/wrapped/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/XSAM/otelsql v0.38.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/kong v1.10.0 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/repr v0.4.0 // indirect

--- a/go-runtime/ftl/ftltest/testdata/go/wrapped/go.sum
+++ b/go-runtime/ftl/ftltest/testdata/go/wrapped/go.sum
@@ -24,8 +24,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
 github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=

--- a/go-runtime/ftl/testdata/go/echo/go.mod
+++ b/go-runtime/ftl/testdata/go/echo/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/XSAM/otelsql v0.38.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/kong v1.10.0 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect

--- a/go-runtime/ftl/testdata/go/echo/go.sum
+++ b/go-runtime/ftl/testdata/go/echo/go.sum
@@ -24,8 +24,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
 github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=

--- a/go-runtime/ftl/testdata/go/mapper/go.mod
+++ b/go-runtime/ftl/testdata/go/mapper/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/XSAM/otelsql v0.38.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/kong v1.10.0 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/repr v0.4.0 // indirect

--- a/go-runtime/ftl/testdata/go/mapper/go.sum
+++ b/go-runtime/ftl/testdata/go/mapper/go.sum
@@ -24,8 +24,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
 github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=

--- a/go-runtime/ftl/testdata/go/time/go.mod
+++ b/go-runtime/ftl/testdata/go/time/go.mod
@@ -7,7 +7,7 @@ replace github.com/block/ftl => ./../../../../..
 require github.com/block/ftl v0.0.0-00010101000000-000000000000
 
 require (
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/deckarep/golang-set/v2 v2.8.0 // indirect

--- a/go-runtime/ftl/testdata/go/time/go.sum
+++ b/go-runtime/ftl/testdata/go/time/go.sum
@@ -1,7 +1,7 @@
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/go-runtime/ftl/testdata/go/typeregistry/go.mod
+++ b/go-runtime/ftl/testdata/go/typeregistry/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/XSAM/otelsql v0.38.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/kong v1.10.0 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/repr v0.4.0 // indirect

--- a/go-runtime/ftl/testdata/go/typeregistry/go.sum
+++ b/go-runtime/ftl/testdata/go/typeregistry/go.sum
@@ -24,8 +24,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
 github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=

--- a/go-runtime/goplugin/testdata/alpha/go.mod
+++ b/go-runtime/goplugin/testdata/alpha/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/XSAM/otelsql v0.38.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/kong v1.10.0 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect

--- a/go-runtime/goplugin/testdata/alpha/go.sum
+++ b/go-runtime/goplugin/testdata/alpha/go.sum
@@ -24,8 +24,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
 github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=

--- a/go-runtime/goplugin/testdata/another/go.mod
+++ b/go-runtime/goplugin/testdata/another/go.mod
@@ -12,7 +12,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect

--- a/go-runtime/goplugin/testdata/another/go.sum
+++ b/go-runtime/goplugin/testdata/another/go.sum
@@ -18,8 +18,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/go-runtime/goplugin/testdata/other/go.mod
+++ b/go-runtime/goplugin/testdata/other/go.mod
@@ -12,7 +12,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect

--- a/go-runtime/goplugin/testdata/other/go.sum
+++ b/go-runtime/goplugin/testdata/other/go.sum
@@ -18,8 +18,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/go-runtime/internal/testdata/go/mapper/go.mod
+++ b/go-runtime/internal/testdata/go/mapper/go.mod
@@ -14,7 +14,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect

--- a/go-runtime/internal/testdata/go/mapper/go.sum
+++ b/go-runtime/internal/testdata/go/mapper/go.sum
@@ -18,8 +18,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/go-runtime/schema/testdata/failing/go.mod
+++ b/go-runtime/schema/testdata/failing/go.mod
@@ -14,7 +14,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect

--- a/go-runtime/schema/testdata/failing/go.sum
+++ b/go-runtime/schema/testdata/failing/go.sum
@@ -18,8 +18,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/go-runtime/schema/testdata/named/go.mod
+++ b/go-runtime/schema/testdata/named/go.mod
@@ -7,7 +7,7 @@ replace github.com/block/ftl => ../../../..
 require github.com/block/ftl v0.430.1
 
 require (
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/deckarep/golang-set/v2 v2.8.0 // indirect

--- a/go-runtime/schema/testdata/named/go.sum
+++ b/go-runtime/schema/testdata/named/go.sum
@@ -1,7 +1,7 @@
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/go-runtime/schema/testdata/one/go.mod
+++ b/go-runtime/schema/testdata/one/go.mod
@@ -14,7 +14,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect

--- a/go-runtime/schema/testdata/one/go.sum
+++ b/go-runtime/schema/testdata/one/go.sum
@@ -18,8 +18,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/go-runtime/schema/testdata/parent/go.mod
+++ b/go-runtime/schema/testdata/parent/go.mod
@@ -12,7 +12,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect

--- a/go-runtime/schema/testdata/parent/go.sum
+++ b/go-runtime/schema/testdata/parent/go.sum
@@ -18,8 +18,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/go-runtime/schema/testdata/pubsub/go.mod
+++ b/go-runtime/schema/testdata/pubsub/go.mod
@@ -3,7 +3,7 @@ module ftl/pubsub
 go 1.24.0
 
 require (
-	github.com/alecthomas/errors v0.7.0
+	github.com/alecthomas/errors v0.8.2
 	github.com/block/ftl v0.430.1
 )
 

--- a/go-runtime/schema/testdata/pubsub/go.sum
+++ b/go-runtime/schema/testdata/pubsub/go.sum
@@ -24,8 +24,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
 github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=

--- a/go-runtime/schema/testdata/subscriber/go.mod
+++ b/go-runtime/schema/testdata/subscriber/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require github.com/block/ftl v0.430.1
 
 require (
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/deckarep/golang-set/v2 v2.8.0 // indirect

--- a/go-runtime/schema/testdata/subscriber/go.sum
+++ b/go-runtime/schema/testdata/subscriber/go.sum
@@ -1,7 +1,7 @@
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/go-runtime/schema/testdata/two/go.mod
+++ b/go-runtime/schema/testdata/two/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/XSAM/otelsql v0.38.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/kong v1.10.0 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect

--- a/go-runtime/schema/testdata/two/go.sum
+++ b/go-runtime/schema/testdata/two/go.sum
@@ -24,8 +24,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
 github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=

--- a/go-runtime/schema/testdata/validation/go.mod
+++ b/go-runtime/schema/testdata/validation/go.mod
@@ -14,7 +14,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect

--- a/go-runtime/schema/testdata/validation/go.sum
+++ b/go-runtime/schema/testdata/validation/go.sum
@@ -18,8 +18,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/alecthomas/atomic v0.1.0-alpha2
 	github.com/alecthomas/chroma/v2 v2.16.0
 	github.com/alecthomas/concurrency v0.0.2
-	github.com/alecthomas/errors v0.7.0
+	github.com/alecthomas/errors v0.8.2
 	github.com/alecthomas/kong v1.10.0
 	github.com/alecthomas/kong-toml v0.2.0
 	github.com/alecthomas/participle/v2 v2.1.4

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,10 @@ github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKB
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
 github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
 github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.1 h1:6b47u4swYkHMB1IsyR5hH80nlN1lPA/FXx2vJtfIHN0=
+github.com/alecthomas/errors v0.8.1/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
 github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/kong-toml v0.2.0 h1:RmUe7ajGUvGD1ew8tGkbLzIYZ0YrUxsYdF/7hfTaYV0=

--- a/go.sum
+++ b/go.sum
@@ -51,10 +51,6 @@ github.com/alecthomas/chroma/v2 v2.16.0 h1:QC5ZMizk67+HzxFDjQ4ASjni5kWBTGiigRG1u
 github.com/alecthomas/chroma/v2 v2.16.0/go.mod h1:RVX6AvYm4VfYe/zsk7mjHueLDZor3aWCNE14TFlepBk=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
-github.com/alecthomas/errors v0.8.1 h1:6b47u4swYkHMB1IsyR5hH80nlN1lPA/FXx2vJtfIHN0=
-github.com/alecthomas/errors v0.8.1/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
 github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=

--- a/internal/buildengine/languageplugin/testdata/go/plugintest/go.mod
+++ b/internal/buildengine/languageplugin/testdata/go/plugintest/go.mod
@@ -12,7 +12,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect

--- a/internal/buildengine/languageplugin/testdata/go/plugintest/go.sum
+++ b/internal/buildengine/languageplugin/testdata/go/plugintest/go.sum
@@ -18,8 +18,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/internal/buildengine/testdata/alpha/go.mod
+++ b/internal/buildengine/testdata/alpha/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/XSAM/otelsql v0.38.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/kong v1.10.0 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect

--- a/internal/buildengine/testdata/alpha/go.sum
+++ b/internal/buildengine/testdata/alpha/go.sum
@@ -24,8 +24,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
 github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=

--- a/internal/buildengine/testdata/another/go.mod
+++ b/internal/buildengine/testdata/another/go.mod
@@ -12,7 +12,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect

--- a/internal/buildengine/testdata/another/go.sum
+++ b/internal/buildengine/testdata/another/go.sum
@@ -18,8 +18,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/internal/buildengine/testdata/other/go.mod
+++ b/internal/buildengine/testdata/other/go.mod
@@ -12,7 +12,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect

--- a/internal/buildengine/testdata/other/go.sum
+++ b/internal/buildengine/testdata/other/go.sum
@@ -18,8 +18,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/internal/config/asm_integration_test.go
+++ b/internal/config/asm_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/block/ftl/internal/config"
 	"github.com/block/ftl/internal/container"
 	"github.com/block/ftl/internal/log"
+	"github.com/block/ftl/internal/projectconfig"
 )
 
 //go:embed testdata/docker-compose.yml
@@ -22,7 +23,9 @@ var composeYAML string
 
 func TestASMIntegration(t *testing.T) {
 	ctx := log.ContextWithNewDefaultLogger(context.TODO())
-	down, err := container.ComposeUp(ctx, "asm", composeYAML, optional.None[string]())
+	project, err := projectconfig.Load(ctx, optional.None[string]())
+	assert.NoError(t, err)
+	down, err := container.ComposeUp(ctx, project, "asm", composeYAML, optional.None[string]())
 	assert.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, down()) })
 

--- a/internal/configuration/routers/projectconfig_router_test.go
+++ b/internal/configuration/routers/projectconfig_router_test.go
@@ -15,28 +15,7 @@ import (
 	"github.com/block/ftl/internal/configuration/providers"
 	"github.com/block/ftl/internal/configuration/routers"
 	"github.com/block/ftl/internal/log"
-	"github.com/block/ftl/internal/projectconfig"
 )
-
-func TestSet(t *testing.T) {
-	defaultPath, ok := projectconfig.DefaultConfigPath().Get()
-	assert.True(t, ok)
-	origConfigBytes, err := os.ReadFile(defaultPath)
-	assert.NoError(t, err)
-
-	config := filepath.Join(t.TempDir(), "ftl-project.toml")
-	existing, err := os.ReadFile("testdata/ftl-project.toml")
-	assert.NoError(t, err)
-	err = os.WriteFile(config, existing, 0600)
-	assert.NoError(t, err)
-
-	setAndAssert(t, "echo", config)
-	setAndAssert(t, "echooo", config)
-
-	// Restore the original config file.
-	err = os.WriteFile(defaultPath, origConfigBytes, 0600)
-	assert.NoError(t, err)
-}
 
 func TestGetGlobal(t *testing.T) {
 	config := filepath.Join(t.TempDir(), "ftl-project.toml")

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -360,17 +360,11 @@ func PollContainerHealth(ctx context.Context, containerName string, timeout time
 // reading from disk. The project file will not be included in the release build.
 //
 // The "down" function can be optionally called to stop the containers.
-func ComposeUp(ctx context.Context, name, composeYAML string, profile optional.Option[string], envars ...string) (down func() error, err error) {
+func ComposeUp(ctx context.Context, project projectconfig.Config, name, composeYAML string, profile optional.Option[string], envars ...string) (down func() error, err error) {
 	logger := log.FromContext(ctx).Scope(name)
 	ctx = log.ContextWithLogger(ctx, logger)
 
-	// A flock is used to provent Docker compose getting confused, which happens when we call `docker compose up`
-	// multiple times simultaneously for the same services.
-	projCfg, ok := projectconfig.DefaultConfigPath().Get()
-	if !ok {
-		return nil, errors.Errorf("failed to get project config path")
-	}
-	dir := filepath.Join(filepath.Dir(projCfg), ".ftl")
+	dir := filepath.Join(project.Root(), ".ftl")
 	err = os.MkdirAll(dir, 0700)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create directory")

--- a/internal/dev/grafana.go
+++ b/internal/dev/grafana.go
@@ -8,13 +8,14 @@ import (
 	"github.com/alecthomas/types/optional"
 
 	"github.com/block/ftl/internal/container"
+	"github.com/block/ftl/internal/projectconfig"
 )
 
 //go:embed docker-compose.grafana.yml
 var grafanaDockerCompose string
 
-func SetupGrafana(ctx context.Context, image string) error {
-	_, err := container.ComposeUp(ctx, "grafana", grafanaDockerCompose, optional.None[string]())
+func SetupGrafana(ctx context.Context, project projectconfig.Config, image string) error {
+	_, err := container.ComposeUp(ctx, project, "grafana", grafanaDockerCompose, optional.None[string]())
 	if err != nil {
 		return errors.Wrap(err, "could not start grafana")
 	}

--- a/internal/dev/redpanda.go
+++ b/internal/dev/redpanda.go
@@ -10,6 +10,7 @@ import (
 	"github.com/alecthomas/types/optional"
 
 	"github.com/block/ftl/internal/container"
+	"github.com/block/ftl/internal/projectconfig"
 )
 
 //go:embed docker-compose.redpanda.yml
@@ -19,7 +20,7 @@ var redpandaDockerCompose string
 var redPandaLock = &sync.Mutex{}
 var redPandaRunning bool
 
-func SetUpRedPanda(ctx context.Context) error {
+func SetUpRedPanda(ctx context.Context, project projectconfig.Config) error {
 	redPandaLock.Lock()
 	defer redPandaLock.Unlock()
 
@@ -31,7 +32,7 @@ func SetUpRedPanda(ctx context.Context) error {
 		// include console except in CI
 		profile = optional.Some[string]("console")
 	}
-	_, err := container.ComposeUp(ctx, "redpanda", redpandaDockerCompose, profile)
+	_, err := container.ComposeUp(ctx, project, "redpanda", redpandaDockerCompose, profile)
 	if err != nil {
 		return errors.Wrap(err, "could not start redpanda")
 	}

--- a/internal/dev/registry.go
+++ b/internal/dev/registry.go
@@ -12,13 +12,14 @@ import (
 	"github.com/alecthomas/types/optional"
 
 	"github.com/block/ftl/internal/container"
+	"github.com/block/ftl/internal/projectconfig"
 )
 
 //go:embed docker-compose.registry.yml
 var registryDockerCompose string
 
-func SetupRegistry(ctx context.Context, image string, port int) error {
-	_, err := container.ComposeUp(ctx, "registry", registryDockerCompose, optional.None[string](),
+func SetupRegistry(ctx context.Context, project projectconfig.Config, image string, port int) error {
+	_, err := container.ComposeUp(ctx, project, "registry", registryDockerCompose, optional.None[string](),
 		"FTL_REGISTRY_IMAGE="+image,
 		"FTL_REGISTRY_PORT="+strconv.Itoa(port))
 	if err != nil {

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -3,6 +3,7 @@ package exec
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"os/exec" //nolint:depguard
 	"strings"
@@ -61,8 +62,8 @@ func CommandWithEnv(ctx context.Context, level log.Level, dir string, env []stri
 func (c *Cmd) RunBuffered(ctx context.Context) error {
 	outputBuffer := NewCircularBuffer(100)
 	output := outputBuffer.WriterAt(ctx, c.level)
-	c.Cmd.Stdout = output
-	c.Cmd.Stderr = output
+	c.Stdout = output
+	c.Stderr = output
 
 	err := c.Run()
 	if err != nil {
@@ -79,12 +80,13 @@ func (c *Cmd) RunBuffered(ctx context.Context) error {
 // RunStderrError runs the command and captures stderr. If the command fails, the stderr is returned as the error message.
 func (c *Cmd) RunStderrError(ctx context.Context) error {
 	errorBuffer := NewCircularBuffer(100)
+	output := errorBuffer.WriterAt(ctx, c.level)
 
-	c.Cmd.Stdout = nil
-	c.Cmd.Stderr = errorBuffer.WriterAt(ctx, c.level)
+	c.Stdout = output
+	c.Stderr = output
 
 	if err := c.Run(); err != nil {
-		return errors.WithStack(errors.New(strings.TrimSpace(string(errorBuffer.Bytes()))))
+		return errors.Wrap(err, c.String()+": "+strings.TrimSpace(string(errorBuffer.Bytes())))
 	}
 
 	return nil
@@ -99,7 +101,7 @@ func (c *Cmd) Capture(ctx context.Context) ([]byte, error) {
 	c.Stderr = errorBuffer.WriterAt(ctx, c.level)
 
 	if err := c.Run(); err != nil {
-		return nil, errors.WithStack(errors.New(strings.TrimSpace(string(errorBuffer.Bytes()))))
+		return nil, errors.Wrap(err, c.String()+": "+strings.TrimSpace(string(errorBuffer.Bytes())))
 	}
 
 	return outBuffer.Bytes(), nil
@@ -112,3 +114,5 @@ func (c *Cmd) Kill(signal syscall.Signal) error {
 	}
 	return errors.WithStack(syscall.Kill(c.Process.Pid, signal))
 }
+
+func (c *Cmd) String() string { return fmt.Sprintf("cd %s && %s", c.Dir, shellquote.Join(c.Args...)) }

--- a/internal/pgproxy/pgproxy_test.go
+++ b/internal/pgproxy/pgproxy_test.go
@@ -13,14 +13,18 @@ import (
 	"github.com/block/ftl/internal/dev"
 	"github.com/block/ftl/internal/log"
 	"github.com/block/ftl/internal/pgproxy"
+	"github.com/block/ftl/internal/projectconfig"
 )
 
 func TestPgProxy(t *testing.T) {
 	ctx := log.ContextWithNewDefaultLogger(context.Background())
 	client, proxy := net.Pipe()
 
+	project, err := projectconfig.Load(ctx, optional.None[string]())
+	assert.NoError(t, err)
+
 	dsn := dev.PostgresDSN(ctx, 0)
-	err := dev.SetupPostgres(ctx, optional.None[string](), 0, false)
+	err = dev.SetupPostgres(ctx, project, optional.None[string](), 0, false)
 	assert.NoError(t, err)
 
 	frontend := pgproto3.NewFrontend(client, client)

--- a/internal/projectconfig/projectconfig.go
+++ b/internal/projectconfig/projectconfig.go
@@ -96,12 +96,12 @@ func (c Config) AbsModuleDirs() []string {
 	return absDirs
 }
 
-// DefaultConfigPath returns the absolute default path for the project config file, if possible.
+// defaultConfigPath returns the absolute default path for the project config file, if possible.
 //
 // The default path is determined by the FTL_CONFIG environment variable, if set, or by the presence of a Git
 // repository. If the Git repository is found, the default path is the root of the repository with the filename
 // "ftl-project.toml".
-func DefaultConfigPath() optional.Option[string] {
+func defaultConfigPath() optional.Option[string] {
 	if envar, ok := os.LookupEnv("FTL_CONFIG"); ok {
 		absPath, err := filepath.Abs(envar)
 		if err != nil {
@@ -156,11 +156,13 @@ func Create(ctx context.Context, config Config, dir string) error {
 }
 
 // Load project config from a file.
+//
+// Will return an empty Config if a path is not provided and a default config cannot be found.
 func Load(ctx context.Context, configPath optional.Option[string]) (Config, error) {
 	var path string
 	var ok bool
 	if path, ok = configPath.Get(); !ok {
-		maybePath, ok := DefaultConfigPath().Get()
+		maybePath, ok := defaultConfigPath().Get()
 		if !ok {
 			return Config{}, nil
 		}

--- a/internal/projectconfig/testdata/go/echo/go.mod
+++ b/internal/projectconfig/testdata/go/echo/go.mod
@@ -12,7 +12,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect

--- a/internal/projectconfig/testdata/go/echo/go.sum
+++ b/internal/projectconfig/testdata/go/echo/go.sum
@@ -18,8 +18,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/internal/projectconfig/testdata/go/findconfig/go.mod
+++ b/internal/projectconfig/testdata/go/findconfig/go.mod
@@ -12,7 +12,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect

--- a/internal/projectconfig/testdata/go/findconfig/go.sum
+++ b/internal/projectconfig/testdata/go/findconfig/go.sum
@@ -18,8 +18,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/internal/projectconfig/testdata/go/validateconfig/go.mod
+++ b/internal/projectconfig/testdata/go/validateconfig/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/XSAM/otelsql v0.38.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/kong v1.10.0 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect

--- a/internal/projectconfig/testdata/go/validateconfig/go.sum
+++ b/internal/projectconfig/testdata/go/validateconfig/go.sum
@@ -24,8 +24,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
 github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=

--- a/internal/watch/testdata/alpha/go.mod
+++ b/internal/watch/testdata/alpha/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/XSAM/otelsql v0.38.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/kong v1.10.0 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect

--- a/internal/watch/testdata/alpha/go.sum
+++ b/internal/watch/testdata/alpha/go.sum
@@ -24,8 +24,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
 github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=

--- a/internal/watch/testdata/another/go.mod
+++ b/internal/watch/testdata/another/go.mod
@@ -12,7 +12,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect

--- a/internal/watch/testdata/another/go.sum
+++ b/internal/watch/testdata/another/go.sum
@@ -18,8 +18,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/internal/watch/testdata/other/go.mod
+++ b/internal/watch/testdata/other/go.mod
@@ -12,7 +12,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect

--- a/internal/watch/testdata/other/go.sum
+++ b/internal/watch/testdata/other/go.sum
@@ -18,8 +18,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/jvm-runtime/testdata/go/gomodule/go.mod
+++ b/jvm-runtime/testdata/go/gomodule/go.mod
@@ -17,7 +17,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/alecthomas/atomic v0.1.0-alpha2 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect

--- a/jvm-runtime/testdata/go/gomodule/go.sum
+++ b/jvm-runtime/testdata/go/gomodule/go.sum
@@ -19,8 +19,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/smoketest/echo/go.mod
+++ b/smoketest/echo/go.mod
@@ -7,7 +7,7 @@ replace github.com/block/ftl => ../..
 require github.com/block/ftl v0.476.1
 
 require (
-	github.com/alecthomas/errors v0.7.0 // indirect
+	github.com/alecthomas/errors v0.8.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/types v0.19.0 // indirect
 	github.com/deckarep/golang-set/v2 v2.8.0 // indirect

--- a/smoketest/echo/go.sum
+++ b/smoketest/echo/go.sum
@@ -1,7 +1,7 @@
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=
 github.com/alecthomas/participle/v2 v2.1.4/go.mod h1:8tqVbpTX20Ru4NfYQgZf4mP18eXPTBViyMWiArNEgGI=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/smoketest/origin/go.mod
+++ b/smoketest/origin/go.mod
@@ -3,7 +3,7 @@ module ftl/origin
 go 1.24.0
 
 require (
-	github.com/alecthomas/errors v0.7.0
+	github.com/alecthomas/errors v0.8.2
 	github.com/block/ftl v0.476.1
 )
 

--- a/smoketest/origin/go.sum
+++ b/smoketest/origin/go.sum
@@ -24,8 +24,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
 github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=

--- a/smoketest/relay/go.mod
+++ b/smoketest/relay/go.mod
@@ -3,7 +3,7 @@ module ftl/relay
 go 1.24.0
 
 require (
-	github.com/alecthomas/errors v0.7.0
+	github.com/alecthomas/errors v0.8.2
 	github.com/block/ftl v0.476.1
 )
 

--- a/smoketest/relay/go.sum
+++ b/smoketest/relay/go.sum
@@ -24,8 +24,8 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.7.0 h1:lBKNV+t5Qrx+k6WUg6xz0yRfXvbj6ZF2vLzdIIZ5sFM=
-github.com/alecthomas/errors v0.7.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
+github.com/alecthomas/errors v0.8.2 h1:PLif19+0yYe+MRyCNjphmSzD3uAXnmdDzHIdlP2xkrg=
+github.com/alecthomas/errors v0.8.2/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
 github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/participle/v2 v2.1.4 h1:W/H79S8Sat/krZ3el6sQMvMaahJ+XcM9WSI2naI7w2U=


### PR DESCRIPTION
This entails injecting `projectconfig.Config` through parameters everywhere. Also simplified ftl-test options.