### PR TITLE
chore: forbid os.Getenv

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -99,6 +99,8 @@ linters:
       default-signifies-exhaustive: true
     forbidigo:
       forbid:
+        - pattern: ^os.Getenv$
+          msg: do not use os.Getenv, use Kong's env tag to inject values from main
         - pattern: ^fmt.Errorf$
           msg: use github.com/alecthomas/errors.Errorf or Wrapf
         - pattern: ^context.WithCancel$

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,3 +1,4 @@
+skip_lfs: true
 output:
   - success
   - failure


### PR DESCRIPTION
It's essentially a global variable, except worse. Don't use it.