### PR TITLE
revert: "chore(ci): log in to Docker Hub for integration tests"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,11 +304,6 @@ jobs:
         with:
           name: maven-repo
           path: ~/.m2/repository
-      - name: Log in to DockerHub to avoid rate limiting
-        env:
-          DOCKER_HUB_PULL_TOKEN: ${{ secrets.DOCKER_HUB_PULL_TOKEN }}
-        run: |
-          echo "${DOCKER_HUB_PULL_TOKEN}" | docker login --username "blockossreleases" --password-stdin
       - name: Run ${{ matrix.test }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
Reverts block/ftl#5368

Unfortunately `blockossreleases` has a very limited pull rate limit, so this breaks things more than fixes