### PR TITLE
fix: ignore FTL_ENDPOINT for dev mode

### DIFF
--- a/cmd/ftl/cmd_dev.go
+++ b/cmd/ftl/cmd_dev.go
@@ -43,6 +43,7 @@ func (d *devCmd) Run(
 	csm *currentStatusManager,
 ) error {
 	cli.AdminEndpoint = d.ServeCmd.Bind
+	os.Unsetenv("FTL_ENDPOINT") //nolint:errcheck
 	adminClient := rpc.Dial(adminpbconnect.NewAdminServiceClient, d.ServeCmd.Bind.String(), log.Error)
 
 	startTime := time.Now()

--- a/cmd/ftl/cmd_dev.go
+++ b/cmd/ftl/cmd_dev.go
@@ -13,7 +13,6 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/block/ftl/backend/protos/xyz/block/ftl/admin/v1/adminpbconnect"
-	"github.com/block/ftl/backend/protos/xyz/block/ftl/buildengine/v1/buildenginepbconnect"
 	"github.com/block/ftl/internal/bind"
 	"github.com/block/ftl/internal/buildengine"
 	"github.com/block/ftl/internal/configuration"
@@ -24,7 +23,6 @@ import (
 	"github.com/block/ftl/internal/rpc"
 	"github.com/block/ftl/internal/schema/schemaeventsource"
 	"github.com/block/ftl/internal/terminal"
-	"github.com/block/ftl/internal/timelineclient"
 )
 
 const maxLogs = 10
@@ -42,13 +40,10 @@ func (d *devCmd) Run(
 	sm *manager.Manager[configuration.Secrets],
 	projConfig projectconfig.Config,
 	bindContext KongContextBinder,
-	schemaEventSource *schemaeventsource.EventSource,
-	timelineClient *timelineclient.Client,
-	buildEngineClient buildenginepbconnect.BuildEngineServiceClient,
 	csm *currentStatusManager,
-	cli *SharedCLI,
 ) error {
-	adminClient := rpc.Dial(adminpbconnect.NewAdminServiceClient, cli.AdminEndpoint.String(), log.Error)
+	cli.AdminEndpoint = d.ServeCmd.Bind
+	adminClient := rpc.Dial(adminpbconnect.NewAdminServiceClient, d.ServeCmd.Bind.String(), log.Error)
 
 	startTime := time.Now()
 	ctx, cancel := context.WithCancelCause(ctx)
@@ -80,7 +75,8 @@ func (d *devCmd) Run(
 	}
 	os.Setenv("FTL_DEV_DIRS", strings.Join(absDirs, ","))
 
-	terminal.LaunchEmbeddedConsole(ctx, createKongApplication(&DevModeCLI{}, csm), schemaEventSource, func(ctx context.Context, k *kong.Kong, args []string, additionalExit func(int)) error {
+	source := schemaeventsource.New(ctx, "dev", adminClient)
+	terminal.LaunchEmbeddedConsole(ctx, createKongApplication(&DevModeCLI{}, csm), source, func(ctx context.Context, k *kong.Kong, args []string, additionalExit func(int)) error {
 		return errors.WithStack(runInnerCmd(ctx, k, projConfig, bindContext, args, additionalExit))
 	})
 	var deployClient buildengine.AdminClient = adminClient
@@ -96,7 +92,7 @@ func (d *devCmd) Run(
 	defer statusManager.Close()
 	starting := statusManager.NewStatus("\u001B[92mStarting FTL Server 🚀\u001B[39m")
 
-	bindAllocator, err := bind.NewBindAllocator(cli.AdminEndpoint, 2)
+	bindAllocator, err := bind.NewBindAllocator(d.ServeCmd.Bind, 2)
 	if err != nil {
 		return errors.Wrap(err, "could not create bind allocator")
 	}
@@ -108,7 +104,7 @@ func (d *devCmd) Run(
 	devModeEndpointUpdates := make(chan dev.LocalEndpoint, 1)
 
 	opts := []buildengine.Option{buildengine.Parallelism(d.Build.Parallelism), buildengine.BuildEnv(d.Build.BuildEnv), buildengine.WithDevMode(devModeEndpointUpdates), buildengine.WithStartTime(startTime)}
-	engine, err := buildengine.New(ctx, deployClient, schemaEventSource, projConfig, d.Build.Dirs, false, opts...)
+	engine, err := buildengine.New(ctx, deployClient, source, projConfig, d.Build.Dirs, false, opts...)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -117,7 +113,7 @@ func (d *devCmd) Run(
 	controllerReady := make(chan bool, 1)
 	if !d.NoServe {
 		if d.ServeCmd.Stop {
-			err := d.ServeCmd.run(ctx, projConfig, cm, sm, optional.Some(controllerReady), true, bindAllocator, timelineClient, adminClient, buildEngineClient, devModeEndpointUpdates, []rpc.Service{engine}, cli)
+			err := d.ServeCmd.run(ctx, projConfig, cm, sm, optional.Some(controllerReady), true, bindAllocator, devModeEndpointUpdates, []rpc.Service{engine})
 			if err != nil {
 				return errors.Wrap(err, "failed to stop server")
 			}
@@ -125,7 +121,7 @@ func (d *devCmd) Run(
 		}
 
 		g.Go(func() error {
-			err := d.ServeCmd.run(ctx, projConfig, cm, sm, optional.Some(controllerReady), true, bindAllocator, timelineClient, adminClient, buildEngineClient, devModeEndpointUpdates, []rpc.Service{engine}, cli)
+			err := d.ServeCmd.run(ctx, projConfig, cm, sm, optional.Some(controllerReady), true, bindAllocator, devModeEndpointUpdates, []rpc.Service{engine})
 			if err != nil {
 				cancel(errors.Wrap(errors.Join(err, context.Canceled), "dev server failed"))
 			} else {

--- a/cmd/ftl/cmd_serve.go
+++ b/cmd/ftl/cmd_serve.go
@@ -57,7 +57,6 @@ type serveCmd struct {
 
 type serveCommonConfig struct {
 	IngressBind         *url.URL             `help:"HTTP Ingress bind" default:"http://127.0.0.1:8891"`
-	Bind                *url.URL             `help:"Starting endpoint to bind to and advertise to for all FTL services" default:"http://127.0.0.1:8892"`
 	DBPort              int                  `help:"Port to use for the database." env:"FTL_DB_PORT" default:"15432"`
 	MysqlPort           int                  `help:"Port to use for the MySQL database, if one is required." env:"FTL_MYSQL_PORT" default:"13306"`
 	RegistryPort        int                  `help:"Port to use for the registry." env:"FTL_OCI_REGISTRY_PORT" default:"15000"`
@@ -90,12 +89,13 @@ func (s *serveCmd) Run(
 	timelineClient *timelineclient.Client,
 	adminClient adminpbconnect.AdminServiceClient,
 	buildEngineClient buildenginepbconnect.BuildEngineServiceClient,
+	cli *SharedCLI,
 ) error {
-	bindAllocator, err := bind.NewBindAllocator(s.Bind, 2)
+	bindAllocator, err := bind.NewBindAllocator(cli.AdminEndpoint, 2)
 	if err != nil {
 		return errors.Wrap(err, "could not create bind allocator")
 	}
-	return s.run(ctx, projConfig, cm, sm, optional.None[chan bool](), false, bindAllocator, timelineClient, adminClient, buildEngineClient, nil, nil)
+	return s.run(ctx, projConfig, cm, sm, optional.None[chan bool](), false, bindAllocator, timelineClient, adminClient, buildEngineClient, nil, nil, cli)
 }
 
 //nolint:maintidx
@@ -112,14 +112,15 @@ func (s *serveCommonConfig) run(
 	buildEngineClient buildenginepbconnect.BuildEngineServiceClient,
 	devModeEndpoints <-chan dev.LocalEndpoint,
 	additionalServices []rpc.Service,
+	cli *SharedCLI,
 ) error {
 
 	logger := log.FromContext(ctx)
 	services := additionalServices
 
-	controllerClient := rpc.Dial(ftlv1connect.NewControllerServiceClient, s.Bind.String(), log.Error)
-	schemaClient := rpc.Dial(ftlv1connect.NewSchemaServiceClient, s.Bind.String(), log.Error)
-	leaseClient := rpc.Dial(leasepbconnect.NewLeaseServiceClient, s.Bind.String(), log.Error)
+	controllerClient := rpc.Dial(ftlv1connect.NewControllerServiceClient, cli.AdminEndpoint.String(), log.Error)
+	schemaClient := rpc.Dial(ftlv1connect.NewSchemaServiceClient, cli.AdminEndpoint.String(), log.Error)
+	leaseClient := rpc.Dial(leasepbconnect.NewLeaseServiceClient, cli.AdminEndpoint.String(), log.Error)
 
 	// We must use our own event source here
 	// The injected one is connected to the admin client for CLI commands, we need this one to connect directly
@@ -196,9 +197,9 @@ func (s *serveCommonConfig) run(
 
 	runnerScaling, err := localscaling.NewLocalScaling(
 		ctx,
-		s.Bind,
-		s.Bind,
-		s.Bind,
+		cli.AdminEndpoint,
+		cli.AdminEndpoint,
+		cli.AdminEndpoint,
 		projConfig.Path,
 		!projConfig.DisableIDEIntegration && !projConfig.DisableVSCodeIntegration,
 		!projConfig.DisableIDEIntegration && !projConfig.DisableIntellijIntegration,
@@ -228,14 +229,14 @@ func (s *serveCommonConfig) run(
 
 	controllerCtx := log.ContextWithLogger(ctx, logger.Scope("controller"))
 
-	controllerService, err := controller.New(controllerCtx, s.Bind, adminClient, schemaClient, leaseClient, config, true)
+	controllerService, err := controller.New(controllerCtx, cli.AdminEndpoint, adminClient, schemaClient, leaseClient, config, true)
 	if err != nil {
 		return errors.Wrap(err, "controller failed")
 	}
 	services = append(services, controllerService)
 
 	if !s.NoConsole {
-		svc := console.New(schemaEventSource, timelineClient, adminClient, router, buildEngineClient, s.Bind, s.Console, optional.Some(projConfig), true)
+		svc := console.New(schemaEventSource, timelineClient, adminClient, router, buildEngineClient, cli.AdminEndpoint, s.Console, optional.Some(projConfig), true)
 		services = append(services, svc)
 		wg.Go(func() error {
 			ctx := log.ContextWithLogger(ctx, log.FromContext(ctx).Scope("console"))
@@ -314,8 +315,8 @@ func (s *serveCommonConfig) run(
 	wg.Go(func() error {
 		ctx := log.ContextWithLogger(ctx, log.FromContext(ctx).Scope("cron"))
 		c := cron.Config{
-			SchemaServiceEndpoint: s.Bind,
-			TimelineEndpoint:      s.Bind,
+			SchemaServiceEndpoint: cli.AdminEndpoint,
+			TimelineEndpoint:      cli.AdminEndpoint,
 		}
 		err := cron.Start(ctx, c, schemaEventSource, router, timelineClient)
 		if err != nil {
@@ -339,7 +340,7 @@ func (s *serveCommonConfig) run(
 
 	// Start the common server
 	wg.Go(func() error {
-		err := rpc.Serve(ctx, s.Bind, rpc.WithServices(services...))
+		err := rpc.Serve(ctx, cli.AdminEndpoint, rpc.WithServices(services...))
 		if err != nil {
 			return errors.Wrap(err, "lease failed")
 		}

--- a/cmd/ftl/cmd_serve.go
+++ b/cmd/ftl/cmd_serve.go
@@ -108,6 +108,7 @@ func (s *serveCommonConfig) run(
 	additionalServices []rpc.Service,
 ) error {
 	cli.AdminEndpoint = s.Bind
+	os.Unsetenv("FTL_ENDPOINT") //nolint:errcheck
 
 	logger := log.FromContext(ctx)
 	services := additionalServices

--- a/internal/schema/schemaeventsource/schemaeventsource.go
+++ b/internal/schema/schemaeventsource/schemaeventsource.go
@@ -28,7 +28,11 @@ type PullSchemaClient interface {
 }
 
 // View is a read-only view of the schema.
-type View struct {
+type View interface {
+	GetCanonical() *schema.Schema
+}
+
+type viewImpl struct {
 	eventSource *EventSource
 }
 
@@ -38,7 +42,9 @@ type currentState struct {
 }
 
 // GetCanonical returns the current canonical schema (ie: without any changes applied from active changesets)
-func (v *View) GetCanonical() *schema.Schema { return v.eventSource.view.Load().schema.WithBuiltins() }
+func (v *viewImpl) GetCanonical() *schema.Schema {
+	return v.eventSource.view.Load().schema.WithBuiltins()
+}
 
 // NewUnattached creates a new EventSource that is not attached to a SchemaService.
 func NewUnattached() *EventSource {
@@ -87,8 +93,8 @@ func (e *EventSource) Subscribe(ctx context.Context) <-chan schema.Notification 
 }
 
 // ViewOnly converts the EventSource into a read-only view of the schema.
-func (e *EventSource) ViewOnly() *View {
-	return &View{eventSource: e}
+func (e *EventSource) ViewOnly() View {
+	return &viewImpl{eventSource: e}
 
 }
 

--- a/internal/terminal/interactive.go
+++ b/internal/terminal/interactive.go
@@ -181,7 +181,7 @@ func errorf(format string, args ...any) {
 
 type FTLCompletion struct {
 	app  *kong.Kong
-	view *schemaeventsource.View
+	view schemaeventsource.View
 }
 
 func (f *FTLCompletion) Do(line []rune, pos int) ([][]rune, int) {
@@ -235,7 +235,7 @@ func (f *FTLCompletion) Do(line []rune, pos int) ([][]rune, int) {
 		LastCompleted: lastCompleted,
 	}
 
-	command, err := kongcompletion.Command(parser, kongcompletion.WithPredictors(Predictors(f.view)))
+	command, err := kongcompletion.Command(parser, kongcompletion.WithPredictors(Predictors(func() schemaeventsource.View { return f.view })))
 	if err != nil {
 		// TODO handle error
 		println(err.Error())


### PR DESCRIPTION
Previously if this was set to something other than localhost you could end up in a situation where some dev mode services connect to another server.