### PR TITLE
fix: duplicated, unformatted engine errors

### DIFF
--- a/internal/buildengine/engine.go
+++ b/internal/buildengine/engine.go
@@ -1245,7 +1245,7 @@ func (e *Engine) build(ctx context.Context, moduleName string, builtModules map[
 				},
 			},
 		}
-		return "", nil, errors.WithStack(err)
+		return "", nil, nil
 	}
 
 	e.rawEngineUpdates <- &buildenginepb.EngineEvent{


### PR DESCRIPTION
It's still very verbose with `jvm` errors, but the duplicate errors should be gone now. Module build errors are handled via our `rawEngineUpdates` channel, so we can ignore them in our error logging of `BuildAndDeploy`