### PR TITLE
fix: build engine collects schemas when not deploying

### DIFF
--- a/internal/buildengine/deploy.go
+++ b/internal/buildengine/deploy.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	stdslices "slices"
 	"strings"
+	"time"
 
 	"connectrpc.com/connect"
 	errors "github.com/alecthomas/errors"
@@ -650,6 +651,17 @@ func (c *DeployCoordinator) terminateModuleDeployment(ctx context.Context, modul
 }
 
 func prepareForDeploy(ctx context.Context, modules map[string]*pendingModule, adminClient AdminClient) (err error) {
+	for _, module := range modules {
+		if module.schema.Runtime == nil {
+			module.schema.Runtime = &schema.ModuleRuntime{
+				Base: schema.ModuleRuntimeBase{
+					CreateTime: time.Now(),
+				},
+			}
+		}
+		module.schema.Runtime.Base.Language = module.module.Config.Language
+	}
+
 	uploadGroup := errgroup.Group{}
 	for _, module := range modules {
 		uploadGroup.Go(func() error {

--- a/internal/buildengine/engine_test.go
+++ b/internal/buildengine/engine_test.go
@@ -69,4 +69,12 @@ func TestGraph(t *testing.T) {
 	assert.Equal(t, expected, graph)
 	err = engine.Build(ctx)
 	assert.NoError(t, err)
+	for _, module := range []string{
+		"alpha",
+		"other",
+		"another",
+	} {
+		_, success := engine.GetModuleSchema(module)
+		assert.True(t, success, "expected schema for %s to be found", module)
+	}
 }


### PR DESCRIPTION
closes #5433

- Build engine collects module schemas when `Build()` is called.
- Build engine hands deploy coordinator each module schema, rather than a path to the schema