### PR TITLE
feat: add support for external realms to ftl-project.toml

### DIFF
--- a/backend/protos/xyz/block/ftl/admin/v1/admin.pb.go
+++ b/backend/protos/xyz/block/ftl/admin/v1/admin.pb.go
@@ -1262,7 +1262,9 @@ type RealmChange struct {
 	// The modules to add or update.
 	Modules []*v1.Module `protobuf:"bytes,2,rep,name=modules,proto3" json:"modules,omitempty"`
 	// The deployments to remove.
-	ToRemove      []string `protobuf:"bytes,3,rep,name=to_remove,json=toRemove,proto3" json:"to_remove,omitempty"`
+	ToRemove []string `protobuf:"bytes,3,rep,name=to_remove,json=toRemove,proto3" json:"to_remove,omitempty"`
+	// Whether this is an external realm.
+	External      bool `protobuf:"varint,4,opt,name=external,proto3" json:"external,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1316,6 +1318,13 @@ func (x *RealmChange) GetToRemove() []string {
 		return x.ToRemove
 	}
 	return nil
+}
+
+func (x *RealmChange) GetExternal() bool {
+	if x != nil {
+		return x.External
+	}
+	return false
 }
 
 type ApplyChangesetRequest struct {
@@ -2566,11 +2575,12 @@ const file_xyz_block_ftl_admin_v1_admin_proto_rawDesc = "" +
 	"\x18ResetSubscriptionRequest\x12@\n" +
 	"\fsubscription\x18\x01 \x01(\v2\x1c.xyz.block.ftl.schema.v1.RefR\fsubscription\x12B\n" +
 	"\x06offset\x18\x02 \x01(\x0e2*.xyz.block.ftl.admin.v1.SubscriptionOffsetR\x06offset\"\x1b\n" +
-	"\x19ResetSubscriptionResponse\"y\n" +
+	"\x19ResetSubscriptionResponse\"\x95\x01\n" +
 	"\vRealmChange\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x129\n" +
 	"\amodules\x18\x02 \x03(\v2\x1f.xyz.block.ftl.schema.v1.ModuleR\amodules\x12\x1b\n" +
-	"\tto_remove\x18\x03 \x03(\tR\btoRemove\"a\n" +
+	"\tto_remove\x18\x03 \x03(\tR\btoRemove\x12\x1a\n" +
+	"\bexternal\x18\x04 \x01(\bR\bexternal\"a\n" +
 	"\x15ApplyChangesetRequest\x12H\n" +
 	"\rrealm_changes\x18\x01 \x03(\v2#.xyz.block.ftl.admin.v1.RealmChangeR\frealmChanges\"Z\n" +
 	"\x16ApplyChangesetResponse\x12@\n" +

--- a/backend/protos/xyz/block/ftl/admin/v1/admin.proto
+++ b/backend/protos/xyz/block/ftl/admin/v1/admin.proto
@@ -147,6 +147,8 @@ message RealmChange {
   repeated ftl.schema.v1.Module modules = 2;
   // The deployments to remove.
   repeated string to_remove = 3;
+  // Whether this is an external realm.
+  bool external = 4;
 }
 
 message ApplyChangesetRequest {

--- a/backend/protos/xyz/block/ftl/v1/schemaservice.pb.go
+++ b/backend/protos/xyz/block/ftl/v1/schemaservice.pb.go
@@ -372,7 +372,9 @@ type RealmChange struct {
 	// The modules to add or update.
 	Modules []*v1.Module `protobuf:"bytes,2,rep,name=modules,proto3" json:"modules,omitempty"`
 	// The deployments to remove.
-	ToRemove      []string `protobuf:"bytes,3,rep,name=to_remove,json=toRemove,proto3" json:"to_remove,omitempty"`
+	ToRemove []string `protobuf:"bytes,3,rep,name=to_remove,json=toRemove,proto3" json:"to_remove,omitempty"`
+	// Whether this is an external realm.
+	External      bool `protobuf:"varint,4,opt,name=external,proto3" json:"external,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -426,6 +428,13 @@ func (x *RealmChange) GetToRemove() []string {
 		return x.ToRemove
 	}
 	return nil
