### PR TITLE
fix: hack support for "warning"

### DIFF
--- a/internal/log/json.go
+++ b/internal/log/json.go
@@ -72,6 +72,8 @@ func JSONStreamer(r io.Reader, log *Logger, defaultLevel Level) error {
 				entry.Entry.Level = Trace
 			case "severe":
 				entry.Entry.Level = Error
+			case "warning":
+				entry.Entry.Level = Warn
 			case "":
 				entry.Entry.Level = Info
 			default:


### PR DESCRIPTION
Some JVM project was resulting in:

> Invalid log level: WARNING does not belong to Level values

Ideally this would be translated correctly by the language runtimes, but we're already doing this for "fine" et al so...