### PR TITLE
fix: calls to sql verbs to go straight to query service

### DIFF
--- a/backend/runner/runner.go
+++ b/backend/runner/runner.go
@@ -166,7 +166,7 @@ func Start(ctx context.Context, config Config, storage *artefacts.OCIArtefactSer
 		case <-ctx.Done():
 			return errors.WithStack(ctx.Err())
 		default:
-			svc.queryService, err = query.New(ctx, module, dbAddresses)
+			svc.queryService, err = query.New(ctx, svc.timelineClient, module, dbAddresses)
 			if err != nil {
 				return errors.Wrap(err, "failed to create query service")
 			}


### PR DESCRIPTION
Fixes issue where JVM runtimes do not post timeline event for sql queries.

- [ ] Make go runtime calls query service directly when calling into a sql verb
- [x] Begin making timeline calls from query service
- [ ] Add all the required info into the query request, including headers