### PR TITLE
feat: schema mirror chart updates

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -83,7 +83,8 @@ DOCKER_IMAGES := '''
   "timeline": {},
   "lease": {},
   "admin": {},
-  "schema": {}
+  "schema": {},
+  "schema-mirror": {}
 }
 '''
 USER_HERMIT_PACKAGES := "openjdk maven go-1"
@@ -158,7 +159,7 @@ build-without-frontend +tools: build-protos build-zips capture-hermit-versions
 
 # Build all backend binaries
 build-backend:
-  just build ftl ftl-runner ftl-sqlc ftl-admin ftl-cron ftl-http-ingress ftl-lease ftl-provisioner ftl-schema ftl-timeline
+  just build ftl ftl-runner ftl-sqlc ftl-admin ftl-cron ftl-http-ingress ftl-lease ftl-provisioner ftl-schema ftl-schema-mirror ftl-timeline
 
 # Build all backend tests
 build-backend-tests:

--- a/backend/schemaservice/schemaservice.go
+++ b/backend/schemaservice/schemaservice.go
@@ -111,10 +111,11 @@ func New(
 			receiverClient: receiverClient,
 			rpcOpts:        rpcOpts,
 		}
-		svc.rpcOpts = append(svc.rpcOpts, rpc.GRPC(ftlv1connect.NewSchemaServiceHandler, svc))
+		svc.rpcOpts = append(svc.rpcOpts, rpc.GRPC(ftlv1connect.NewSchemaServiceHandler, svc), rpc.StartHook(func(ctx context.Context) error {
+			go svc.pushSchema(ctx)
+			return nil
+		}))
 	}
-
-	go svc.pushSchema(ctx)
 
 	svc.devMode = devMode
 

--- a/charts/ftl/templates/_helpers.tpl
+++ b/charts/ftl/templates/_helpers.tpl
@@ -82,6 +82,11 @@ app.kubernetes.io/name: {{ include "ftl.fullname" . }}
 app.kubernetes.io/component: schema
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
+{{- define "ftl-schema-mirror.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ftl.fullname" . }}
+app.kubernetes.io/component: schema-mirror
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
 {{/*
 Common pod configuration, boilerplate that is not generally used
 */}}

--- a/charts/ftl/templates/cron-deployment.yaml
+++ b/charts/ftl/templates/cron-deployment.yaml
@@ -60,12 +60,11 @@ spec:
             - name: FTL_TIMELINE_ENDPOINT
               value: "http://{{ include "ftl.fullname" . }}-timeline:{{ .Values.timeline.port }}"
             - name: FTL_SCHEMA_ENDPOINT
-              value: >
-                {{ if $.Values.schemaMirror.service.enabled }}
+              value: {{ if $.Values.schemaMirror.service.enabled -}}
                 http://{{ include "ftl.fullname" . }}-schema-mirror:{{ $.Values.schemaMirror.service.port }}
-                {{ else }}
+                {{- else -}}
                 http://{{ include "ftl.fullname" . }}-schema:{{ $.Values.schema.services.schema.port }}
-                {{ end }}
+                {{- end }}
             - name: LOG_LEVEL
               value: "{{ .Values.cron.logLevel | default .Values.logLevel }}"
             - name: LOG_JSON

--- a/charts/ftl/templates/cron-deployment.yaml
+++ b/charts/ftl/templates/cron-deployment.yaml
@@ -61,9 +61,9 @@ spec:
               value: "http://{{ include "ftl.fullname" . }}-timeline:{{ .Values.timeline.port }}"
             - name: FTL_SCHEMA_ENDPOINT
               value: {{ if $.Values.schemaMirror.service.enabled -}}
-                http://{{ include "ftl.fullname" . }}-schema-mirror:{{ $.Values.schemaMirror.service.port }}
+                http://{{ include "ftl.fullname" . }}-schema-mirror.{{ .Release.Namespace }}:{{ $.Values.schemaMirror.service.port }}
                 {{- else -}}
-                http://{{ include "ftl.fullname" . }}-schema:{{ $.Values.schema.services.schema.port }}
+                http://{{ include "ftl.fullname" . }}-schema.{{ .Release.Namespace }}:{{ $.Values.schema.services.schema.port }}
                 {{- end }}
             - name: LOG_LEVEL
               value: "{{ .Values.cron.logLevel | default .Values.logLevel }}"

--- a/charts/ftl/templates/cron-deployment.yaml
+++ b/charts/ftl/templates/cron-deployment.yaml
@@ -60,11 +60,12 @@ spec:
             - name: FTL_TIMELINE_ENDPOINT
               value: "http://{{ include "ftl.fullname" . }}-timeline:{{ .Values.timeline.port }}"
             - name: FTL_SCHEMA_ENDPOINT