+}
+
+func (x *RealmChange) GetExternal() bool {
+	if x != nil {
+		return x.External
+	}
+	return false
 }
 
 type CreateChangesetRequest struct {
@@ -1198,11 +1207,12 @@ const file_xyz_block_ftl_v1_schemaservice_proto_rawDesc = "" +
 	"\x1fUpdateDeploymentRuntimeResponse\"\x17\n" +
 	"\x15GetDeploymentsRequest\"R\n" +
 	"\x16GetDeploymentsResponse\x128\n" +
-	"\x06schema\x18\x01 \x03(\v2 .xyz.block.ftl.v1.DeployedSchemaR\x06schema\"y\n" +
+	"\x06schema\x18\x01 \x03(\v2 .xyz.block.ftl.v1.DeployedSchemaR\x06schema\"\x95\x01\n" +
 	"\vRealmChange\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x129\n" +
 	"\amodules\x18\x02 \x03(\v2\x1f.xyz.block.ftl.schema.v1.ModuleR\amodules\x12\x1b\n" +
-	"\tto_remove\x18\x03 \x03(\tR\btoRemove\"\\\n" +
+	"\tto_remove\x18\x03 \x03(\tR\btoRemove\x12\x1a\n" +
+	"\bexternal\x18\x04 \x01(\bR\bexternal\"\\\n" +
 	"\x16CreateChangesetRequest\x12B\n" +
 	"\rrealm_changes\x18\x01 \x03(\v2\x1d.xyz.block.ftl.v1.RealmChangeR\frealmChanges\"7\n" +
 	"\x17CreateChangesetResponse\x12\x1c\n" +

--- a/backend/protos/xyz/block/ftl/v1/schemaservice.proto
+++ b/backend/protos/xyz/block/ftl/v1/schemaservice.proto
@@ -41,6 +41,8 @@ message RealmChange {
   repeated ftl.schema.v1.Module modules = 2;
   // The deployments to remove.
   repeated string to_remove = 3;
+  // Whether this is an external realm.
+  bool external = 4;
 }
 
 message CreateChangesetRequest {

--- a/common/schema/schema.go
+++ b/common/schema/schema.go
@@ -355,6 +355,26 @@ func (s *Schema) External() *Schema {
 	return filtered
 }
 
+func (s *Schema) UpdateRealms(realms []*Realm) {
+	byName := make(map[string]*Realm)
+	found := make(map[string]bool)
+	for _, r := range realms {
+		byName[r.Name] = r
+		found[r.Name] = true
+	}
+	for i, r := range s.Realms {
+		if n, ok := byName[r.Name]; ok {
+			s.Realms[i] = n
+		}
+		found[r.Name] = true
+	}
+	for _, r := range realms {
+		if !found[r.Name] {
+			s.Realms = append(s.Realms, r)
+		}
+	}
+}
+
 func filterExternalMetadata(metadata []Metadata) []Metadata {
 	var filtered []Metadata
 	for _, m := range metadata {

--- a/frontend/console/src/protos/xyz/block/ftl/admin/v1/admin_pb.ts
+++ b/frontend/console/src/protos/xyz/block/ftl/admin/v1/admin_pb.ts
@@ -1121,6 +1121,13 @@ export class RealmChange extends Message<RealmChange> {
    */
   toRemove: string[] = [];
 
+  /**
+   * Whether this is an external realm.
+   *
+   * @generated from field: bool external = 4;
+   */
+  external = false;
+
   constructor(data?: PartialMessage<RealmChange>) {
     super();
     proto3.util.initPartial(data, this);
@@ -1132,6 +1139,7 @@ export class RealmChange extends Message<RealmChange> {
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "modules", kind: "message", T: Module, repeated: true },
     { no: 3, name: "to_remove", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
+    { no: 4, name: "external", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): RealmChange {

--- a/frontend/console/src/protos/xyz/block/ftl/v1/schemaservice_pb.ts
+++ b/frontend/console/src/protos/xyz/block/ftl/v1/schemaservice_pb.ts
@@ -320,6 +320,13 @@ export class RealmChange extends Message<RealmChange> {
    */
   toRemove: string[] = [];
 
+  /**
+   * Whether this is an external realm.
+   *
+   * @generated from field: bool external = 4;
+   */
+  external = false;
+
   constructor(data?: PartialMessage<RealmChange>) {
     super();
     proto3.util.initPartial(data, this);
@@ -331,6 +338,7 @@ export class RealmChange extends Message<RealmChange> {
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "modules", kind: "message", T: Module, repeated: true },
     { no: 3, name: "to_remove", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
+    { no: 4, name: "external", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): RealmChange {

--- a/ftl-project.toml
+++ b/ftl-project.toml
@@ -17,3 +17,4 @@ disable-vscode-integration = true
 
 [commands]
   startup = ["echo 'FTL startup command ⚡️'"]
+

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -68,6 +68,7 @@ type SharedCLI struct {
 	Mysql     mySQLCmd     `cmd:"" help:"Manage MySQL databases."`
 	Postgres  postgresCmd  `cmd:"" help:"Manage PostgreSQL databases."`
 	Edit      editCmd      `cmd:"" help:"Edit a declaration in an IDE."`
+	Realm     realmCmd     `cmd:"" help:"Manage realms." hidden:""`
 }
 
 type BuildAndDeploy struct {

--- a/internal/app/cmd_realm.go
+++ b/internal/app/cmd_realm.go
@@ -1,0 +1,44 @@
+package app
+
+import (
+	"context"
+
+	errors "github.com/alecthomas/errors"
+	"github.com/block/ftl/internal/projectconfig"
+	"github.com/block/ftl/internal/realm"
+)
+
+type realmCmd struct {
+	Add realmAddCmd `cmd:"" help:"Add a new external realm."`
+}
+
+type realmAddCmd struct {
+	GitRepo   string `help:"The git repository to use for the realm." required:""`
+	GitBranch string `help:"The git branch to use for the realm." required:""`
+	GitPath   string `help:"The path to the schema file in the git repository." default:"ftl-external-schema.json"`
+}
+
+func (c *realmAddCmd) Run(ctx context.Context, p projectconfig.Config) error {
+	realm, commitSHA, err := realm.LatestExternalRealm(ctx, projectconfig.ExternalRealmConfig{
+		GitRepo:   c.GitRepo,
+		GitBranch: c.GitBranch,
+		GitPath:   c.GitPath,
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to fetch external realm")
+	}
+
+	if p.ExternalRealms == nil {
+		p.ExternalRealms = make(map[string]projectconfig.ExternalRealmConfig)
+	}
+	p.ExternalRealms[realm.Name] = projectconfig.ExternalRealmConfig{
+		GitRepo:   c.GitRepo,
+		GitBranch: c.GitBranch,
+		GitPath:   c.GitPath,
+		GitCommit: commitSHA,
+	}
+	if err := projectconfig.Save(p); err != nil {
+		return errors.Wrap(err, "failed to save project config")
+	}
+	return nil
+}

--- a/internal/app/cmd_realm.go
+++ b/internal/app/cmd_realm.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	errors "github.com/alecthomas/errors"
+
 	"github.com/block/ftl/internal/projectconfig"
 	"github.com/block/ftl/internal/realm"
 )

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1,0 +1,74 @@
+package git
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/alecthomas/errors"
+	"github.com/block/ftl/internal/exec"
+	"github.com/block/ftl/internal/log"
+)
+
+type Git interface {
+	Init(ctx context.Context, repo string) error
+	Fetch(ctx context.Context, branch string, shallow bool) error
+	Checkout(ctx context.Context, ref string) error
+	GetCommitSHA(ctx context.Context) (string, error)
+	ReadFile(ctx context.Context, path string) ([]byte, error)
+}
+
+type gitCLI struct {
+	dir string
+}
+
+func NewGitCLI(dir string) Git {
+	return &gitCLI{dir: dir}
+}
+
+func (g *gitCLI) Init(ctx context.Context, repo string) error {
+	if err := exec.Command(ctx, log.Debug, g.dir, "git", "init", ".").Run(); err != nil {
+		return errors.Wrapf(err, "failed to init git repo")
+	}
+	if err := exec.Command(ctx, log.Debug, g.dir, "git", "remote", "add", "origin", repo).Run(); err != nil {
+		return errors.Wrap(err, "failed to add remote to git repo")
+	}
+	return nil
+}
+
+func (g *gitCLI) Fetch(ctx context.Context, branch string, shallow bool) error {
+	if shallow {
+		if err := exec.Command(ctx, log.Debug, g.dir, "git", "fetch", "--depth", "1", "origin", branch).Run(); err != nil {
+			return errors.Wrap(err, "failed to fetch shallow git repo")
+		}
+	} else {
+		if err := exec.Command(ctx, log.Debug, g.dir, "git", "fetch", "origin", branch).Run(); err != nil {
+			return errors.Wrap(err, "failed to fetch git repo")
+		}
+	}
+	return nil
+}
+
+func (g *gitCLI) Checkout(ctx context.Context, ref string) error {
+	if err := exec.Command(ctx, log.Debug, g.dir, "git", "checkout", ref).Run(); err != nil {
+		return errors.Wrapf(err, "failed to checkout git ref %s", ref)
+	}
+	return nil
+}
+
+func (g *gitCLI) GetCommitSHA(ctx context.Context) (string, error) {
+	commitSHA, err := exec.Capture(ctx, g.dir, "git", "rev-parse", "HEAD")
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get commit SHA")
+	}
+	return strings.TrimSpace(string(commitSHA)), nil
+}
+
+func (g *gitCLI) ReadFile(ctx context.Context, path string) ([]byte, error) {
+	content, err := os.ReadFile(filepath.Join(g.dir, path))
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read external schema")
+	}
+	return content, nil
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/alecthomas/errors"
+
 	"github.com/block/ftl/internal/exec"
 	"github.com/block/ftl/internal/log"
 )

--- a/internal/projectconfig/projectconfig.go
+++ b/internal/projectconfig/projectconfig.go
@@ -29,6 +29,7 @@ type ExternalRealmConfig struct {
 	GitRepo   string `toml:"git-repo,omitempty"`
 	GitBranch string `toml:"git-branch,omitempty"`
 	GitCommit string `toml:"git-commit,omitempty"`
+	GitPath   string `toml:"git-path,omitempty"`
 }
 
 type Config struct {
@@ -219,12 +220,21 @@ func Save(config Config) error {
 	return errors.WithStack(os.Rename(w.Name(), config.Path))
 }
 
+func (c Config) FTLWorkingDir() string {
+	return filepath.Join(c.Root(), ".ftl")
+}
+
 // SchemaPath returns the path to the schema file for the given module.
 func (c Config) SchemaPath(module string) string {
-	return filepath.Join(c.Root(), ".ftl", "schemas", module+".pb")
+	return filepath.Join(c.FTLWorkingDir(), "schemas", module+".pb")
 }
 
 // WatchModulesLockPath returns the path to the lock file used to prevent scaffolding new modules while discovering modules.
 func (c Config) WatchModulesLockPath() string {
-	return filepath.Join(c.Root(), ".ftl", "modules.lock")
+	return filepath.Join(c.FTLWorkingDir(), "modules.lock")
+}
+
+// ExternalRealmPath returns the path to the locally cached external realm files.
+func (c Config) ExternalRealmPath() string {
+	return filepath.Join(c.FTLWorkingDir(), "realms")
 }

--- a/internal/projectconfig/projectconfig.go
+++ b/internal/projectconfig/projectconfig.go
@@ -25,23 +25,30 @@ type ConfigAndSecrets struct {
 	Secrets map[string]*URL `toml:"secrets"`
 }
 
+type ExternalRealmConfig struct {
+	GitRepo   string `toml:"git-repo,omitempty"`
+	GitBranch string `toml:"git-branch,omitempty"`
+	GitCommit string `toml:"git-commit,omitempty"`
+}
+
 type Config struct {
 	// Path to the config file populated on load.
 	Path string `toml:"-"`
 
-	Name                       string                      `toml:"name,omitempty"`
-	Global                     ConfigAndSecrets            `toml:"global,omitempty"`
-	SecretsProvider            configuration.ProviderKey   `toml:"secrets-provider,omitempty"`
-	ConfigProvider             configuration.ProviderKey   `toml:"config-provider,omitempty"`
-	Modules                    map[string]ConfigAndSecrets `toml:"modules,omitempty"`
-	ModuleDirs                 []string                    `toml:"module-dirs,omitempty"`
-	Commands                   Commands                    `toml:"commands,omitempty"`
-	FTLMinVersion              string                      `toml:"ftl-min-version,omitempty"`
-	Hermit                     bool                        `toml:"hermit,omitempty"`
-	NoGit                      bool                        `toml:"no-git,omitempty"`
-	DisableIDEIntegration      bool                        `toml:"disable-ide-integration,omitempty"`
-	DisableVSCodeIntegration   bool                        `toml:"disable-vscode-integration,omitempty"`
-	DisableIntellijIntegration bool                        `toml:"disable-intellij-integration,omitempty"`
+	Name                       string                         `toml:"name,omitempty"`
+	Global                     ConfigAndSecrets               `toml:"global,omitempty"`
+	SecretsProvider            configuration.ProviderKey      `toml:"secrets-provider,omitempty"`
+	ConfigProvider             configuration.ProviderKey      `toml:"config-provider,omitempty"`
+	Modules                    map[string]ConfigAndSecrets    `toml:"modules,omitempty"`
+	ModuleDirs                 []string                       `toml:"module-dirs,omitempty"`
+	Commands                   Commands                       `toml:"commands,omitempty"`
+	FTLMinVersion              string                         `toml:"ftl-min-version,omitempty"`
+	Hermit                     bool                           `toml:"hermit,omitempty"`
+	NoGit                      bool                           `toml:"no-git,omitempty"`
+	DisableIDEIntegration      bool                           `toml:"disable-ide-integration,omitempty"`
+	DisableVSCodeIntegration   bool                           `toml:"disable-vscode-integration,omitempty"`
+	DisableIntellijIntegration bool                           `toml:"disable-intellij-integration,omitempty"`
+	ExternalRealms             map[string]ExternalRealmConfig `toml:"external-realms,omitempty"`
 }
 
 // Root directory of the project.

--- a/internal/projectconfig/projectconfig_test.go
+++ b/internal/projectconfig/projectconfig_test.go
@@ -33,6 +33,13 @@ func TestProjectConfig(t *testing.T) {
 		Commands: Commands{
 			Startup: []string{"echo 'Executing global pre-build command'"},
 		},
+		ExternalRealms: map[string]ExternalRealmConfig{
+			"foo": {
+				GitRepo:   "git@github.com:block/ftl.git",
+				GitBranch: "main",
+				GitCommit: "04d1eb9286891a292f50aa8553896e78a4811b4a",
+			},
+		},
 	}
 
 	assert.Equal(t, expected, actual)

--- a/internal/projectconfig/testdata/ftl-project.toml
+++ b/internal/projectconfig/testdata/ftl-project.toml
@@ -10,3 +10,8 @@ module-dirs = ["a/b/c", "d"]
 
 [commands]
   startup = ["echo 'Executing global pre-build command'"]
+
+[external-realms.foo]
+  git-repo = "git@github.com:block/ftl.git"
+  git-branch = "main"
+  git-commit = "04d1eb9286891a292f50aa8553896e78a4811b4a"

--- a/internal/realm/realm.go
+++ b/internal/realm/realm.go
@@ -1,0 +1,126 @@
+package realm
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/alecthomas/errors"
+	schemapb "github.com/block/ftl/common/protos/xyz/block/ftl/schema/v1"
+	"github.com/block/ftl/common/schema"
+	"github.com/block/ftl/internal/git"
+	"github.com/block/ftl/internal/log"
+	"github.com/block/ftl/internal/projectconfig"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+// LatestExternalRealm returns the latest external realm that the config refers to, with the commit SHA.
+func LatestExternalRealm(ctx context.Context, cfg projectconfig.ExternalRealmConfig) (realm *schema.Realm, commitSHA string, err error) {
+	tmpdir, err := os.MkdirTemp("", "ftl-realm")
+	if err != nil {
+		return nil, "", errors.Wrap(err, "failed to create temp directory")
+	}
+	defer os.RemoveAll(tmpdir)
+
+	git := git.NewGitCLI(tmpdir)
+	if err := git.Init(ctx, cfg.GitRepo); err != nil {
+		return nil, "", errors.Wrap(err, "failed to init git repo")
+	}
+	if err := git.Fetch(ctx, cfg.GitBranch, true); err != nil {
+		return nil, "", errors.Wrap(err, "failed to fetch git repo")
+	}
+	if err := git.Checkout(ctx, cfg.GitBranch); err != nil {
+		return nil, "", errors.Wrap(err, "failed to checkout git commit")
+	}
+	commitSHA, err = git.GetCommitSHA(ctx)
+	if err != nil {
+		return nil, "", errors.Wrap(err, "failed to get commit SHA")
+	}
+
+	content, err := git.ReadFile(ctx, cfg.GitPath)
+	if err != nil {
+		return nil, "", errors.Wrap(err, "failed to read "+cfg.GitPath)
+	}
+	realm, err = parseExternal(content)
+	if err != nil {
+		return nil, "", errors.Wrap(err, "failed to parse external realm")
+	}
+	return realm, commitSHA, nil
+}
+
+// GetExternalRealm returns the external realm that the config refers to, with the commit SHA.
+// It will cache the realm in the given directory if it does not yet exist.
+func GetExternalRealm(ctx context.Context, cacheDir, name string, cfg projectconfig.ExternalRealmConfig) (*schema.Realm, error) {
+	logger := log.FromContext(ctx)
+
+	if err := os.MkdirAll(cacheDir, 0700); err != nil {
+		return nil, errors.Wrapf(err, "failed to create external realm dir")
+	}
+
+	var content []byte
+	cachedFile := filepath.Join(cacheDir, cfg.GitCommit+".json")
+	_, err := os.Stat(cachedFile)
+	if errors.Is(err, os.ErrNotExist) {
+		logger.Infof("Fetching external realm %s from %s (%s)", name, cfg.GitRepo, cfg.GitCommit) //nolint:forbidigo
+
+		content, err = fetchExternalSchemaFile(ctx, cfg)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to fetch external realm")
+		}
+
+		if err := os.WriteFile(cachedFile, content, 0600); err != nil {
+			return nil, errors.Wrap(err, "failed to write external realm to local cache")
+		}
+	} else if err != nil {
+		return nil, errors.Wrapf(err, "failed to stat external realm")
+	} else {
+		content, err = os.ReadFile(cachedFile)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to read external realm from cache")
+		}
+	}
+
+	return errors.WithStack2(parseExternal(content))
+}
+
+func fetchExternalSchemaFile(ctx context.Context, cfg projectconfig.ExternalRealmConfig) (content []byte, err error) {
+	tmpdir, err := os.MkdirTemp("", "ftl-external-realm")
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create temp directory")
+	}
+	defer os.RemoveAll(tmpdir)
+
+	git := git.NewGitCLI(tmpdir)
+	if err := git.Init(ctx, cfg.GitRepo); err != nil {
+		return nil, errors.Wrap(err, "failed to init git repo")
+	}
+	if err := git.Fetch(ctx, cfg.GitBranch, true); err != nil {
+		return nil, errors.Wrap(err, "failed to fetch git repo")
+	}
+	if err := git.Checkout(ctx, cfg.GitCommit); err != nil {
+		return nil, errors.Wrap(err, "failed to checkout git branch")
+	}
+
+	content, err = git.ReadFile(ctx, cfg.GitPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read "+cfg.GitPath)
+	}
+	return content, nil
+}
+
+func parseExternal(content []byte) (*schema.Realm, error) {
+	proto := &schemapb.Schema{}
+	if err := protojson.Unmarshal(content, proto); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal schema")
+	}
+	sch, err := schema.FromProto(proto)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal schema")
+	}
+	if len(sch.InternalRealms()) != 1 {
+		return nil, errors.New("expected exactly one internal realm")
+	}
+	result := sch.InternalRealms()[0]
+	result.External = true
+	return result, nil
+}

--- a/internal/realm/realm.go
+++ b/internal/realm/realm.go
@@ -6,12 +6,13 @@ import (
 	"path/filepath"
 
 	"github.com/alecthomas/errors"
+	"google.golang.org/protobuf/encoding/protojson"
+
 	schemapb "github.com/block/ftl/common/protos/xyz/block/ftl/schema/v1"
 	"github.com/block/ftl/common/schema"
 	"github.com/block/ftl/internal/git"
 	"github.com/block/ftl/internal/log"
 	"github.com/block/ftl/internal/projectconfig"
-	"google.golang.org/protobuf/encoding/protojson"
 )
 
 // LatestExternalRealm returns the latest external realm that the config refers to, with the commit SHA.


### PR DESCRIPTION
Also propagates the realm to the schema state.
However, the content of external realms are yet not stored in state. The new command
```
ftl realm add --git-repo=<> --git-branch=<>
```
is hidden until it is working e2e

When it is working e2e, will add an integration test.