### PR TITLE
fix: subscripbe to notifications before getting previous value

### DIFF
--- a/internal/raft/cluster.go
+++ b/internal/raft/cluster.go
@@ -247,13 +247,14 @@ func (s *ShardHandle[Q, R, E]) StateIter(ctx context.Context, query Q) (iter.Seq
 	result := make(chan R, 64)
 	logger := log.FromContext(ctx).Scope("raft")
 
+	notificationCh := s.notifier.Subscribe(ctx)
+
 	previous, err := s.Query(ctx, query)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 
 	result <- previous
-	notificationCh := s.notifier.Subscribe(ctx)
 
 	go func() {
 		for {


### PR DESCRIPTION
Avoids missing an update if it happens between subscription and getting a previous value