-              value: {{- if $.Values.schema.services.schema-mirror.enabled -}}
-                "http://{{ include "ftl.fullname" . }}-schema-mirror:{{ $.Values.schema.services.schema-mirror.port }}"
-              {{- else -}}
-                "http://{{ include "ftl.fullname" . }}-schema:{{ $.Values.schema.services.schema.port }}"
-              {{- end }}
+              value: >
+                {{ if $.Values.schemaMirror.service.enabled }}
+                http://{{ include "ftl.fullname" . }}-schema-mirror:{{ $.Values.schemaMirror.service.port }}
+                {{ else }}
+                http://{{ include "ftl.fullname" . }}-schema:{{ $.Values.schema.services.schema.port }}
+                {{ end }}
             - name: LOG_LEVEL
               value: "{{ .Values.cron.logLevel | default .Values.logLevel }}"
             - name: LOG_JSON

--- a/charts/ftl/templates/cron-deployment.yaml
+++ b/charts/ftl/templates/cron-deployment.yaml
@@ -60,7 +60,11 @@ spec:
             - name: FTL_TIMELINE_ENDPOINT
               value: "http://{{ include "ftl.fullname" . }}-timeline:{{ .Values.timeline.port }}"
             - name: FTL_SCHEMA_ENDPOINT
-              value: "http://{{ include "ftl.fullname" . }}-schema:{{ $.Values.schema.services.schema.port }}"
+              value: {{- if $.Values.schema.services.schema-mirror.enabled -}}
+                "http://{{ include "ftl.fullname" . }}-schema-mirror:{{ $.Values.schema.services.schema-mirror.port }}"
+              {{- else -}}
+                "http://{{ include "ftl.fullname" . }}-schema:{{ $.Values.schema.services.schema.port }}"
+              {{- end }}
             - name: LOG_LEVEL
               value: "{{ .Values.cron.logLevel | default .Values.logLevel }}"
             - name: LOG_JSON

--- a/charts/ftl/templates/http-ingress-deployment.yaml
+++ b/charts/ftl/templates/http-ingress-deployment.yaml
@@ -49,12 +49,11 @@ spec:
             - name: FTL_TIMELINE_ENDPOINT
               value: "http://{{ include "ftl.fullname" . }}-timeline:{{ .Values.timeline.port }}"
             - name: FTL_SCHEMA_ENDPOINT
-              value: >
-                {{ if $.Values.schemaMirror.service.enabled }}
+              value: {{ if $.Values.schemaMirror.service.enabled -}}
                 http://{{ include "ftl.fullname" . }}-schema-mirror:{{ $.Values.schemaMirror.service.port }}
-                {{ else }}
+                {{- else -}}
                 http://{{ include "ftl.fullname" . }}-schema:{{ $.Values.schema.services.schema.port }}
-                {{ end }}
+                {{- end }}
             - name: LOG_LEVEL
               value: "{{ .Values.ingress.logLevel | default .Values.logLevel }}"
             - name: LOG_JSON

--- a/charts/ftl/templates/http-ingress-deployment.yaml
+++ b/charts/ftl/templates/http-ingress-deployment.yaml
@@ -49,7 +49,11 @@ spec:
             - name: FTL_TIMELINE_ENDPOINT
               value: "http://{{ include "ftl.fullname" . }}-timeline:{{ .Values.timeline.port }}"
             - name: FTL_SCHEMA_ENDPOINT
-              value: "http://{{ include "ftl.fullname" . }}-schema:{{ $.Values.schema.services.schema.port }}"
+              value: {{- if $.Values.schema.services.schema-mirror.enabled -}}
+                "http://{{ include "ftl.fullname" . }}-schema-mirror:{{ $.Values.schema.services.schema-mirror.port }}"
+              {{- else -}}
+                "http://{{ include "ftl.fullname" . }}-schema:{{ $.Values.schema.services.schema.port }}"
+              {{- end }}
             - name: LOG_LEVEL
               value: "{{ .Values.ingress.logLevel | default .Values.logLevel }}"
             - name: LOG_JSON

--- a/charts/ftl/templates/http-ingress-deployment.yaml
+++ b/charts/ftl/templates/http-ingress-deployment.yaml
@@ -49,11 +49,12 @@ spec:
             - name: FTL_TIMELINE_ENDPOINT
               value: "http://{{ include "ftl.fullname" . }}-timeline:{{ .Values.timeline.port }}"
             - name: FTL_SCHEMA_ENDPOINT
