### PR TITLE
fix: prevent CMD+S from breaking app

### DIFF
--- a/frontend/console/src/shared/providers/app-providers.tsx
+++ b/frontend/console/src/shared/providers/app-providers.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { Notification } from '../layout/Notification'
 import { InfoProvider } from './info-provider'
 import { NotificationsProvider } from './notifications-provider'
@@ -6,6 +7,17 @@ import { RoutingProvider } from './routing-provider'
 import { UserPreferencesProvider } from './user-preferences-provider'
 
 export const AppProvider = () => {
+  // Prevent Ctrl+S from saving the page
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 's') {
+        e.preventDefault()
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [])
+
   return (
     <ReactQueryProvider>
       <InfoProvider>


### PR DESCRIPTION
Prevent default action for CMD+S in console web app