### PR TITLE
feat: use abstract sockets for the runner

### DIFF
--- a/backend/controller/sql/database_kube_test.go
+++ b/backend/controller/sql/database_kube_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestSQLVerbsInKube(t *testing.T) {
 	in.Run(t,
-		in.WithKubernetes("--set", "ftl.provisioner.modulePerNamespace=true"),
+		in.WithKubernetes("--set", "ftl.provisioner.modulePerNamespace=true", "--set", "ftl.provisioner.userNamespace=null"),
 		in.WithLanguages("kotlin"),
 		in.CopyModule("mysql"),
 		in.Deploy("mysql"),

--- a/backend/provisioner/scaling/kube_scaling_integration_test.go
+++ b/backend/provisioner/scaling/kube_scaling_integration_test.go
@@ -24,7 +24,7 @@ func TestKubeScalingUserNamespace(t *testing.T) {
 func TestKubeScalingDeploymentPerNamespace(t *testing.T) {
 	runTest(t, func(dep string) string {
 		return dep + "-ftl"
-	}, "--set", "ftl.provisioner.modulePerNamespace=true")
+	}, "--set", "ftl.provisioner.modulePerNamespace=true", "--set", "ftl.provisioner.userNamespace=null")
 }
 
 func runTest(t *testing.T, namespace func(dep string) string, helmArgs ...string) {

--- a/charts/ftl-k3d/values.yaml
+++ b/charts/ftl-k3d/values.yaml
@@ -1,5 +1,7 @@
 
 ftl:
+  istio:
+    enabled: true
   ingress:
     enabled: true
     urlPrefix: "/ingress/"

--- a/charts/ftl/templates/runner.yaml
+++ b/charts/ftl/templates/runner.yaml
@@ -64,12 +64,19 @@ data:
                 {{- if .Values.runner.env }}
                 {{- toYaml .Values.runner.env | nindent 16 }}
                 {{- end }}
+                {{- if and .Values.istio.enabled .Values.provisioner.userNamespace }}
+                - name: FTL_BIND
+                  value: "unix://@istio-proxy.sock"
+                - name: FTL_HEALTH_BIND
+                  value: "http://0.0.0.0:{{ .Values.runner.port }}"
+                {{- else }}
+                - name: FTL_BIND
+                  value: "http://0.0.0.0:{{ .Values.runner.port }}"
+                {{- end }}
                 - name: FTL_CONTROLLER_ENDPOINT
                   value: "http://{{ include "ftl.fullname" . }}-controller.{{ .Release.Namespace }}:{{ .Values.controller.port }}"
                 - name: FTL_ARTEFACT_REGISTRY
                   value: "{{ .Values.registry.repository }}"
-                - name: FTL_BIND
-                  value: "http://0.0.0.0:{{ .Values.runner.port }}"
                 - name: FTL_SCHEMA_ENDPOINT
                   value: http://{{ include "ftl.fullname" . }}-schema.{{ .Release.Namespace }}:{{ .Values.schema.services.schema.port }}
                 - name: FTL_LEASE_ENDPOINT

--- a/charts/ftl/templates/sidecar.yaml
+++ b/charts/ftl/templates/sidecar.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.istio.enabled .Values.provisioner.userNamespace }}
+apiVersion: networking.istio.io/v1
+kind: Sidecar
+metadata:
+  name: {{ include "ftl.fullname" . }}-sidecar-config
+  namespace: {{ .Values.provisioner.userNamespace }}
+  labels:
+    {{- include "ftl.labels" . | nindent 4 }}
+spec:
+  ingress:
+    - port:
+        number: 8892
+        protocol: http2
+        name: http2
+      defaultEndpoint: unix://@istio-proxy.sock
+      captureMode: IPTABLES
+{{- end }}


### PR DESCRIPTION
When running in a single namespace use abstract sockets for the runner.

We can't provision per-namespace sidecar config yet, so this is only for single namespace.