### PR TITLE
fix: add some defense against graph calculation errors

### DIFF
--- a/frontend/console/src/features/graph/GraphPane.tsx
+++ b/frontend/console/src/features/graph/GraphPane.tsx
@@ -237,9 +237,14 @@ const getLayoutedElements = (nodes: Node[], edges: Edge[], direction = 'LR') => 
 
       // Make child positions relative to the group
       for (const child of group.childNodes) {
+        const childX = typeof child.position.x === 'number' && !Number.isNaN(child.position.x) ? child.position.x : 0
+        const childY = typeof child.position.y === 'number' && !Number.isNaN(child.position.y) ? child.position.y : 0
+        const groupX = typeof group.x === 'number' && !Number.isNaN(group.x) ? group.x : 0
+        const groupY = typeof group.y === 'number' && !Number.isNaN(group.y) ? group.y : 0
+
         child.position = {
-          x: child.position.x - group.x,
-          y: child.position.y - group.y,
+          x: childX - groupX,
+          y: childY - groupY,
         }
       }
     }


### PR DESCRIPTION
Attempt to fix these:
![Screenshot 2025-05-14 at 3 42 59 pm](https://github.com/user-attachments/assets/bd1b1b04-7189-418a-9fa7-c9f652509649)
![Screenshot 2025-05-14 at 3 43 29 pm](https://github.com/user-attachments/assets/90d019ed-e7e0-47ad-9597-656c5da4725d)
