### PR TITLE
fix: mirror's schema service readiness depends on whether it is receiving pushes

### DIFF
--- a/backend/schemamirror/mirror_service.go
+++ b/backend/schemamirror/mirror_service.go
@@ -1,0 +1,58 @@
+package schemamirror
+
+import (
+	"context"
+	"sync/atomic"
+
+	"connectrpc.com/connect"
+	"github.com/alecthomas/errors"
+
+	ftlv1 "github.com/block/ftl/backend/protos/xyz/block/ftl/v1"
+	"github.com/block/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
+	"github.com/block/ftl/common/log"
+	"github.com/block/ftl/common/schema"
+	"github.com/block/ftl/internal/schema/schemaeventsource"
+)
+
+type MirrorService struct {
+	receiving   *atomic.Bool
+	eventSource *schemaeventsource.EventSource
+}
+
+func NewMirrorService() *MirrorService {
+	return &MirrorService{
+		receiving:   &atomic.Bool{},
+		eventSource: schemaeventsource.NewUnattached(),
+	}
+}
+
+var _ ftlv1connect.SchemaMirrorServiceHandler = (*MirrorService)(nil)
+
+func (s *MirrorService) Ping(context.Context, *connect.Request[ftlv1.PingRequest]) (*connect.Response[ftlv1.PingResponse], error) {
+	return connect.NewResponse(&ftlv1.PingResponse{}), nil
+}
+
+func (s *MirrorService) PushSchema(ctx context.Context, stream *connect.ClientStream[ftlv1.PushSchemaRequest]) (*connect.Response[ftlv1.PushSchemaResponse], error) {
+	logger := log.FromContext(ctx)
+	if !s.receiving.CompareAndSwap(false, true) {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("mirror is already receiving schema updates"))
+	}
+	defer s.receiving.Store(false)
+
+	logger.Debugf("Started receiving schema stream pushes")
+	for stream.Receive() {
+		req := stream.Msg()
+		notification, err := schema.NotificationFromProto(req.Event)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to convert notification from proto")
+		}
+		err = s.eventSource.Publish(notification)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to publish schema notification")
+		}
+	}
+	if err := stream.Err(); err != nil {
+		return nil, errors.Wrap(err, "failed to receive schema push stream")
+	}
+	return connect.NewResponse(&ftlv1.PushSchemaResponse{}), nil
+}

--- a/backend/schemamirror/schema_service.go
+++ b/backend/schemamirror/schema_service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"maps"
 	"slices"
-	"sync/atomic"
 
 	"connectrpc.com/connect"
 	"github.com/alecthomas/errors"
@@ -12,31 +11,24 @@ import (
 	ftlv1 "github.com/block/ftl/backend/protos/xyz/block/ftl/v1"
 	"github.com/block/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
 	"github.com/block/ftl/common/key"
-	"github.com/block/ftl/common/log"
 	schemapb "github.com/block/ftl/common/protos/xyz/block/ftl/schema/v1"
 	"github.com/block/ftl/common/schema"
 	islices "github.com/block/ftl/common/slices"
 	"github.com/block/ftl/internal/channels"
-	"github.com/block/ftl/internal/schema/schemaeventsource"
 )
 
