### PR TITLE
fix: pass log messages through directly in the runner

### DIFF
--- a/backend/provisioner/registry.go
+++ b/backend/provisioner/registry.go
@@ -103,6 +103,7 @@ func provisionerIDToProvisioner(ctx context.Context, id string, workingDir strin
 			workingDir,
 			"ftl-provisioner-"+id,
 			provisionerconnect.NewProvisionerPluginServiceClient,
+			true,
 		)
 		if err != nil {
 			return nil, errors.Wrap(err, "error spawning plugin")

--- a/backend/runner/runner.go
+++ b/backend/runner/runner.go
@@ -490,6 +490,7 @@ func (s *Service) deploy(ctx context.Context, key key.Deployment, module *schema
 			deploymentDir,
 			"./launch",
 			ftlv1connect.NewVerbServiceClient,
+			false, // we log the plugins output directly
 			plugin.WithEnvars(
 				envVars...,
 			),

--- a/common/plugin/spawn.go
+++ b/common/plugin/spawn.go
@@ -87,7 +87,7 @@ func Spawn[Client rpc.Pingable[Req, Resp, RespPtr], Req any, Resp any, RespPtr r
 	defaultLevel log.Level,
 	name, module, dir, exe string,
 	makeClient rpc.ClientFactory[Client, Req, Resp, RespPtr],
-	streamJson bool,
+	streamJSON bool,
 	options ...Option,
 ) (plugin *Plugin[Client, Req, Resp, RespPtr], cmdCtx context.Context, err error) {
 	logger := log.FromContext(ctx).Scope(name).Module(module)
@@ -124,7 +124,7 @@ func Spawn[Client rpc.Pingable[Req, Resp, RespPtr], Req any, Resp any, RespPtr r
 	logger.Tracef("Spawning plugin on %s", pluginEndpoint)
 	cmd := exec.Command(ctx, defaultLevel, dir, exe)
 
-	if streamJson {
+	if streamJSON {
 		// Send the plugin's stderr and stdout to the logger.
 		cmd.Stderr = nil
 		epipe, err := cmd.StderrPipe()

--- a/internal/buildengine/languageplugin/plugin_client.go
+++ b/internal/buildengine/languageplugin/plugin_client.go
@@ -75,6 +75,7 @@ func (p *pluginClientImpl) start(ctx context.Context, dir, language, name string
 		dir,
 		cmdPath,
 		langconnect.NewLanguageServiceClient,
+		true,
 		plugin.WithEnvars(envvars...),
 	)
 	if err != nil {

--- a/internal/log/json.go
+++ b/internal/log/json.go
@@ -70,9 +70,9 @@ func JSONStreamer(r io.Reader, log *Logger, defaultLevel Level) error {
 				entry.Entry.Level = Debug
 			case "finest":
 				entry.Entry.Level = Trace
-			case "severe":
+			case "severe", "error":
 				entry.Entry.Level = Error
-			case "warning":
+			case "warning", "warn":
 				entry.Entry.Level = Warn
 			case "":
 				entry.Entry.Level = Info


### PR DESCRIPTION
At the moment we don't have a proper non-dev mode translation layer between the JVM and go log JSON formats, so the JVM logs are getting all of their exception information being stripped from them. This can hide critical errors, as only the outermost exception is present in the logs.

For now the simplest solution is to just pass them through so they get written directly to the kube pod logs. There is already transaction in place in dev mode so this only affects prod.