-              value: {{- if $.Values.schema.services.schema-mirror.enabled -}}
-                "http://{{ include "ftl.fullname" . }}-schema-mirror:{{ $.Values.schema.services.schema-mirror.port }}"
-              {{- else -}}
-                "http://{{ include "ftl.fullname" . }}-schema:{{ $.Values.schema.services.schema.port }}"
-              {{- end }}
+              value: >
+                {{ if $.Values.schemaMirror.service.enabled }}
+                http://{{ include "ftl.fullname" . }}-schema-mirror:{{ $.Values.schemaMirror.service.port }}
+                {{ else }}
+                http://{{ include "ftl.fullname" . }}-schema:{{ $.Values.schema.services.schema.port }}
+                {{ end }}
             - name: LOG_LEVEL
               value: "{{ .Values.ingress.logLevel | default .Values.logLevel }}"
             - name: LOG_JSON

--- a/charts/ftl/templates/http-ingress-deployment.yaml
+++ b/charts/ftl/templates/http-ingress-deployment.yaml
@@ -50,9 +50,9 @@ spec:
               value: "http://{{ include "ftl.fullname" . }}-timeline:{{ .Values.timeline.port }}"
             - name: FTL_SCHEMA_ENDPOINT
               value: {{ if $.Values.schemaMirror.service.enabled -}}
-                http://{{ include "ftl.fullname" . }}-schema-mirror:{{ $.Values.schemaMirror.service.port }}
+                http://{{ include "ftl.fullname" . }}-schema-mirror.{{ .Release.Namespace }}:{{ $.Values.schemaMirror.service.port }}
                 {{- else -}}
-                http://{{ include "ftl.fullname" . }}-schema:{{ $.Values.schema.services.schema.port }}
+                http://{{ include "ftl.fullname" . }}-schema.{{ .Release.Namespace }}:{{ $.Values.schema.services.schema.port }}
                 {{- end }}
             - name: LOG_LEVEL
               value: "{{ .Values.ingress.logLevel | default .Values.logLevel }}"

--- a/charts/ftl/templates/runner.yaml
+++ b/charts/ftl/templates/runner.yaml
@@ -79,9 +79,9 @@ data:
                   value: "{{ .Values.registry.repository }}"
                 - name: FTL_SCHEMA_ENDPOINT
                   value: {{ if $.Values.schemaMirror.service.enabled -}}
-                    http://{{ include "ftl.fullname" . }}-schema-mirror:{{ $.Values.schemaMirror.service.port }}
+                    http://{{ include "ftl.fullname" . }}-schema-mirror.{{ .Release.Namespace }}:{{ $.Values.schemaMirror.service.port }}
                     {{- else -}}
-                    http://{{ include "ftl.fullname" . }}-schema:{{ $.Values.schema.services.schema.port }}
+                    http://{{ include "ftl.fullname" . }}-schema.{{ .Release.Namespace }}:{{ $.Values.schema.services.schema.port }}
                     {{- end }}
                 - name: FTL_LEASE_ENDPOINT
                   value: http://{{ include "ftl.fullname" . }}-lease.{{ .Release.Namespace }}:{{ .Values.lease.port }}

--- a/charts/ftl/templates/runner.yaml
+++ b/charts/ftl/templates/runner.yaml
@@ -78,7 +78,11 @@ data:
                 - name: FTL_ARTEFACT_REGISTRY
                   value: "{{ .Values.registry.repository }}"
                 - name: FTL_SCHEMA_ENDPOINT
-                  value: http://{{ include "ftl.fullname" . }}-schema.{{ .Release.Namespace }}:{{ .Values.schema.services.schema.port }}
+                  value: {{- if $.Values.schema.services.schema-mirror.enabled -}}
+                    "http://{{ include "ftl.fullname" . }}-schema-mirror:{{ $.Values.schema.services.schema-mirror.port }}"
+                  {{- else -}}
+                    "http://{{ include "ftl.fullname" . }}-schema:{{ $.Values.schema.services.schema.port }}"
+                  {{- end }}
                 - name: FTL_LEASE_ENDPOINT
                   value: http://{{ include "ftl.fullname" . }}-lease.{{ .Release.Namespace }}:{{ .Values.lease.port }}
                 - name: FTL_TIMELINE_ENDPOINT

--- a/charts/ftl/templates/runner.yaml
+++ b/charts/ftl/templates/runner.yaml
@@ -78,12 +78,11 @@ data:
                 - name: FTL_ARTEFACT_REGISTRY
                   value: "{{ .Values.registry.repository }}"
                 - name: FTL_SCHEMA_ENDPOINT