-type Service struct {
-	receiving   *atomic.Bool
-	eventSource *schemaeventsource.EventSource
+type SchemaService struct {
+	mirror *MirrorService
 }
 
-func New(ctx context.Context) *Service {
-	return &Service{
-		receiving:   &atomic.Bool{},
-		eventSource: schemaeventsource.NewUnattached(),
-	}
+func NewSchemaService(mirror *MirrorService) *SchemaService {
+	return &SchemaService{mirror: mirror}
 }
 
-var _ ftlv1connect.SchemaServiceHandler = (*Service)(nil)
-var _ ftlv1connect.SchemaMirrorServiceHandler = (*Service)(nil)
+var _ ftlv1connect.SchemaServiceHandler = (*SchemaService)(nil)
 
-func (s *Service) Ping(context.Context, *connect.Request[ftlv1.PingRequest]) (*connect.Response[ftlv1.PingResponse], error) {
-	if !s.receiving.Load() {
+func (s *SchemaService) Ping(context.Context, *connect.Request[ftlv1.PingRequest]) (*connect.Response[ftlv1.PingResponse], error) {
+	if !s.mirror.receiving.Load() {
 		reason := "Mirror is not receiving schema push updates"
 		return connect.NewResponse(&ftlv1.PingResponse{
 			NotReady: &reason,
@@ -45,47 +37,28 @@ func (s *Service) Ping(context.Context, *connect.Request[ftlv1.PingRequest]) (*c
 	return connect.NewResponse(&ftlv1.PingResponse{}), nil
 }
 
-func (s *Service) PushSchema(ctx context.Context, stream *connect.ClientStream[ftlv1.PushSchemaRequest]) (*connect.Response[ftlv1.PushSchemaResponse], error) {
-	logger := log.FromContext(ctx)
-	if !s.receiving.CompareAndSwap(false, true) {
-		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("mirror is already receiving schema updates"))
-	}
-	defer s.receiving.Store(false)
-
-	logger.Debugf("Started receiving schema stream pushes")
-	for stream.Receive() {
-		req := stream.Msg()
-		notification, err := schema.NotificationFromProto(req.Event)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to convert notification from proto")
-		}
-		err = s.eventSource.Publish(notification)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to publish schema notification")
-		}
-	}
-	if err := stream.Err(); err != nil {
-		return nil, errors.Wrap(err, "failed to receive schema push stream")
-	}
-	return connect.NewResponse(&ftlv1.PushSchemaResponse{}), nil
-}
-
 // GetSchema gets the full schema.
-func (s *Service) GetSchema(context.Context, *connect.Request[ftlv1.GetSchemaRequest]) (*connect.Response[ftlv1.GetSchemaResponse], error) {
+func (s *SchemaService) GetSchema(context.Context, *connect.Request[ftlv1.GetSchemaRequest]) (*connect.Response[ftlv1.GetSchemaResponse], error) {
+	if !s.mirror.receiving.Load() {
+		return nil, connect.NewError(connect.CodeUnavailable, errors.New("mirror is not receiving schema updates"))
+	}
 	return connect.NewResponse(&ftlv1.GetSchemaResponse{
-		Schema: s.eventSource.CanonicalView().ToProto(),
+		Schema: s.mirror.eventSource.CanonicalView().ToProto(),
 	}), nil
 }
 
 // PullSchema streams changes to the schema.
-func (s *Service) PullSchema(ctx context.Context, req *connect.Request[ftlv1.PullSchemaRequest], stream *connect.ServerStream[ftlv1.PullSchemaResponse]) error {
-	updates := s.eventSource.Subscribe(ctx)
+func (s *SchemaService) PullSchema(ctx context.Context, req *connect.Request[ftlv1.PullSchemaRequest], stream *connect.ServerStream[ftlv1.PullSchemaResponse]) error {
+	if !s.mirror.receiving.Load() {
+		return connect.NewError(connect.CodeUnavailable, errors.New("mirror is not receiving schema updates"))
+	}
+	updates := s.mirror.eventSource.Subscribe(ctx)
 	if err := stream.Send(&ftlv1.PullSchemaResponse{
 		Event: &schemapb.Notification{
 			Value: &schemapb.Notification_FullSchemaNotification{
 				FullSchemaNotification: &schemapb.FullSchemaNotification{
-					Schema: s.eventSource.CanonicalView().ToProto(),
-					Changesets: islices.Map(slices.Collect(maps.Values(s.eventSource.ActiveChangesets())), func(cs *schema.Changeset) *schemapb.Changeset {
+					Schema: s.mirror.eventSource.CanonicalView().ToProto(),
+					Changesets: islices.Map(slices.Collect(maps.Values(s.mirror.eventSource.ActiveChangesets())), func(cs *schema.Changeset) *schemapb.Changeset {
 						return cs.ToProto()
 					}),
 				},
@@ -105,11 +78,14 @@ func (s *Service) PullSchema(ctx context.Context, req *connect.Request[ftlv1.Pul
 }
 
 // GetDeployments is used to get the schema for all deployments.
-func (s *Service) GetDeployments(context.Context, *connect.Request[ftlv1.GetDeploymentsRequest]) (*connect.Response[ftlv1.GetDeploymentsResponse], error) {
+func (s *SchemaService) GetDeployments(context.Context, *connect.Request[ftlv1.GetDeploymentsRequest]) (*connect.Response[ftlv1.GetDeploymentsResponse], error) {
+	if !s.mirror.receiving.Load() {
+		return nil, connect.NewError(connect.CodeUnavailable, errors.New("mirror is not receiving schema updates"))
+	}
 	result := []*ftlv1.DeployedSchema{}
 
 	activeDeployments := map[key.Deployment]*schema.Module{}
-	for _, realm := range s.eventSource.CanonicalView().Realms {
+	for _, realm := range s.mirror.eventSource.CanonicalView().Realms {
 		for _, m := range realm.Modules {
 			d := m.GetRuntime().GetDeployment()
 			if d == nil {
@@ -123,7 +99,7 @@ func (s *Service) GetDeployments(context.Context, *connect.Request[ftlv1.GetDepl
 			})
 		}
 	}
-	for _, cs := range s.eventSource.ActiveChangesets() {
+	for _, cs := range s.mirror.eventSource.ActiveChangesets() {
 		for _, m := range cs.InternalRealm().Modules {
 			d := m.GetRuntime().GetDeployment()
 			if d == nil {
@@ -146,12 +122,15 @@ func (s *Service) GetDeployments(context.Context, *connect.Request[ftlv1.GetDepl
 }
 
 // GetDeployment gets a deployment by deployment key
-func (s *Service) GetDeployment(ctx context.Context, req *connect.Request[ftlv1.GetDeploymentRequest]) (*connect.Response[ftlv1.GetDeploymentResponse], error) {
+func (s *SchemaService) GetDeployment(ctx context.Context, req *connect.Request[ftlv1.GetDeploymentRequest]) (*connect.Response[ftlv1.GetDeploymentResponse], error) {
+	if !s.mirror.receiving.Load() {
+		return nil, connect.NewError(connect.CodeUnavailable, errors.New("mirror is not receiving schema updates"))
+	}
 	deploymentKey, err := key.ParseDeploymentKey(req.Msg.DeploymentKey)
 	if err != nil {
 		return nil, errors.WithStack(connect.NewError(connect.CodeInvalidArgument, errors.Wrap(err, "invalid deployment key")))
 	}
-	for _, realm := range s.eventSource.CanonicalView().Realms {
+	for _, realm := range s.mirror.eventSource.CanonicalView().Realms {
 		for _, m := range realm.Modules {
 			d := m.GetRuntime().GetDeployment()
 			if d == nil {
@@ -164,7 +143,7 @@ func (s *Service) GetDeployment(ctx context.Context, req *connect.Request[ftlv1.
 			}
 		}
 	}
-	for _, cs := range s.eventSource.ActiveChangesets() {
+	for _, cs := range s.mirror.eventSource.ActiveChangesets() {
 		for _, m := range cs.InternalRealm().Modules {
 			d := m.GetRuntime().GetDeployment()
 			if d == nil {
@@ -180,34 +159,34 @@ func (s *Service) GetDeployment(ctx context.Context, req *connect.Request[ftlv1.
 	return nil, errors.Wrapf(err, "failed to find deployment %s", deploymentKey)
 }
 
-func (s *Service) UpdateDeploymentRuntime(context.Context, *connect.Request[ftlv1.UpdateDeploymentRuntimeRequest]) (*connect.Response[ftlv1.UpdateDeploymentRuntimeResponse], error) {
+func (s *SchemaService) UpdateDeploymentRuntime(context.Context, *connect.Request[ftlv1.UpdateDeploymentRuntimeRequest]) (*connect.Response[ftlv1.UpdateDeploymentRuntimeResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("schema mirror is read only"))
 }
 
-func (s *Service) CreateChangeset(context.Context, *connect.Request[ftlv1.CreateChangesetRequest]) (*connect.Response[ftlv1.CreateChangesetResponse], error) {
+func (s *SchemaService) CreateChangeset(context.Context, *connect.Request[ftlv1.CreateChangesetRequest]) (*connect.Response[ftlv1.CreateChangesetResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("schema mirror is read only"))
 }
 
-func (s *Service) PrepareChangeset(context.Context, *connect.Request[ftlv1.PrepareChangesetRequest]) (*connect.Response[ftlv1.PrepareChangesetResponse], error) {
+func (s *SchemaService) PrepareChangeset(context.Context, *connect.Request[ftlv1.PrepareChangesetRequest]) (*connect.Response[ftlv1.PrepareChangesetResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("schema mirror is read only"))
 }
 
-func (s *Service) CommitChangeset(context.Context, *connect.Request[ftlv1.CommitChangesetRequest]) (*connect.Response[ftlv1.CommitChangesetResponse], error) {
+func (s *SchemaService) CommitChangeset(context.Context, *connect.Request[ftlv1.CommitChangesetRequest]) (*connect.Response[ftlv1.CommitChangesetResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("schema mirror is read only"))
 }
 
-func (s *Service) DrainChangeset(context.Context, *connect.Request[ftlv1.DrainChangesetRequest]) (*connect.Response[ftlv1.DrainChangesetResponse], error) {
+func (s *SchemaService) DrainChangeset(context.Context, *connect.Request[ftlv1.DrainChangesetRequest]) (*connect.Response[ftlv1.DrainChangesetResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("schema mirror is read only"))
 }
 
-func (s *Service) FinalizeChangeset(context.Context, *connect.Request[ftlv1.FinalizeChangesetRequest]) (*connect.Response[ftlv1.FinalizeChangesetResponse], error) {
+func (s *SchemaService) FinalizeChangeset(context.Context, *connect.Request[ftlv1.FinalizeChangesetRequest]) (*connect.Response[ftlv1.FinalizeChangesetResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("schema mirror is read only"))
 }
 
-func (s *Service) RollbackChangeset(context.Context, *connect.Request[ftlv1.RollbackChangesetRequest]) (*connect.Response[ftlv1.RollbackChangesetResponse], error) {
+func (s *SchemaService) RollbackChangeset(context.Context, *connect.Request[ftlv1.RollbackChangesetRequest]) (*connect.Response[ftlv1.RollbackChangesetResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("schema mirror is read only"))
 }
 
-func (s *Service) FailChangeset(context.Context, *connect.Request[ftlv1.FailChangesetRequest]) (*connect.Response[ftlv1.FailChangesetResponse], error) {
+func (s *SchemaService) FailChangeset(context.Context, *connect.Request[ftlv1.FailChangesetRequest]) (*connect.Response[ftlv1.FailChangesetResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("schema mirror is read only"))
 }

--- a/cmd/ftl-schema-mirror/main.go
+++ b/cmd/ftl-schema-mirror/main.go
@@ -40,8 +40,11 @@ func main() {
 	err := observability.Init(ctx, false, "", "ftl-schema-mirror", ftl.Version, cli.ObservabilityConfig)
 	kctx.FatalIfErrorf(err, "failed to initialize observability")
 
-	svc := schemamirror.New(ctx)
-	err = rpc.Serve(ctx, cli.Bind, rpc.GRPC(ftlv1connect.NewSchemaMirrorServiceHandler, svc), rpc.GRPC(ftlv1connect.NewSchemaServiceHandler, svc))
+	mirrorSvc := schemamirror.NewMirrorService()
+	schemaSvc := schemamirror.NewSchemaService(mirrorSvc)
+	err = rpc.Serve(ctx, cli.Bind,
+		rpc.GRPC(ftlv1connect.NewSchemaMirrorServiceHandler, mirrorSvc),
+		rpc.GRPC(ftlv1connect.NewSchemaServiceHandler, schemaSvc))
 	logger.Debugf("Listening on %s", cli.Bind)
 	kctx.FatalIfErrorf(err)
 }


### PR DESCRIPTION
Split up the mirror into two service with different availability:
- Mirror service is always available (so that schema service can push to it)
- Schema service is only available when receiving schema pushes