### PR TITLE
chore: ensure leading prefix of stack trace paths is stripped

### DIFF
--- a/bin/hermit.hcl
+++ b/bin/hermit.hcl
@@ -1,6 +1,7 @@
 env = {
   "DBMATE_MIGRATIONS_DIR": "${HERMIT_ENV}/backend/controller/sql/schema",
   "DBMATE_NO_DUMP_SCHEMA": "true",
+  "GOFLAGS": "-trimpath",
   "FTL_DIR": "$HERMIT_ENV",
   "FTL_INIT_GO_REPLACE": "github.com/block/ftl=${HERMIT_ENV}",
   "FTL_SOURCE": "${HERMIT_ENV}",

--- a/internal/testdata/ziprelative/test.txt
+++ b/internal/testdata/ziprelative/test.txt
@@ -1,0 +1,1 @@
+Test text

--- a/internal/zip_relative.go
+++ b/internal/zip_relative.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"runtime/debug"
+	"strings"
 )
 
 // ZipRelativeToCaller creates a temporary zip file from a path relative to the caller.
@@ -14,15 +16,21 @@ import (
 // This function will leak a file descriptor and thus can only be used in development.
 func ZipRelativeToCaller(relativePath string) *zip.Reader {
 	_, file, _, _ := runtime.Caller(1)
+	// Strip main module prefix, ie. github.com/block/ftl
+	moduleRoot, ok := debug.ReadBuildInfo()
+	if ok {
+		file = strings.TrimPrefix(file, moduleRoot.Main.Path+"/")
+		gitRoot, ok := GitRoot(".").Get()
+		if ok {
+			file = filepath.Join(gitRoot, file)
+		}
+	}
 	dir := filepath.Join(filepath.Dir(file), relativePath)
 	w, err := os.CreateTemp("", "")
 	if err != nil {
 		panic(err)
 	}
 	defer os.Remove(w.Name()) // This is okay because the zip.Reader will keep it open.
-	if err != nil {
-		panic(err)
-	}
 
 	err = ZipDir(dir, w.Name())
 	if err != nil {

--- a/internal/zip_relative_test.go
+++ b/internal/zip_relative_test.go
@@ -1,0 +1,40 @@
+//go:build !release
+
+package internal_test
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+	"github.com/alecthomas/errors"
+
+	"github.com/block/ftl/common/slices"
+	"github.com/block/ftl/internal"
+)
+
+var files = internal.ZipRelativeToCaller("testdata/ziprelative")
+
+func TestZipRelative(t *testing.T) {
+	files := slices.Filter(files.File, func(f *zip.File) bool { return !f.Mode().IsDir() })
+	filenames := slices.Map(files, func(f *zip.File) string { return f.Name })
+	assert.Equal(t, []string{"test.txt"}, filenames)
+	r, err := files[0].Open()
+	assert.NoError(t, err)
+	t.Cleanup(func() {
+		err := r.Close()
+		assert.NoError(t, err)
+	})
+	data, err := io.ReadAll(r)
+	assert.NoError(t, err)
+	assert.Equal(t, "Test text", strings.TrimSpace(string(data)))
+}
+
+func TestErrorPrefixStripped(t *testing.T) {
+	err := errors.New("test error")
+	errorStr := fmt.Sprintf("%+v", err)
+	assert.Equal(t, "internal/zip_relative_test.go:37: test error", errorStr)
+}


### PR DESCRIPTION
The alecthomas/errors package attempts to reduce the size of paths by stripping the main package, but this requires that all Go binaries are built with "-trimpath". This has been added to the Hermit environment as a default compile flag.

Also added a test for ZipRelativeToCaller.

Before:

> /Users/aat/dev/ftl/go-runtime/ftl/ftltest/ftltest.go:379: /Users/aat/dev/ftl/go-runtime/ftl/ftltest/ftltest.go:434: test harness failed to call verb mysql.insert: /Users/aat/dev/ftl/internal/deploymentcontext/module_context.go:360: /Users/aat/dev/ftl/go-runtime/ftl/ftltest/ftltest.go:450: /Users/aat/dev/ftl/go-runtime/server/server.go:153: /Users/aat/dev/ftl/common/reflection/verb.go:87: /Users/aat/dev/ftl/go-runtime/server/server.go:187: /Users/aat/dev/ftl/go-runtime/server/server.go:232: mysql.createRequest: /Users/aat/dev/ftl/internal/deploymentcontext/module_context.go:360: /Users/aat/dev/ftl/go-runtime/server/server.go:339: /Users/aat/dev/ftl/go-runtime/server/server.go:153: /Users/aat/dev/ftl/common/reflection/verb.go:87: /Users/aat/dev/ftl/go-runtime/server/query.go:116: /Users/aat/dev/ftl/go-runtime/server/query/client.go:100: /Users/aat/dev/ftl/go-runtime/server/query/client.go:136: failed to execute query: /Users/aat/dev/ftl/go-runtime/server/query/client.go:201: failed to execute query: /Users/aat/dev/ftl/backend/runner/query/service.go:119: /Users/aat/dev/ftl/backend/runner/query/service.go:146: not_found: database connection for testdb not found

After:

> go-runtime/ftl/ftltest/ftltest.go:379: go-runtime/ftl/ftltest/ftltest.go:434: test harness failed to call verb mysql.insert: internal/deploymentcontext/module_context.go:360: go-runtime/ftl/ftltest/ftltest.go:450: go-runtime/server/server.go:153: common/reflection/verb.go:87: go-runtime/server/server.go:187: go-runtime/server/server.go:232: mysql.createRequest: internal/deploymentcontext/module_context.go:360: go-runtime/server/server.go:339: go-runtime/server/server.go:153: common/reflection/verb.go:87: go-runtime/server/query.go:116: go-runtime/server/query/client.go:100: go-runtime/server/query/client.go:136: failed to execute query: go-runtime/server/query/client.go:201: failed to execute query: backend/runner/query/service.go:119: backend/runner/query/service.go:146: not_found: database connection for testdb not found