### PR TITLE
chore(ci): speed up Go and Maven dependency cache writes

### DIFF
--- a/.github/workflows/writecache.yml
+++ b/.github/workflows/writecache.yml
@@ -109,37 +109,70 @@ jobs:
           path: ~/.cache/ms-playwright
           key: ${{ steps.playwright-hash.outputs.key }}
 
-  write-go-maven-cache:
-    name: Write Go+Maven Cache
+  write-go-cache:
+    name: Write Go Cache
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
       - name: Init Hermit
         uses: cashapp/activate-hermit@12a728b03ad41eace0f9abaf98a035e7e8ea2318 # ratchet:cashapp/activate-hermit@v1.1.4
-      - name: Install Hermit Packages
-        run: hermit install
-      - name: Rebuild All
-        run: just build-all
+      - name: Hash Go
+        id: go-hash
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          hash="${{ hashFiles('go.sum') }}"
+          echo "hash=$hash" >> "$GITHUB_OUTPUT"
+          key="${{ runner.os }}-${{ runner.arch }}-go-${hash}"
+          echo "key=$key" >> "$GITHUB_OUTPUT"
+          exists="$(gh api -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" "/repos/block/ftl/actions/caches?key=$key" | jq '.actions_caches | length')"
+          echo "exists=$exists" >> "$GITHUB_OUTPUT"
       - name: Download Go Dependencies
+        if: ${{ steps.go-hash.outputs.exists == 0 }}
         run: go mod download -x
       - id: find-go-build-cache
+        if: ${{ steps.go-hash.outputs.exists == 0 }}
         shell: bash
         run: echo "cache=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
       - name: Save Go Module Cache
+        if: ${{ steps.go-hash.outputs.exists == 0 }}
         uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # ratchet:actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: |
             ~/go/pkg/mod
             ${{ steps.find-go-build-cache.outputs.cache }}
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          key: ${{ steps.go-hash.outputs.hash }}
+
+  write-maven-cache:
+    name: Write Maven Cache
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
+      - name: Init Hermit
+        uses: cashapp/activate-hermit@12a728b03ad41eace0f9abaf98a035e7e8ea2318 # ratchet:cashapp/activate-hermit@v1.1.4
+      - name: Hash Maven
+        id: maven-hash
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          hash="${{ hashFiles('jvm-runtime/**/pom.xml') }}"
+          echo "hash=$hash" >> "$GITHUB_OUTPUT"
+          key="${{ runner.os }}-${{ runner.arch }}-maven-${hash}"
+          echo "key=$key" >> "$GITHUB_OUTPUT"
+          exists="$(gh api -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" "/repos/block/ftl/actions/caches?key=$key" | jq '.actions_caches | length')"
+          echo "exists=$exists" >> "$GITHUB_OUTPUT"
+      - name: Download Maven Dependencies
+        run: mvn -f jvm-runtime/ftl-runtime dependency:go-offline
       - name: Delete Maven Snapshots
-        id: maven-delete-snapshots
+        # Do we need to do this when we're just downloading deps? Not sure.
         run: |
           find ~/.m2/repository -type d -name "*SNAPSHOT" -exec rm -rf {} +
       - name: Save Maven Modules Cache
-        id: cache-maven
         uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # ratchet:actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ steps.maven-hash.outputs.key }}

--- a/Justfile
+++ b/Justfile
@@ -168,6 +168,7 @@ build-backend:
 build-backend-tests:
   go test -run ^NONE -tags integration,infrastructure ./... > /dev/null
 
+# Build JVM runtime
 build-jvm *args:
   @mk {{JVM_RUNTIME_OUT}} : {{JVM_RUNTIME_IN}} -- mvn -f jvm-runtime/ftl-runtime clean install {{args}}
 


### PR DESCRIPTION
Previously we were doing a `rebuild-all` in order to populate the Go module cache and the Maven m2 cache. Instead, we now just download the dependencies directly without building.