-                  value: >
-                    {{ if $.Values.schemaMirror.service.enabled }}
+                  value: {{ if $.Values.schemaMirror.service.enabled -}}
                     http://{{ include "ftl.fullname" . }}-schema-mirror:{{ $.Values.schemaMirror.service.port }}
-                    {{ else }}
+                    {{- else -}}
                     http://{{ include "ftl.fullname" . }}-schema:{{ $.Values.schema.services.schema.port }}
-                    {{ end }}
+                    {{- end }}
                 - name: FTL_LEASE_ENDPOINT
                   value: http://{{ include "ftl.fullname" . }}-lease.{{ .Release.Namespace }}:{{ .Values.lease.port }}
                 - name: FTL_TIMELINE_ENDPOINT

--- a/charts/ftl/templates/runner.yaml
+++ b/charts/ftl/templates/runner.yaml
@@ -78,11 +78,12 @@ data:
                 - name: FTL_ARTEFACT_REGISTRY
                   value: "{{ .Values.registry.repository }}"
                 - name: FTL_SCHEMA_ENDPOINT
-                  value: {{- if $.Values.schema.services.schema-mirror.enabled -}}
-                    "http://{{ include "ftl.fullname" . }}-schema-mirror:{{ $.Values.schema.services.schema-mirror.port }}"
-                  {{- else -}}
-                    "http://{{ include "ftl.fullname" . }}-schema:{{ $.Values.schema.services.schema.port }}"
-                  {{- end }}
+                  value: >
+                    {{ if $.Values.schemaMirror.service.enabled }}
+                    http://{{ include "ftl.fullname" . }}-schema-mirror:{{ $.Values.schemaMirror.service.port }}
+                    {{ else }}
+                    http://{{ include "ftl.fullname" . }}-schema:{{ $.Values.schema.services.schema.port }}
+                    {{ end }}
                 - name: FTL_LEASE_ENDPOINT
                   value: http://{{ include "ftl.fullname" . }}-lease.{{ .Release.Namespace }}:{{ .Values.lease.port }}
                 - name: FTL_TIMELINE_ENDPOINT

--- a/charts/ftl/templates/schema-deployment.yaml
+++ b/charts/ftl/templates/schema-deployment.yaml
@@ -80,9 +80,9 @@ spec:
               value: "http://{{ include "ftl.fullname" . }}-schema:{{ $.Values.schema.services.schema.port }}"
             - name: FTL_TIMELINE_ENDPOINT
               value: "http://{{ include "ftl.fullname" . }}-timeline:{{ .Values.timeline.port }}"
-            {{- if .Values.schema-mirror.enabled }}
+            {{- if .Values.schemaMirror.enabled }}
             - name: FTL_SCHEMA_MIRROR_ENDPOINT
-              value: "http://{{ include "ftl.fullname" . }}-schema-mirror:{{ .Values.schema-mirror.port }}"
+              value: "http://{{ include "ftl.fullname" . }}-schema-mirror:{{ .Values.schemaMirror.port }}"
             {{- end }}
             - name: FTL_REALM
               value: {{ .Values.realmName }}

--- a/charts/ftl/templates/schema-deployment.yaml
+++ b/charts/ftl/templates/schema-deployment.yaml
@@ -82,7 +82,7 @@ spec:
               value: "http://{{ include "ftl.fullname" . }}-timeline:{{ .Values.timeline.port }}"
             {{- if .Values.schemaMirror.enabled }}
             - name: FTL_SCHEMA_MIRROR_ENDPOINT
-              value: "http://{{ include "ftl.fullname" . }}-schema-mirror:{{ .Values.schemaMirror.port }}"
+              value: "http://{{ include "ftl.fullname" . }}-schema-mirror:{{ .Values.schemaMirror.service.port }}"
             {{- end }}
             - name: FTL_REALM
               value: {{ .Values.realmName }}

--- a/charts/ftl/templates/schema-deployment.yaml
+++ b/charts/ftl/templates/schema-deployment.yaml
@@ -80,6 +80,10 @@ spec:
               value: "http://{{ include "ftl.fullname" . }}-schema:{{ $.Values.schema.services.schema.port }}"
             - name: FTL_TIMELINE_ENDPOINT
               value: "http://{{ include "ftl.fullname" . }}-timeline:{{ .Values.timeline.port }}"
+            {{- if .Values.schema-mirror.enabled }}
+            - name: FTL_SCHEMA_MIRROR_ENDPOINT
+              value: "http://{{ include "ftl.fullname" . }}-schema-mirror:{{ .Values.schema-mirror.port }}"
+            {{- end }}
             - name: FTL_REALM
               value: {{ .Values.realmName }}
           ports:

