### PR TITLE
chore: rename artefacts package to oci, and storage to OCIArtefactService

### DIFF
--- a/backend/admin/service.go
+++ b/backend/admin/service.go
@@ -32,10 +32,10 @@ import (
 	"github.com/block/ftl/common/schema"
 	"github.com/block/ftl/common/sha256"
 	islices "github.com/block/ftl/common/slices"
-	"github.com/block/ftl/internal/artefacts"
 	"github.com/block/ftl/internal/channels"
 	"github.com/block/ftl/internal/configuration"
 	"github.com/block/ftl/internal/configuration/manager"
+	"github.com/block/ftl/internal/oci"
 	"github.com/block/ftl/internal/routing"
 	"github.com/block/ftl/internal/rpc"
 	"github.com/block/ftl/internal/rpc/headers"
@@ -52,7 +52,7 @@ type Service struct {
 	timelineClient *timelineclient.Client
 	schemaClient   ftlv1connect.SchemaServiceClient
 	source         *schemaeventsource.EventSource
-	storage        *artefacts.OCIArtefactService
+	storage        *oci.OCIArtefactService
 	config         Config
 	routeTable     *routing.VerbCallRouter
 	waitFor        []string
@@ -85,7 +85,7 @@ func NewAdminService(
 	sm *manager.Manager[configuration.Secrets],
 	schr ftlv1connect.SchemaServiceClient,
 	source *schemaeventsource.EventSource,
-	storage *artefacts.OCIArtefactService,
+	storage *oci.OCIArtefactService,
 	routes *routing.VerbCallRouter,
 	timelineClient *timelineclient.Client,
 	waitFor []string,
@@ -726,7 +726,7 @@ func (s *Service) UploadArtefact(ctx context.Context, stream *connect.ClientStre
 		}
 		logger = logger.Scope("uploadArtefact:" + digest.String())
 		logger.Debugf("Starting upload to OCI")
-		err = s.storage.Upload(ctx, artefacts.ArtefactUpload{
+		err = s.storage.Upload(ctx, oci.ArtefactUpload{
 			Digest:  digest,
 			Size:    msg.Size,
 			Content: r,

--- a/backend/provisioner/oci_image_provisioner.go
+++ b/backend/provisioner/oci_image_provisioner.go
@@ -14,18 +14,18 @@ import (
 	"github.com/block/ftl/common/log"
 	"github.com/block/ftl/common/schema"
 	"github.com/block/ftl/common/slices"
-	"github.com/block/ftl/internal/artefacts"
+	"github.com/block/ftl/internal/oci"
 )
 
 // NewRunnerScalingProvisioner creates a new provisioner that provisions resources locally when running FTL in dev mode
 
-func NewOCIImageProvisioner(storage *artefacts.OCIArtefactService, defaultImage string) *InMemProvisioner {
+func NewOCIImageProvisioner(storage *oci.OCIArtefactService, defaultImage string) *InMemProvisioner {
 	return NewEmbeddedProvisioner(map[schema.ResourceType]InMemResourceProvisionerFn{
 		schema.ResourceTypeImage: provisionOCIImage(storage, defaultImage),
 	}, map[schema.ResourceType]InMemResourceProvisionerFn{})
 }
 
-func provisionOCIImage(storage *artefacts.OCIArtefactService, defaultImage string) InMemResourceProvisionerFn {
+func provisionOCIImage(storage *oci.OCIArtefactService, defaultImage string) InMemResourceProvisionerFn {
 	return func(ctx context.Context, changeset key.Changeset, deployment key.Deployment, rc schema.Provisioned, moduleSch *schema.Module) (*schema.RuntimeElement, error) {
 		logger := log.FromContext(ctx)
 		variants := goslices.Collect(slices.FilterVariants[*schema.MetadataArtefact](moduleSch.Metadata))
@@ -65,7 +65,7 @@ func provisionOCIImage(storage *artefacts.OCIArtefactService, defaultImage strin
 		tgt += moduleSch.Name
 		tgt += ":"
 		tgt += tag
-		err = storage.BuildOCIImageFromRemote(ctx, image, tgt, tempDir, moduleSch, variants, artefacts.WithRemotePush())
+		err = storage.BuildOCIImageFromRemote(ctx, image, tgt, tempDir, moduleSch, variants, oci.WithRemotePush())
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to build image")
 		}

--- a/backend/provisioner/registry.go
+++ b/backend/provisioner/registry.go
@@ -15,7 +15,7 @@ import (
 	"github.com/block/ftl/common/plugin"
 	"github.com/block/ftl/common/schema"
 	"github.com/block/ftl/common/slices"
-	"github.com/block/ftl/internal/artefacts"
+	"github.com/block/ftl/internal/oci"
 )
 
 // provisionerPluginConfig is a map of provisioner name to resources it supports
@@ -68,7 +68,7 @@ func (reg *ProvisionerRegistry) listBindings() []*ProvisionerBinding {
 	return result
 }
 
-func registryFromConfig(ctx context.Context, workingDir string, cfg *provisionerPluginConfig, runnerScaling scaling.RunnerScaling, adminClient adminpbconnect.AdminServiceClient, storage *artefacts.OCIArtefactService) (*ProvisionerRegistry, error) {
+func registryFromConfig(ctx context.Context, workingDir string, cfg *provisionerPluginConfig, runnerScaling scaling.RunnerScaling, adminClient adminpbconnect.AdminServiceClient, storage *oci.OCIArtefactService) (*ProvisionerRegistry, error) {
 	logger := log.FromContext(ctx)
 	result := &ProvisionerRegistry{}
 	if err := cfg.Validate(); err != nil {
@@ -85,7 +85,7 @@ func registryFromConfig(ctx context.Context, workingDir string, cfg *provisioner
 	return result, nil
 }
 
-func provisionerIDToProvisioner(ctx context.Context, id string, workingDir string, scaling scaling.RunnerScaling, adminClient adminpbconnect.AdminServiceClient, storage *artefacts.OCIArtefactService) (Plugin, error) {
+func provisionerIDToProvisioner(ctx context.Context, id string, workingDir string, scaling scaling.RunnerScaling, adminClient adminpbconnect.AdminServiceClient, storage *oci.OCIArtefactService) (Plugin, error) {
 	switch id {
 	case "kubernetes":
 		// TODO: move this into a plugin

--- a/backend/provisioner/scaling/localscaling/local_scaling.go
+++ b/backend/provisioner/scaling/localscaling/local_scaling.go
@@ -23,12 +23,12 @@ import (
 	"github.com/block/ftl/common/log"
 	"github.com/block/ftl/common/plugin"
 	"github.com/block/ftl/common/schema"
-	"github.com/block/ftl/internal/artefacts"
 	"github.com/block/ftl/internal/channels"
 	"github.com/block/ftl/internal/deploymentcontext"
 	"github.com/block/ftl/internal/dev"
 	"github.com/block/ftl/internal/download"
 	"github.com/block/ftl/internal/localdebug"
+	"github.com/block/ftl/internal/oci"
 	"github.com/block/ftl/internal/routing"
 	"github.com/block/ftl/internal/rpc"
 )
@@ -51,7 +51,7 @@ type localScaling struct {
 
 	prevRunnerSuffix int
 	ideSupport       optional.Option[localdebug.IDEIntegration]
-	storage          *artefacts.OCIArtefactService
+	storage          *oci.OCIArtefactService
 	enableOtel       bool
 
 	devModeEndpointsUpdates <-chan dev.LocalEndpoint
@@ -190,7 +190,7 @@ func NewLocalScaling(
 	configPath string,
 	enableVSCodeIntegration bool,
 	enableIntellijIntegration bool,
-	storage *artefacts.OCIArtefactService,
+	storage *oci.OCIArtefactService,
 	enableOtel bool,
 	devModeEndpoints <-chan dev.LocalEndpoint,
 	routeTable *routing.RouteTable,
@@ -236,7 +236,7 @@ func (l *localScaling) startRunner(ctx context.Context, deploymentKey key.Deploy
 	default:
 	}
 
-	var deploymentProvider artefacts.DeploymentArtefactProvider
+	var deploymentProvider oci.DeploymentArtefactProvider
 
 	module := info.key.Payload.Module
 	devEndpoint := l.devModeEndpoints[module]

--- a/backend/provisioner/service.go
+++ b/backend/provisioner/service.go
@@ -25,8 +25,8 @@ import (
 	"github.com/block/ftl/common/reflect"
 	"github.com/block/ftl/common/schema"
 	"github.com/block/ftl/common/slices"
-	"github.com/block/ftl/internal/artefacts"
 	"github.com/block/ftl/internal/channels"
+	"github.com/block/ftl/internal/oci"
 	"github.com/block/ftl/internal/schema/schemaeventsource"
 	timeline "github.com/block/ftl/internal/timelineclient"
 )
@@ -198,7 +198,7 @@ func Start(
 	return nil
 }
 
-func RegistryFromConfigFile(ctx context.Context, workingDir string, file *os.File, scaling scaling.RunnerScaling, adminClient adminpbconnect.AdminServiceClient, storage *artefacts.OCIArtefactService) (*ProvisionerRegistry, error) {
+func RegistryFromConfigFile(ctx context.Context, workingDir string, file *os.File, scaling scaling.RunnerScaling, adminClient adminpbconnect.AdminServiceClient, storage *oci.OCIArtefactService) (*ProvisionerRegistry, error) {
 	config := provisionerPluginConfig{}
 	bytes, err := io.ReadAll(bufio.NewReader(file))
 	if err != nil {

--- a/backend/provisioner/sql_migration_provisioner.go
+++ b/backend/provisioner/sql_migration_provisioner.go
@@ -22,20 +22,20 @@ import (
 	"github.com/block/ftl/common/schema"
 	"github.com/block/ftl/common/sha256"
 	"github.com/block/ftl/common/slices"
-	"github.com/block/ftl/internal/artefacts"
 	"github.com/block/ftl/internal/dsn"
+	"github.com/block/ftl/internal/oci"
 )
 
 const tenMB = 1024 * 1024 * 10
 
 // NewSQLMigrationProvisioner creates a new provisioner that provisions database migrations
-func NewSQLMigrationProvisioner(storage *artefacts.OCIArtefactService) *InMemProvisioner {
+func NewSQLMigrationProvisioner(storage *oci.OCIArtefactService) *InMemProvisioner {
 	return NewEmbeddedProvisioner(map[schema.ResourceType]InMemResourceProvisionerFn{
 		schema.ResourceTypeSQLMigration: provisionSQLMigration(storage),
 	}, make(map[schema.ResourceType]InMemResourceProvisionerFn))
 }
 
-func provisionSQLMigration(storage *artefacts.OCIArtefactService) InMemResourceProvisionerFn {
+func provisionSQLMigration(storage *oci.OCIArtefactService) InMemResourceProvisionerFn {
 	return func(ctx context.Context, changeset key.Changeset, deployment key.Deployment, resource schema.Provisioned, module *schema.Module) (*schema.RuntimeElement, error) {
 		logger := log.FromContext(ctx)
 

--- a/backend/runner/runner.go
+++ b/backend/runner/runner.go
@@ -41,11 +41,11 @@ import (
 	"github.com/block/ftl/common/plugin"
 	"github.com/block/ftl/common/schema"
 	"github.com/block/ftl/common/slices"
-	"github.com/block/ftl/internal/artefacts"
 	"github.com/block/ftl/internal/deploymentcontext"
 	"github.com/block/ftl/internal/dsn"
 	"github.com/block/ftl/internal/exec"
 	ftlobservability "github.com/block/ftl/internal/observability"
+	"github.com/block/ftl/internal/oci"
 	"github.com/block/ftl/internal/pgproxy"
 	"github.com/block/ftl/internal/rpc"
 	timeline "github.com/block/ftl/internal/timelineclient"
@@ -71,7 +71,7 @@ type Config struct {
 	DevModeRunnerSequence int64                   `help:"Runner sequence number for dev mode runner. " hidden:""`
 }
 
-func Start(ctx context.Context, config Config, deploymentArtifactProvider artefacts.DeploymentArtefactProvider, deploymentContextProvider deploymentcontext.DeploymentContextProvider, module *schema.Module) error {
+func Start(ctx context.Context, config Config, deploymentArtifactProvider oci.DeploymentArtefactProvider, deploymentContextProvider deploymentcontext.DeploymentContextProvider, module *schema.Module) error {
 	ctx, doneFunc := context.WithCancelCause(ctx)
 	defer doneFunc(errors.Wrap(context.Canceled, "runner terminated"))
 	hostname, err := os.Hostname()
@@ -201,7 +201,7 @@ type Service struct {
 	readyTime  atomic.Value[time.Time]
 
 	config                    Config
-	deploymentProvider        artefacts.DeploymentArtefactProvider
+	deploymentProvider        oci.DeploymentArtefactProvider
 	deploymentContextProvider <-chan deploymentcontext.DeploymentContext
 	schema                    *schema.Module
 	timelineClient            *timeline.Client

--- a/cmd/ftl-provisioner/main.go
+++ b/cmd/ftl-provisioner/main.go
@@ -15,27 +15,27 @@ import (
 	"github.com/block/ftl/common/log"
 	"github.com/block/ftl/common/schema"
 	"github.com/block/ftl/common/slices"
-	"github.com/block/ftl/internal/artefacts"
 	"github.com/block/ftl/internal/observability"
+	"github.com/block/ftl/internal/oci"
 	_ "github.com/block/ftl/internal/prodinit"
 	"github.com/block/ftl/internal/rpc"
 	timeline "github.com/block/ftl/internal/timelineclient"
 )
 
 var cli struct {
-	Version               kong.VersionFlag         `help:"Show version."`
-	ObservabilityConfig   observability.Config     `embed:"" prefix:"o11y-"`
-	LogConfig             log.Config               `embed:"" prefix:"log-"`
-	ProvisionerConfig     provisioner.Config       `embed:""`
-	ConfigFlag            string                   `name:"config" short:"C" help:"Path to FTL project cf file." env:"FTL_CONFIG" placeholder:"FILE"`
-	RegistryConfig        artefacts.RegistryConfig `prefix:"oci-" embed:""`
-	InstanceName          string                   `help:"Instance name, use to differentiate ownership when there are multiple FTL instances ina cluster." env:"FTL_INSTANCE_NAME" default:"ftl"`
-	UserNamespace         string                   `help:"Namespace to use for user resources." env:"FTL_USER_NAMESPACE"`
-	CronServiceAccount    string                   `help:"Service account for cron." env:"FTL_CRON_SERVICE_ACCOUNT"`
-	ConsoleServiceAccount string                   `help:"Service account for console." env:"FTL_CONSOLE_SERVICE_ACCOUNT"`
-	AdminServiceAccount   string                   `help:"Service account for admin." env:"FTL_ADMIN_SERVICE_ACCOUNT"`
-	HTTPServiceAccount    string                   `help:"Service account for http." env:"FTL_HTTP_SERVICE_ACCOUNT"`
-	DefaultRunnerImage    string                   `help:"Default image to use for a runner." env:"FTL_DEFAULT_RUNNER_IMAGE" default:"ftl0/ftl-runner"`
+	Version               kong.VersionFlag     `help:"Show version."`
+	ObservabilityConfig   observability.Config `embed:"" prefix:"o11y-"`
+	LogConfig             log.Config           `embed:"" prefix:"log-"`
+	ProvisionerConfig     provisioner.Config   `embed:""`
+	ConfigFlag            string               `name:"config" short:"C" help:"Path to FTL project cf file." env:"FTL_CONFIG" placeholder:"FILE"`
+	RegistryConfig        oci.RegistryConfig   `prefix:"oci-" embed:""`
+	InstanceName          string               `help:"Instance name, use to differentiate ownership when there are multiple FTL instances ina cluster." env:"FTL_INSTANCE_NAME" default:"ftl"`
+	UserNamespace         string               `help:"Namespace to use for user resources." env:"FTL_USER_NAMESPACE"`
+	CronServiceAccount    string               `help:"Service account for cron." env:"FTL_CRON_SERVICE_ACCOUNT"`
+	ConsoleServiceAccount string               `help:"Service account for console." env:"FTL_CONSOLE_SERVICE_ACCOUNT"`
+	AdminServiceAccount   string               `help:"Service account for admin." env:"FTL_ADMIN_SERVICE_ACCOUNT"`
+	HTTPServiceAccount    string               `help:"Service account for http." env:"FTL_HTTP_SERVICE_ACCOUNT"`
+	DefaultRunnerImage    string               `help:"Default image to use for a runner." env:"FTL_DEFAULT_RUNNER_IMAGE" default:"ftl0/ftl-runner"`
 }
 
 func main() {
@@ -68,7 +68,7 @@ func main() {
 		}
 	}
 
-	storage, err := artefacts.NewOCIRegistryStorage(ctx, cli.RegistryConfig)
+	storage, err := oci.NewArtefactService(ctx, cli.RegistryConfig)
 	kctx.FatalIfErrorf(err, "failed to create OCI registry storage")
 
 	scaling := k8sscaling.NewK8sScaling(false, cli.InstanceName, mapper, routeTemplate, cli.CronServiceAccount, cli.AdminServiceAccount, cli.ConsoleServiceAccount, cli.HTTPServiceAccount)

--- a/cmd/ftl/cmd_serve.go
+++ b/cmd/ftl/cmd_serve.go
@@ -34,13 +34,13 @@ import (
 	"github.com/block/ftl/common/log"
 	"github.com/block/ftl/common/schema"
 	consolefrontend "github.com/block/ftl/frontend/console"
-	"github.com/block/ftl/internal/artefacts"
 	"github.com/block/ftl/internal/bind"
 	"github.com/block/ftl/internal/configuration"
 	"github.com/block/ftl/internal/configuration/manager"
 	"github.com/block/ftl/internal/dev"
 	"github.com/block/ftl/internal/exec"
 	"github.com/block/ftl/internal/observability"
+	"github.com/block/ftl/internal/oci"
 	"github.com/block/ftl/internal/projectconfig"
 	"github.com/block/ftl/internal/routing"
 	"github.com/block/ftl/internal/rpc"
@@ -53,27 +53,27 @@ type serveCmd struct {
 }
 
 type serveCommonConfig struct {
-	IngressBind         *url.URL                 `help:"HTTP Ingress bind" default:"http://127.0.0.1:8891"`
-	Bind                *url.URL                 `help:"Starting endpoint to bind to and advertise to for all FTL services" default:"http://127.0.0.1:8892"`
-	DBPort              int                      `help:"Port to use for the database." env:"FTL_DB_PORT" default:"15432"`
-	MysqlPort           int                      `help:"Port to use for the MySQL database, if one is required." env:"FTL_MYSQL_PORT" default:"13306"`
-	RegistryPort        int                      `help:"Port to use for the registry." env:"FTL_OCI_REGISTRY_PORT" default:"15000"`
-	RegistryConfig      artefacts.RegistryConfig `prefix:"oci-" hidden:"" embed:""`
-	Background          bool                     `help:"Run in the background." default:"false"`
-	Stop                bool                     `help:"Stop the running FTL instance. Can be used with --background to restart the server" default:"false"`
-	StartupTimeout      time.Duration            `help:"Timeout for the server to start up." default:"10s" env:"FTL_STARTUP_TIMEOUT"`
-	ObservabilityConfig observability.Config     `embed:"" prefix:"o11y-"`
-	DatabaseImage       string                   `help:"The container image to start for the database" default:"postgres:15.10" env:"FTL_DATABASE_IMAGE" hidden:""`
-	RegistryImage       string                   `help:"The container image to start for the image registry" default:"registry:2" env:"FTL_REGISTRY_IMAGE" hidden:""`
-	GrafanaImage        string                   `help:"The container image to start for the automatic Grafana instance" default:"grafana/otel-lgtm" env:"FTL_GRAFANA_IMAGE" hidden:""`
-	EnableGrafana       bool                     `help:"Enable Grafana to view telemetry data." default:"false"`
-	NoConsole           bool                     `help:"Disable the console."`
-	Ingress             ingress.Config           `embed:"" prefix:"ingress-"`
-	Timeline            timeline.Config          `embed:"" prefix:"timeline-"`
-	Console             console.Config           `embed:"" prefix:"console-"`
-	Admin               admin.Config             `embed:"" prefix:"admin-"`
-	Recreate            bool                     `help:"Recreate any stateful resources if they already exist." default:"false"`
-	WaitFor             []string                 `help:"Wait for these modules to be deployed before becoming ready." placeholder:"MODULE"`
+	IngressBind         *url.URL             `help:"HTTP Ingress bind" default:"http://127.0.0.1:8891"`
+	Bind                *url.URL             `help:"Starting endpoint to bind to and advertise to for all FTL services" default:"http://127.0.0.1:8892"`
+	DBPort              int                  `help:"Port to use for the database." env:"FTL_DB_PORT" default:"15432"`
+	MysqlPort           int                  `help:"Port to use for the MySQL database, if one is required." env:"FTL_MYSQL_PORT" default:"13306"`
+	RegistryPort        int                  `help:"Port to use for the registry." env:"FTL_OCI_REGISTRY_PORT" default:"15000"`
+	RegistryConfig      oci.RegistryConfig   `prefix:"oci-" hidden:"" embed:""`
+	Background          bool                 `help:"Run in the background." default:"false"`
+	Stop                bool                 `help:"Stop the running FTL instance. Can be used with --background to restart the server" default:"false"`
+	StartupTimeout      time.Duration        `help:"Timeout for the server to start up." default:"10s" env:"FTL_STARTUP_TIMEOUT"`
+	ObservabilityConfig observability.Config `embed:"" prefix:"o11y-"`
+	DatabaseImage       string               `help:"The container image to start for the database" default:"postgres:15.10" env:"FTL_DATABASE_IMAGE" hidden:""`
+	RegistryImage       string               `help:"The container image to start for the image registry" default:"registry:2" env:"FTL_REGISTRY_IMAGE" hidden:""`
+	GrafanaImage        string               `help:"The container image to start for the automatic Grafana instance" default:"grafana/otel-lgtm" env:"FTL_GRAFANA_IMAGE" hidden:""`
+	EnableGrafana       bool                 `help:"Enable Grafana to view telemetry data." default:"false"`
+	NoConsole           bool                 `help:"Disable the console."`
+	Ingress             ingress.Config       `embed:"" prefix:"ingress-"`
+	Timeline            timeline.Config      `embed:"" prefix:"timeline-"`
+	Console             console.Config       `embed:"" prefix:"console-"`
+	Admin               admin.Config         `embed:"" prefix:"admin-"`
+	Recreate            bool                 `help:"Recreate any stateful resources if they already exist." default:"false"`
+	WaitFor             []string             `help:"Wait for these modules to be deployed before becoming ready." placeholder:"MODULE"`
 	provisioner.CommonProvisionerConfig
 	schemaservice.CommonSchemaServiceConfig
 }
@@ -170,12 +170,12 @@ func (s *serveCommonConfig) run(
 	}
 	rc := s.RegistryConfig
 	if rc.Registry == "" {
-		rc = artefacts.RegistryConfig{
+		rc = oci.RegistryConfig{
 			AllowInsecure: true,
 			Registry:      fmt.Sprintf("127.0.0.1:%d/ftl", s.RegistryPort),
 		}
 	}
-	storage, err := artefacts.NewOCIRegistryStorage(ctx, rc)
+	storage, err := oci.NewArtefactService(ctx, rc)
 	if err != nil {
 		return errors.Wrap(err, "failed to create OCI registry storage")
 	}

--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -17,7 +17,7 @@ import (
 	"github.com/block/ftl/common/key"
 	"github.com/block/ftl/common/log"
 	"github.com/block/ftl/common/schema"
-	"github.com/block/ftl/internal/artefacts"
+	"github.com/block/ftl/internal/oci"
 )
 
 // Artefacts downloads artefacts for a deployment from the Controller.
@@ -73,7 +73,7 @@ func Artefacts(ctx context.Context, client adminpbconnect.AdminServiceClient, ke
 }
 
 // ArtefactsFromOCI downloads artefacts for a deployment from an OCI registry.
-func ArtefactsFromOCI(ctx context.Context, client ftlv1connect.SchemaServiceClient, key key.Deployment, dest string, service *artefacts.OCIArtefactService) error {
+func ArtefactsFromOCI(ctx context.Context, client ftlv1connect.SchemaServiceClient, key key.Deployment, dest string, service *oci.OCIArtefactService) error {
 	logger := log.FromContext(ctx)
 	response, err := client.GetDeployment(ctx, connect.NewRequest(&ftlv1.GetDeploymentRequest{
 		DeploymentKey: key.String(),

--- a/internal/oci/oci_artefact_service.go
+++ b/internal/oci/oci_artefact_service.go
@@ -1,4 +1,4 @@
-package artefacts
+package oci
 
 import (
 	"archive/tar"
@@ -132,8 +132,8 @@ func (r *registryAuth) Authorization() (*authn.AuthConfig, error) {
 	return r.auth.Load(), nil
 }
 
-func NewForTesting() *OCIArtefactService {
-	storage, err := NewOCIRegistryStorage(context.TODO(), RegistryConfig{Registry: "127.0.0.1:15000/ftl-tests", AllowInsecure: true})
+func NewNewArtefactServiceForTesting() *OCIArtefactService {
+	storage, err := NewArtefactService(context.TODO(), RegistryConfig{Registry: "127.0.0.1:15000/ftl-tests", AllowInsecure: true})
 	if err != nil {
 		panic(err)
 	}
@@ -145,7 +145,7 @@ func isECRRepository(repo string) bool {
 	return ecrRegex.MatchString(repo)
 }
 
-func NewOCIRegistryStorage(ctx context.Context, config RegistryConfig) (*OCIArtefactService, error) {
+func NewArtefactService(ctx context.Context, config RegistryConfig) (*OCIArtefactService, error) {
 	// Connect the registry targeting the specified container
 
 	logger := log.FromContext(ctx)


### PR DESCRIPTION
This is in preparation to adding a new serparate ImageService. OCIArtefactService was in oci_registry file, which was confusing. Unifies the naming here