### PR TITLE
fix: cache downloaded Hermit artefacts, not extracted

### DIFF
--- a/.github/actions/build-cache/action.yml
+++ b/.github/actions/build-cache/action.yml
@@ -27,7 +27,7 @@ runs:
     - name: Restore Hermit Cache
       uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4
       with:
-        path: ${{ runner.os == 'macOS' && '~/Library/Caches/hermit/pkg' || '~/.cache/hermit/pkg' }}
+        path: ${{ runner.os == 'macOS' && '~/Library/Caches/hermit/cache' || '~/.cache/hermit/cache' }}
         key: ${{ runner.os }}-${{ runner.arch }}-hermit-cache-${{ steps.bin-hash.outputs.hash }}
         restore-keys: |
           ${{ runner.os }}-${{ runner.arch }}-hermit-cache-${{ steps.bin-hash.outputs.hash }}

--- a/.github/workflows/writecache.yml
+++ b/.github/workflows/writecache.yml
@@ -38,7 +38,7 @@ jobs:
         if: ${{ steps.hermit-hash.outputs.exists == 0 }}
         uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # ratchet:actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
-          path: ${{ runner.os == 'macOS' && '~/Library/Caches/hermit/pkg' || '~/.cache/hermit/pkg' }}
+          path: ${{ runner.os == 'macOS' && '~/Library/Caches/hermit/cache' || '~/.cache/hermit/cache' }}
           key: ${{ steps.hermit-hash.outputs.key }}
 
   write-pnpm-cache:


### PR DESCRIPTION
This should be slightly faster, as only packages used will be unpacked.