### PR TITLE
feat: update `ftl schema diff` to support diffing to/from endpoint or file

### DIFF
--- a/cmd/ftl/integration_test.go
+++ b/cmd/ftl/integration_test.go
@@ -134,15 +134,13 @@ func NewFunction(ctx context.Context, req TimeRequest) (TimeResponse, error) {
 	in.Run(t,
 		in.CopyModule("time"),
 		in.Deploy("time"),
-		in.ExecWithOutput("ftl", []string{"schema", "diff"}, func(output string) {
-			assert.Equal(t, "", output)
-		}),
+		in.Exec("ftl", "schema", "save"),
 		in.EditFile("time", func(bytes []byte) []byte {
 			s := string(bytes)
 			s += newVerb
 			return []byte(s)
 		}, "time.go"),
-		in.Build("time"),
+		in.Deploy("time"),
 		// We exit with code 1 when there is a difference
 		in.ExpectError(
 			in.ExecWithOutput("ftl", []string{"schema", "diff"}, func(output string) {

--- a/cmd/ftl/main.go
+++ b/cmd/ftl/main.go
@@ -25,12 +25,12 @@ func main() {
 	}()
 	app, err := New(ctx)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "ftl: error: %s", err)
+		fmt.Fprintf(os.Stderr, "ftl: error: %s\n", err)
 		os.Exit(1)
 	}
 	err = app.Run(ctx, os.Args[1:])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "ftl: error: %s", err)
+		fmt.Fprintf(os.Stderr, "ftl: error: %s\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Previously could only diff against the running cluster.