--- a/charts/ftl/templates/schema-deployment.yaml
+++ b/charts/ftl/templates/schema-deployment.yaml
@@ -82,7 +82,7 @@ spec:
               value: "http://{{ include "ftl.fullname" . }}-timeline:{{ .Values.timeline.port }}"
             {{- if .Values.schemaMirror.enabled }}
             - name: FTL_SCHEMA_MIRROR_ENDPOINT
-              value: "http://{{ include "ftl.fullname" . }}-schema-mirror:{{ .Values.schemaMirror.service.port }}"
+              value: "http://{{ include "ftl.fullname" . }}-schema-mirror.{{ .Release.Namespace }}:{{ .Values.schemaMirror.service.port }}"
             {{- end }}
             - name: FTL_REALM
               value: {{ .Values.realmName }}

--- a/charts/ftl/templates/schema-mirror-deployment.yaml
+++ b/charts/ftl/templates/schema-mirror-deployment.yaml
@@ -1,0 +1,73 @@
+{{ $version := printf "v%s" .Chart.Version -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "ftl.fullname" . }}-schema-mirror
+  labels:
+    {{- include "ftl.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.schema-mirror.replicas }}
+  podManagementPolicy: Parallel
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  ordinals:
+    start: 1
+  revisionHistoryLimit: {{ .Values.schema-mirror.revisionHistoryLimit }}
+  serviceName: {{ .Values.schema-mirror.serviceName }}
+  selector:
+    matchLabels:
+      {{- include "ftl-schema-mirror.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "ftl-schema-mirror.selectorLabels" . | nindent 8 }}
+      annotations:
+      {{- if .Values.schema-mirror.podAnnotations }}
+        {{- toYaml .Values.schema-mirror.podAnnotations | nindent 8 }}
+      {{- end }}
+      {{ if .Values.istio.holdApplicationUntilProxyStarts }}
+        proxy.istio.io/config: |
+          holdApplicationUntilProxyStarts: true
+      {{- end }}
+    spec:
+      serviceAccountName: {{ .Values.schema-mirror.serviceAccountName }}
+      securityContext:
+        fsGroup: 1000
+      containers:
+        - name: app
+          image: "{{ .Values.schema-mirror.image.repository | default (printf "%s/%s" .Values.image.base .Values.schema-mirror.image.name) }}:{{ .Values.schema-mirror.image.tag | default .Values.image.tag | default $version }}"
+          imagePullPolicy: {{ .Values.schema-mirror.image.pullPolicy | default .Values.image.pullPolicy }}
+          {{- if .Values.schema-mirror.envFrom }}
+          envFrom:
+            {{- if .Values.schema-mirror.envFrom }}
+            {{- toYaml .Values.schema-mirror.envFrom | nindent 12 }}
+            {{- end }}
+          {{- else if or .Values.secrets.logEncryptionKey .Values.secrets.asyncEncryptionKey }}
+          envFrom:
+            - secretRef:
+                name: {{ include "ftl.fullname" . }}-secrets
+          {{- end }}
+          env:
+            {{- if .Values.schema-mirror.env }}
+            {{- toYaml .Values.schema-mirror.env | nindent 12 }}
+            {{- end }}
+            - name: FTL_BIND
+              value: "http://0.0.0.0:{{ .Values.schema-mirror.services.schema-mirror.port }}"
+            - name: LOG_LEVEL
+              value: "{{ .Values.schema-mirror.logLevel | default .Values.logLevel }}"
+            - name: LOG_JSON
+              value: "{{ .Values.schema-mirror.logJson | default .Values.logJson }}"
+            - name: FTL_TIMELINE_ENDPOINT
+              value: "http://{{ include "ftl.fullname" . }}-timeline:{{ .Values.timeline.port }}"
+            - name: FTL_REALM
+              value: {{ .Values.realmName }}
+          ports:
+            - name: http2
+              containerPort: {{ .Values.schema-mirror.services.schema-mirror.port }}
+              protocol: "TCP"
+          {{- include "ftl.resources" .Values.schema-mirror | nindent 10 }}
+          {{- include "ftl.healthProbes" .Values.schema-mirror | nindent 10 }}
+          {{- include "ftl.securityContext" .Values.schema-mirror | nindent 10 }}
+      {{- include "ftl.commonPodConfig" .Values.schema-mirror | nindent 6 }}

--- a/charts/ftl/templates/schema-mirror-deployment.yaml
+++ b/charts/ftl/templates/schema-mirror-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "ftl.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.schema-mirror.replicas }}
+  replicas: {{ .Values.schemaMirror.replicas }}
   podManagementPolicy: Parallel
   strategy:
     type: RollingUpdate
@@ -14,8 +14,8 @@ spec:
       maxUnavailable: 1
   ordinals:
     start: 1
-  revisionHistoryLimit: {{ .Values.schema-mirror.revisionHistoryLimit }}
-  serviceName: {{ .Values.schema-mirror.serviceName }}
+  revisionHistoryLimit: {{ .Values.schemaMirror.revisionHistoryLimit }}
+  serviceName: {{ .Values.schemaMirror.serviceName }}
   selector:
     matchLabels:
       {{- include "ftl-schema-mirror.selectorLabels" . | nindent 6 }}
@@ -24,25 +24,25 @@ spec:
       labels:
         {{- include "ftl-schema-mirror.selectorLabels" . | nindent 8 }}
       annotations:
-      {{- if .Values.schema-mirror.podAnnotations }}
-        {{- toYaml .Values.schema-mirror.podAnnotations | nindent 8 }}
+      {{- if .Values.schemaMirror.podAnnotations }}
+        {{- toYaml .Values.schemaMirror.podAnnotations | nindent 8 }}
       {{- end }}
       {{ if .Values.istio.holdApplicationUntilProxyStarts }}
         proxy.istio.io/config: |
           holdApplicationUntilProxyStarts: true
       {{- end }}
     spec:
-      serviceAccountName: {{ .Values.schema-mirror.serviceAccountName }}
+      serviceAccountName: {{ .Values.schemaMirror.serviceAccountName }}
       securityContext:
         fsGroup: 1000
       containers:
         - name: app
-          image: "{{ .Values.schema-mirror.image.repository | default (printf "%s/%s" .Values.image.base .Values.schema-mirror.image.name) }}:{{ .Values.schema-mirror.image.tag | default .Values.image.tag | default $version }}"
-          imagePullPolicy: {{ .Values.schema-mirror.image.pullPolicy | default .Values.image.pullPolicy }}
-          {{- if .Values.schema-mirror.envFrom }}
+          image: "{{ .Values.schemaMirror.image.repository | default (printf "%s/%s" .Values.image.base .Values.schemaMirror.image.name) }}:{{ .Values.schemaMirror.image.tag | default .Values.image.tag | default $version }}"
+          imagePullPolicy: {{ .Values.schemaMirror.image.pullPolicy | default .Values.image.pullPolicy }}
+          {{- if .Values.schemaMirror.envFrom }}
           envFrom:
-            {{- if .Values.schema-mirror.envFrom }}
-            {{- toYaml .Values.schema-mirror.envFrom | nindent 12 }}
+            {{- if .Values.schemaMirror.envFrom }}
+            {{- toYaml .Values.schemaMirror.envFrom | nindent 12 }}
             {{- end }}
           {{- else if or .Values.secrets.logEncryptionKey .Values.secrets.asyncEncryptionKey }}
           envFrom:
@@ -50,24 +50,24 @@ spec:
                 name: {{ include "ftl.fullname" . }}-secrets
           {{- end }}
           env:
-            {{- if .Values.schema-mirror.env }}
-            {{- toYaml .Values.schema-mirror.env | nindent 12 }}
+            {{- if .Values.schemaMirror.env }}
+            {{- toYaml .Values.schemaMirror.env | nindent 12 }}
             {{- end }}
             - name: FTL_BIND
-              value: "http://0.0.0.0:{{ .Values.schema-mirror.services.schema-mirror.port }}"
+              value: "http://0.0.0.0:{{ .Values.schemaMirror.service.port }}"
             - name: LOG_LEVEL
-              value: "{{ .Values.schema-mirror.logLevel | default .Values.logLevel }}"
+              value: "{{ .Values.schemaMirror.logLevel | default .Values.logLevel }}"
             - name: LOG_JSON
-              value: "{{ .Values.schema-mirror.logJson | default .Values.logJson }}"
+              value: "{{ .Values.schemaMirror.logJson | default .Values.logJson }}"
             - name: FTL_TIMELINE_ENDPOINT
               value: "http://{{ include "ftl.fullname" . }}-timeline:{{ .Values.timeline.port }}"
             - name: FTL_REALM
               value: {{ .Values.realmName }}
           ports:
             - name: http2
-              containerPort: {{ .Values.schema-mirror.services.schema-mirror.port }}
+              containerPort: {{ .Values.schemaMirror.service.port }}
               protocol: "TCP"
-          {{- include "ftl.resources" .Values.schema-mirror | nindent 10 }}
-          {{- include "ftl.healthProbes" .Values.schema-mirror | nindent 10 }}
-          {{- include "ftl.securityContext" .Values.schema-mirror | nindent 10 }}
-      {{- include "ftl.commonPodConfig" .Values.schema-mirror | nindent 6 }}
+          {{- include "ftl.resources" .Values.schemaMirror | nindent 10 }}
+          {{- include "ftl.healthProbes" .Values.schemaMirror | nindent 10 }}
+          {{- include "ftl.securityContext" .Values.schemaMirror | nindent 10 }}
+      {{- include "ftl.commonPodConfig" .Values.schemaMirror | nindent 6 }}

--- a/charts/ftl/templates/schema-mirror-deployment.yaml
+++ b/charts/ftl/templates/schema-mirror-deployment.yaml
@@ -1,6 +1,6 @@
 {{ $version := printf "v%s" .Chart.Version -}}
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: {{ include "ftl.fullname" . }}-schema-mirror
   labels:

--- a/charts/ftl/templates/schema-mirror-role.yaml
+++ b/charts/ftl/templates/schema-mirror-role.yaml
@@ -1,11 +1,11 @@
-{{- if .Values.schema-mirror.enabled }}
+{{- if .Values.schemaMirror.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.schema-mirror.serviceAccountName }}
+  name: {{ .Values.schemaMirror.serviceAccountName }}
   namespace: {{ .Release.Namespace }}
-  {{- if .Values.schema-mirror.schemaMirrorRoleArn }}
+  {{- if .Values.schemaMirror.schemaMirrorRoleArn }}
   annotations:
-    eks.amazonaws.com/role-arn: {{ .Values.schema-mirror.schemaMirrorRoleArn }}
+    eks.amazonaws.com/role-arn: {{ .Values.schemaMirror.schemaMirrorRoleArn }}
   {{- end }}
 {{- end }}

--- a/charts/ftl/templates/schema-mirror-role.yaml
+++ b/charts/ftl/templates/schema-mirror-role.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.schema-mirror.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.schema-mirror.serviceAccountName }}
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.schema-mirror.schemaMirrorRoleArn }}
+  annotations:
+    eks.amazonaws.com/role-arn: {{ .Values.schema-mirror.schemaMirrorRoleArn }}
+  {{- end }}
+{{- end }}

