### PR TITLE
fix: log an error if secret s provider returns nil values

### DIFF
--- a/internal/configuration/manager/cache.go
+++ b/internal/configuration/manager/cache.go
@@ -209,6 +209,10 @@ func (c *cacheProvider[R]) sync(ctx context.Context) {
 		}
 		return
 	}
+	if values == nil {
+		logger.Warnf("provider %s returned nil values", provider.Key())
+		return
+	}
 	c.valuesLock.Lock()
 	defer c.valuesLock.Unlock()
 	c.values = values


### PR DESCRIPTION
Previously, this would set the ref map to nil, which would explode later