--- a/charts/ftl/templates/schema-mirror-services.yaml
+++ b/charts/ftl/templates/schema-mirror-services.yaml
@@ -4,15 +4,15 @@ metadata:
   labels:
     {{- include "ftl.labels" . | nindent 4 }}
   name: {{ include "ftl.fullname" . }}-schema-mirror
-  {{- if .Values.schema-mirror.services.schema-mirror.annotations }}
+  {{- if .Values.schemaMirror.service.annotations }}
   annotations:
-    {{- toYaml .Values.schema-mirror.services.schema-mirror.annotations | nindent 4 }}
+    {{- toYaml .Values.schemaMirror.service.annotations | nindent 4 }}
   {{- end }}
 spec:
   ports:
     - name: http2
-      port: {{ .Values.schema-mirror.services.schema-mirror.port }}
+      port: {{ .Values.schemaMirror.service.port }}
       protocol: TCP
   selector:
     {{- include "ftl-schema-mirror.selectorLabels" . | nindent 4 }}
-  type: {{ .Values.schema-mirror.services.schema-mirror.type | default "ClusterIP" }}
+  type: {{ .Values.schemaMirror.service.type | default "ClusterIP" }}

--- a/charts/ftl/templates/schema-mirror-services.yaml
+++ b/charts/ftl/templates/schema-mirror-services.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    {{- include "ftl.labels" . | nindent 4 }}
+  name: {{ include "ftl.fullname" . }}-schema-mirror
+  {{- if .Values.schema-mirror.services.schema.annotations }}
+  annotations:
+    {{- toYaml .Values.schema-mirror.services.schema-mirror.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  ports:
+    - name: http2
+      port: {{ .Values.schema-mirror.services.schema-mirror.port }}
+      protocol: TCP
+  selector:
+    {{- include "ftl-schema-mirror.selectorLabels" . | nindent 4 }}
+  type: {{ .Values.schema-mirror.services.schema-mirror.type | default "ClusterIP" }}

--- a/charts/ftl/templates/schema-mirror-services.yaml
+++ b/charts/ftl/templates/schema-mirror-services.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     {{- include "ftl.labels" . | nindent 4 }}
   name: {{ include "ftl.fullname" . }}-schema-mirror
-  {{- if .Values.schema-mirror.services.schema.annotations }}
+  {{- if .Values.schema-mirror.services.schema-mirror.annotations }}
   annotations:
     {{- toYaml .Values.schema-mirror.services.schema-mirror.annotations | nindent 4 }}
   {{- end }}

--- a/charts/ftl/values.yaml
+++ b/charts/ftl/values.yaml
@@ -261,6 +261,43 @@ schema:
   topologySpreadConstraints: null
   tolerations: null
 
+schema-mirror:
+  enabled: true
+  replicas: 1
+  env: null
+
+  revisionHistoryLimit: 0
+
+  image:
+    repository: null
+    tag: null
+    pullPolicy: null
+    name: "ftl-schema-mirror"
+
+  resources:
+    requests:
+      memory: 256Mi
+      cpu: 10m
+    limits:
+      memory: 256Mi
+      cpu: 2
+
+  envFrom: null
+  serviceAccountName: ftl-schema-mirror
+
+  readinessProbe: null
+
+  services:
+    schema-mirror:
+      type: ClusterIP
+      annotations: null
+      port: 8892
+  podAnnotations: null
+  nodeSelector: null
+  affinity: null
+  topologySpreadConstraints: null
+  tolerations: null
+
 console:
   enabled: true
   env: null

--- a/charts/ftl/values.yaml
+++ b/charts/ftl/values.yaml
@@ -261,7 +261,7 @@ schema:
   topologySpreadConstraints: null
   tolerations: null
 
-schema-mirror:
+schemaMirror:
   enabled: true
   replicas: 1
   env: null
@@ -287,11 +287,9 @@ schema-mirror:
 
   readinessProbe: null
 
-  services:
-    schema-mirror:
-      type: ClusterIP
-      annotations: null
-      port: 8892
+  service:
+    annotations: null
+    port: 8892
   podAnnotations: null
   nodeSelector: null
   affinity: null

--- a/cmd/ftl-schema/main.go
+++ b/cmd/ftl-schema/main.go
@@ -21,14 +21,14 @@ import (
 )
 
 var cli struct {
-	Version             kong.VersionFlag          `help:"Show version."`
-	Bind                *url.URL                  `help:"Socket to bind to." default:"http://127.0.0.1:8892" env:"FTL_BIND"`
-	ObservabilityConfig observability.Config      `embed:"" prefix:"o11y-"`
-	LogConfig           log.Config                `embed:"" prefix:"log-"`
-	SchemaServiceConfig schemaservice.Config      `embed:""`
-	TimelineEndpoint    *url.URL                  `help:"Timeline Service endpoint." env:"FTL_TIMELINE_ENDPOINT" default:"http://127.0.0.1:8898"`
-	MirrorEndpoint      optional.Option[*url.URL] `help:"Schema Mirror endpoint." env:"FTL_SCHEMA_MIRROR_ENDPOINT"`
-	Realm               string                    `help:"Realm to use." env:"FTL_REALM" default:"ftl"`
+	Version             kong.VersionFlag     `help:"Show version."`
+	Bind                *url.URL             `help:"Socket to bind to." default:"http://127.0.0.1:8892" env:"FTL_BIND"`
+	ObservabilityConfig observability.Config `embed:"" prefix:"o11y-"`
+	LogConfig           log.Config           `embed:"" prefix:"log-"`
+	SchemaServiceConfig schemaservice.Config `embed:""`
+	TimelineEndpoint    *url.URL             `help:"Timeline Service endpoint." env:"FTL_TIMELINE_ENDPOINT" default:"http://127.0.0.1:8898"`
+	MirrorEndpoint      *url.URL             `help:"Schema Mirror endpoint." env:"FTL_SCHEMA_MIRROR_ENDPOINT"`
+	Realm               string               `help:"Realm to use." env:"FTL_REALM" default:"ftl"`
 }
 
 func main() {
@@ -49,8 +49,8 @@ func main() {
 	timelineClient := timelineclient.NewClient(ctx, cli.TimelineEndpoint)
 
 	var pushClient optional.Option[ftlv1connect.SchemaMirrorServiceClient]
-	if e, ok := cli.MirrorEndpoint.Get(); ok {
-		pushClient = optional.Some(rpc.Dial(ftlv1connect.NewSchemaMirrorServiceClient, e.String(), log.Debug))
+	if cli.MirrorEndpoint != nil {
+		pushClient = optional.Some(rpc.Dial(ftlv1connect.NewSchemaMirrorServiceClient, cli.MirrorEndpoint.String(), log.Debug))
 	}
 
 	svc := schemaservice.New(ctx, cli.SchemaServiceConfig, timelineClient, pushClient, cli.Realm, false)


### PR DESCRIPTION
- Added schema-mirror
- Runners, ingress and cron use the mirror instead of the actual schema service if schema mirror is enabled
- Schema service pushes to the mirror if it is enabled