### PR TITLE
refactor: allow timeline client to be a null sink

### DIFF
--- a/backend/cron/service.go
+++ b/backend/cron/service.go
@@ -53,10 +53,10 @@ func (c cronJob) String() string {
 }
 
 type Config struct {
-	Bind                  *url.URL        `help:"Address to bind to." env:"FTL_BIND" default:"http://127.0.0.1:8990"`
-	SchemaServiceEndpoint *url.URL        `name:"ftl-endpoint" help:"Schema Service endpoint." env:"FTL_SCHEMA_ENDPOINT" default:"http://127.0.0.1:8892"`
-	TimelineEndpoint      *url.URL        `help:"Timeline endpoint." env:"FTL_TIMELINE_ENDPOINT" default:"http://127.0.0.1:8892"`
-	Raft                  raft.RaftConfig `embed:"" prefix:"raft-"`
+	Bind                  *url.URL              `help:"Address to bind to." env:"FTL_BIND" default:"http://127.0.0.1:8990"`
+	SchemaServiceEndpoint *url.URL              `name:"ftl-endpoint" help:"Schema Service endpoint." env:"FTL_SCHEMA_ENDPOINT" default:"http://127.0.0.1:8892"`
+	TimelineConfig        timelineclient.Config `embed:""`
+	Raft                  raft.RaftConfig       `embed:"" prefix:"raft-"`
 }
 
 // Start the cron service. Blocks until the context is cancelled.

--- a/backend/cron/service_test.go
+++ b/backend/cron/service_test.go
@@ -66,10 +66,7 @@ func TestCron(t *testing.T) {
 	assert.NoError(t, eventSource.PublishModuleForTest(module))
 
 	ctx := log.ContextWithLogger(context.Background(), log.Configure(os.Stderr, log.Config{Level: log.Trace}))
-	timelineEndpoint, err := url.Parse("http://localhost:8080")
-	assert.NoError(t, err)
-
-	timelineClient := timelineclient.NewClient(ctx, timelineEndpoint)
+	timelineClient := timelineclient.NewClient(ctx, timelineclient.NullConfig)
 	ctx, cancel := context.WithTimeout(ctx, time.Second*5)
 	t.Cleanup(cancel)
 
@@ -78,7 +75,7 @@ func TestCron(t *testing.T) {
 
 	cfg := Config{
 		SchemaServiceEndpoint: schemaEndpoint,
-		TimelineEndpoint:      timelineEndpoint,
+		TimelineConfig:        timelineclient.NullConfig,
 		Raft:                  raft.RaftConfig{},
 	}
 

--- a/backend/ingress/handler_test.go
+++ b/backend/ingress/handler_test.go
@@ -71,9 +71,6 @@ func TestIngress(t *testing.T) {
 	}
 
 	ctx := log.ContextWithNewDefaultLogger(context.Background())
-	timelineEndpoint, err := url.Parse("http://localhost:8080")
-	assert.NoError(t, err)
-
 	for _, test := range []struct {
 		name       string
 		method     string
@@ -126,7 +123,7 @@ func TestIngress(t *testing.T) {
 			svc := &service{
 				view:           syncView(ctx, eventSource),
 				client:         fv,
-				timelineClient: timelineclient.NewClient(ctx, timelineEndpoint),
+				timelineClient: timelineclient.NewClient(ctx, timelineclient.NullConfig),
 				routeTable:     routing.New(ctx, eventSource),
 			}
 			svc.handleHTTP(time.Now(), sch, reqKey, routes, rec, req, fv)

--- a/backend/provisioner/service.go
+++ b/backend/provisioner/service.go
@@ -38,9 +38,9 @@ type CommonProvisionerConfig struct {
 }
 
 type Config struct {
-	SchemaEndpoint   *url.URL `help:"Schema service endpoint." env:"FTL_SCHEMA_ENDPOINT" default:"http://127.0.0.1:8892"`
-	AdminEndpoint    *url.URL `help:"Admin service endpoint." env:"FTL_ENDPOINT" default:"http://127.0.0.1:8892"`
-	TimelineEndpoint *url.URL `help:"Timeline endpoint." env:"FTL_TIMELINE_ENDPOINT" default:"http://127.0.0.1:8892"`
+	SchemaEndpoint *url.URL        `help:"Schema service endpoint." env:"FTL_SCHEMA_ENDPOINT" default:"http://127.0.0.1:8892"`
+	AdminEndpoint  *url.URL        `help:"Admin service endpoint." env:"FTL_ENDPOINT" default:"http://127.0.0.1:8892"`
+	TimelineConfig timeline.Config `embed:""`
 	CommonProvisionerConfig
 }
 

--- a/backend/runner/runner.go
+++ b/backend/runner/runner.go
@@ -58,7 +58,7 @@ type Config struct {
 	HealthBind            *url.URL                `help:"Endpoint the Runner should bind to for health check" env:"FTL_HEALTH_BIND"`
 	Key                   key.Runner              `help:"Runner key (auto)."`
 	LeaseEndpoint         *url.URL                `name:"ftl-lease-endpoint" help:"Lease endpoint endpoint." env:"FTL_LEASE_ENDPOINT" default:"http://127.0.0.1:8895"`
-	TimelineEndpoint      *url.URL                `help:"Timeline endpoint." env:"FTL_TIMELINE_ENDPOINT" default:"http://127.0.0.1:8892"`
+	TimelineConfig        timeline.Config         `embed:""`
 	DeploymentKeepHistory int                     `help:"Number of deployments to keep history for." default:"3"`
 	HeartbeatPeriod       time.Duration           `help:"Minimum period between heartbeats." default:"3s"`
 	HeartbeatJitter       time.Duration           `help:"Jitter to add to heartbeat period." default:"2s"`
@@ -106,7 +106,7 @@ func Start(ctx context.Context, config Config, deploymentArtifactProvider oci.De
 		observability.Runner.StartupFailed(ctx)
 		return errors.Wrap(err, "failed to marshal labels")
 	}
-	timelineClient := timeline.NewClient(ctx, config.TimelineEndpoint)
+	timelineClient := timeline.NewClient(ctx, config.TimelineConfig)
 
 	svc := &Service{
 		key:                       runnerKey,

--- a/cmd/ftl-admin/main.go
+++ b/cmd/ftl-admin/main.go
@@ -25,16 +25,16 @@ import (
 )
 
 var cli struct {
-	Bind                *url.URL             `help:"Socket to bind to." default:"http://127.0.0.1:8892" env:"FTL_BIND"`
-	Version             kong.VersionFlag     `help:"Show version."`
-	ObservabilityConfig observability.Config `embed:"" prefix:"o11y-"`
-	LogConfig           log.Config           `embed:"" prefix:"log-"`
-	AdminConfig         admin.Config         `embed:"" prefix:"admin-"`
-	SchemaEndpoint      *url.URL             `help:"Schema endpoint." env:"FTL_SCHEMA_ENDPOINT" default:"http://127.0.0.1:8892"`
-	TimelineEndpoint    *url.URL             `help:"Timeline endpoint." env:"FTL_TIMELINE_ENDPOINT" default:"http://127.0.0.1:8892"`
-	Realm               string               `help:"Realm name." env:"FTL_REALM" required:""`
-	Config              string               `help:"Path to FTL configuration file." env:"FTL_CONFIG" required:""`
-	RegistryConfig      oci.ArtefactConfig   `embed:"" prefix:"oci-"`
+	Bind                *url.URL              `help:"Socket to bind to." default:"http://127.0.0.1:8892" env:"FTL_BIND"`
+	Version             kong.VersionFlag      `help:"Show version."`
+	ObservabilityConfig observability.Config  `embed:"" prefix:"o11y-"`
+	LogConfig           log.Config            `embed:"" prefix:"log-"`
+	AdminConfig         admin.Config          `embed:"" prefix:"admin-"`
+	SchemaEndpoint      *url.URL              `help:"Schema endpoint." env:"FTL_SCHEMA_ENDPOINT" default:"http://127.0.0.1:8892"`
+	TimelineConfig      timelineclient.Config `embed:""`
+	Realm               string                `help:"Realm name." env:"FTL_REALM" required:""`
+	Config              string                `help:"Path to FTL configuration file." env:"FTL_CONFIG" required:""`
+	RegistryConfig      oci.ArtefactConfig    `embed:"" prefix:"oci-"`
 }
 
 func main() {
@@ -65,7 +65,7 @@ func main() {
 
 	storage, err := oci.NewArtefactService(ctx, cli.RegistryConfig)
 	kctx.FatalIfErrorf(err, "failed to create OCI registry storage")
-	client := timelineclient.NewClient(ctx, cli.TimelineEndpoint)
+	client := timelineclient.NewClient(ctx, cli.TimelineConfig)
 	svc := admin.NewAdminService(cli.AdminConfig, cm, sm, schemaClient, eventSource, storage, routing.NewVerbRouter(ctx, eventSource, client), client, []string{})
 
 	kctx.FatalIfErrorf(err, "failed to start admin service handlers")

--- a/cmd/ftl-console/main.go
+++ b/cmd/ftl-console/main.go
@@ -23,13 +23,13 @@ import (
 )
 
 var cli struct {
-	Version             kong.VersionFlag     `help:"Show version."`
-	Bind                *url.URL             `help:"Socket to bind to." default:"http://127.0.0.1:8892" env:"FTL_BIND"`
-	ObservabilityConfig observability.Config `embed:"" prefix:"o11y-"`
-	LogConfig           log.Config           `embed:"" prefix:"log-"`
-	ConsoleConfig       console.Config       `embed:"" prefix:"console-"`
-	TimelineEndpoint    *url.URL             `help:"Timeline endpoint." env:"FTL_TIMELINE_ENDPOINT" default:"http://127.0.0.1:8892"`
-	AdminEndpoint       *url.URL             `help:"Admin endpoint." env:"FTL_ENDPOINT" default:"http://127.0.0.1:8892"`
+	Version             kong.VersionFlag      `help:"Show version."`
+	Bind                *url.URL              `help:"Socket to bind to." default:"http://127.0.0.1:8892" env:"FTL_BIND"`
+	ObservabilityConfig observability.Config  `embed:"" prefix:"o11y-"`
+	LogConfig           log.Config            `embed:"" prefix:"log-"`
+	ConsoleConfig       console.Config        `embed:"" prefix:"console-"`
+	TimelineConfig      timelineclient.Config `embed:""`
+	AdminEndpoint       *url.URL              `help:"Admin endpoint." env:"FTL_ENDPOINT" default:"http://127.0.0.1:8892"`
 }
 
 func main() {
@@ -43,7 +43,7 @@ func main() {
 	err := observability.Init(ctx, false, "", "ftl-console", ftl.Version, cli.ObservabilityConfig)
 	kctx.FatalIfErrorf(err, "failed to initialize observability")
 
-	timelineClient := timelineclient.NewClient(ctx, cli.TimelineEndpoint)
+	timelineClient := timelineclient.NewClient(ctx, cli.TimelineConfig)
 	adminClient := rpc.Dial(adminpbconnect.NewAdminServiceClient, cli.AdminEndpoint.String(), log.Error)
 	buildEngineClient := rpc.Dial(buildenginepbconnect.NewBuildEngineServiceClient, cli.AdminEndpoint.String(), log.Error)
 	eventSource := schemaeventsource.New(ctx, "console", adminClient)

--- a/cmd/ftl-cron/main.go
+++ b/cmd/ftl-cron/main.go
@@ -39,7 +39,7 @@ func main() {
 	schemaClient := rpc.Dial(ftlv1connect.NewSchemaServiceClient, cli.CronConfig.SchemaServiceEndpoint.String(), log.Error)
 	eventSource := schemaeventsource.New(ctx, "cron", schemaClient)
 
-	timelineClient := timelineclient.NewClient(ctx, cli.CronConfig.TimelineEndpoint)
+	timelineClient := timelineclient.NewClient(ctx, cli.CronConfig.TimelineConfig)
 	routeManager := routing.NewVerbRouter(ctx, eventSource, timelineClient)
 
 	err = cron.Start(ctx, cli.CronConfig, eventSource, routeManager, timelineClient)

--- a/cmd/ftl-http-ingress/main.go
+++ b/cmd/ftl-http-ingress/main.go
@@ -20,13 +20,13 @@ import (
 )
 
 var cli struct {
-	Bind                 *url.URL             `help:"Socket to bind to for ingress." default:"http://127.0.0.1:8892" env:"FTL_BIND"`
-	Version              kong.VersionFlag     `help:"Show version."`
-	ObservabilityConfig  observability.Config `embed:"" prefix:"o11y-"`
-	LogConfig            log.Config           `embed:"" prefix:"log-"`
-	HTTPIngressConfig    ingress.Config       `embed:""`
-	SchemaServerEndpoint *url.URL             `name:"ftl-endpoint" help:"Controller endpoint." env:"FTL_SCHEMA_ENDPOINT" default:"http://127.0.0.1:8892"`
-	TimelineEndpoint     *url.URL             `help:"Timeline endpoint." env:"FTL_TIMELINE_ENDPOINT" default:"http://127.0.0.1:8892"`
+	Bind                 *url.URL              `help:"Socket to bind to for ingress." default:"http://127.0.0.1:8892" env:"FTL_BIND"`
+	Version              kong.VersionFlag      `help:"Show version."`
+	ObservabilityConfig  observability.Config  `embed:"" prefix:"o11y-"`
+	LogConfig            log.Config            `embed:"" prefix:"log-"`
+	HTTPIngressConfig    ingress.Config        `embed:""`
+	SchemaServerEndpoint *url.URL              `name:"ftl-endpoint" help:"Controller endpoint." env:"FTL_SCHEMA_ENDPOINT" default:"http://127.0.0.1:8892"`
+	TimelineConfig       timelineclient.Config `embed:""`
 }
 
 func main() {
@@ -41,7 +41,7 @@ func main() {
 	kctx.FatalIfErrorf(err, "failed to initialize observability")
 
 	schemaClient := rpc.Dial(ftlv1connect.NewSchemaServiceClient, cli.SchemaServerEndpoint.String(), log.Error)
-	timelineClient := timelineclient.NewClient(ctx, cli.TimelineEndpoint)
+	timelineClient := timelineclient.NewClient(ctx, cli.TimelineConfig)
 	eventSource := schemaeventsource.New(ctx, "http-ingress", schemaClient)
 	routeManager := routing.NewVerbRouter(ctx, eventSource, timelineClient)
 	err = ingress.Start(ctx, cli.Bind, cli.HTTPIngressConfig, eventSource, routeManager, timelineClient)

--- a/cmd/ftl-provisioner-cloudformation/provisioner.go
+++ b/cmd/ftl-provisioner-cloudformation/provisioner.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"context"
-	"net/url"
 	"strconv"
 	"time"
 
@@ -44,7 +43,7 @@ type Config struct {
 	DatabaseSecurityGroup string `help:"SG for databases" env:"FTL_PROVISIONER_CF_DB_SECURITY_GROUP"`
 	MysqlSecurityGroup    string `help:"SG for mysql" env:"FTL_PROVISIONER_CF_MYSQL_SECURITY_GROUP"`
 
-	TimelineEndpoint *url.URL `help:"Endpoint for the timeline service" env:"FTL_TIMELINE_ENDPOINT"`
+	TimelineConfig timeline.Config `embed:""`
 }
 
 type CloudformationProvisioner struct {
@@ -70,7 +69,7 @@ func NewCloudformationProvisioner(ctx context.Context, config Config) (context.C
 		return nil, nil, errors.Wrap(err, "failed to create secretsmanager client")
 	}
 
-	timelineClient := timeline.NewClient(ctx, config.TimelineEndpoint)
+	timelineClient := timeline.NewClient(ctx, config.TimelineConfig)
 	timelineLogSink := timeline.NewLogSink(timelineClient, log.Debug)
 	go timelineLogSink.RunLogLoop(ctx)
 	logger = logger.AddSink(timelineLogSink)

--- a/cmd/ftl-provisioner-sandbox/provisioner.go
+++ b/cmd/ftl-provisioner-sandbox/provisioner.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"net/url"
 
 	"connectrpc.com/connect"
 	errors "github.com/alecthomas/errors"
@@ -30,7 +29,7 @@ type Config struct {
 	MySQLEndpoint             string   `help:"Endpoint for the mysql database" env:"FTL_SANDBOX_MYSQL_ENDPOINT"`
 	KafkaBrokers              []string `help:"Brokers for the kafka cluster" env:"FTL_SANDBOX_KAFKA_BROKERS"`
 
-	TimelineEndpoint *url.URL `help:"Endpoint for the timeline service" env:"FTL_TIMELINE_ENDPOINT"`
+	TimelineConfig timeline.Config `embed:""`
 }
 
 type SandboxProvisioner struct {
@@ -51,7 +50,7 @@ func NewSandboxProvisioner(ctx context.Context, config Config) (context.Context,
 		return nil, nil, errors.Wrap(err, "failed to create secretsmanager client")
 	}
 
-	timelineClient := timeline.NewClient(ctx, config.TimelineEndpoint)
+	timelineClient := timeline.NewClient(ctx, config.TimelineConfig)
 	timelineLogSink := timeline.NewLogSink(timelineClient, log.Debug)
 	go timelineLogSink.RunLogLoop(ctx)
 	logger = logger.AddSink(timelineLogSink)

--- a/cmd/ftl-provisioner/main.go
+++ b/cmd/ftl-provisioner/main.go
@@ -49,7 +49,7 @@ func main() {
 
 	logger := log.Configure(os.Stderr, cli.LogConfig).Scope("provisioner")
 	ctx := log.ContextWithLogger(context.Background(), logger)
-	timelineClient := timeline.NewClient(ctx, cli.ProvisionerConfig.TimelineEndpoint)
+	timelineClient := timeline.NewClient(ctx, cli.ProvisionerConfig.TimelineConfig)
 	adminClient := rpc.Dial(adminpbconnect.NewAdminServiceClient, cli.ProvisionerConfig.AdminEndpoint.String(), log.Error)
 	err := observability.Init(ctx, false, "", "ftl-provisioner", ftl.Version, cli.ObservabilityConfig)
 	kctx.FatalIfErrorf(err, "failed to initialize observability")

--- a/cmd/ftl-schema/main.go
+++ b/cmd/ftl-schema/main.go
@@ -21,14 +21,14 @@ import (
 )
 
 var cli struct {
-	Version             kong.VersionFlag     `help:"Show version."`
-	Bind                *url.URL             `help:"Socket to bind to." default:"http://127.0.0.1:8892" env:"FTL_BIND"`
-	ObservabilityConfig observability.Config `embed:"" prefix:"o11y-"`
-	LogConfig           log.Config           `embed:"" prefix:"log-"`
-	SchemaServiceConfig schemaservice.Config `embed:""`
-	TimelineEndpoint    *url.URL             `help:"Timeline Service endpoint." env:"FTL_TIMELINE_ENDPOINT" default:"http://127.0.0.1:8898"`
-	MirrorEndpoint      *url.URL             `help:"Schema Mirror endpoint." env:"FTL_SCHEMA_MIRROR_ENDPOINT"`
-	Realm               string               `help:"Realm to use." env:"FTL_REALM" default:"ftl"`
+	Version             kong.VersionFlag      `help:"Show version."`
+	Bind                *url.URL              `help:"Socket to bind to." default:"http://127.0.0.1:8892" env:"FTL_BIND"`
+	ObservabilityConfig observability.Config  `embed:"" prefix:"o11y-"`
+	LogConfig           log.Config            `embed:"" prefix:"log-"`
+	SchemaServiceConfig schemaservice.Config  `embed:""`
+	TimelineConfig      timelineclient.Config `embed:""`
+	MirrorEndpoint      *url.URL              `help:"Schema Mirror endpoint." env:"FTL_SCHEMA_MIRROR_ENDPOINT"`
+	Realm               string                `help:"Realm to use." env:"FTL_REALM" default:"ftl"`
 }
 
 func main() {
@@ -46,7 +46,7 @@ func main() {
 	err := observability.Init(ctx, false, "", "ftl-schema", ftl.Version, cli.ObservabilityConfig)
 	kctx.FatalIfErrorf(err, "failed to initialize observability")
 
-	timelineClient := timelineclient.NewClient(ctx, cli.TimelineEndpoint)
+	timelineClient := timelineclient.NewClient(ctx, cli.TimelineConfig)
 
 	var pushClient optional.Option[ftlv1connect.SchemaMirrorServiceClient]
 	if cli.MirrorEndpoint != nil {

--- a/cmd/ftl/app.go
+++ b/cmd/ftl/app.go
@@ -38,12 +38,12 @@ import (
 )
 
 type SharedCLI struct {
-	Version          kong.VersionFlag `help:"Show version."`
-	Project          string           `short:"P" name:"project" help:"Path to FTL project root directory. The git root will be used if not found in the current directory." env:"FTL_PROJECT" placeholder:"DIR" default:""`
-	ConfigFlag       string           `name:"config" short:"C" help:"Path to FTL project configuration file." env:"FTL_CONFIG" placeholder:"FILE"`
-	TimelineEndpoint *url.URL         `help:"Timeline endpoint." env:"FTL_TIMELINE_ENDPOINT" default:"http://127.0.0.1:8892"`
-	AdminEndpoint    *url.URL         `help:"Admin endpoint." env:"FTL_ENDPOINT" default:"http://127.0.0.1:8892"`
-	Trace            string           `help:"File to write golang runtime/trace output to." hidden:""`
+	Version        kong.VersionFlag      `help:"Show version."`
+	Project        string                `short:"P" name:"project" help:"Path to FTL project root directory. The git root will be used if not found in the current directory." env:"FTL_PROJECT" placeholder:"DIR" default:""`
+	ConfigFlag     string                `name:"config" short:"C" help:"Path to FTL project configuration file." env:"FTL_CONFIG" placeholder:"FILE"`
+	TimelineConfig timelineclient.Config `embed:""`
+	AdminEndpoint  *url.URL              `help:"Admin endpoint." env:"FTL_ENDPOINT" default:"http://127.0.0.1:8892"`
+	Trace          string                `help:"File to write golang runtime/trace output to." hidden:""`
 
 	Ping       pingCmd       `cmd:"" help:"Ping the FTL cluster."`
 	Init       initCmd       `cmd:"" help:"Initialize a new FTL project."`
@@ -261,7 +261,7 @@ func makeBindContext(logger *log.Logger, cancel context.CancelCauseFunc, csm *cu
 		kctx.Bind(&cli.SharedCLI)
 
 		err = kctx.BindToProvider(func() (*timelineclient.Client, error) {
-			return timelineclient.NewClient(ctx, cli.TimelineEndpoint), nil
+			return timelineclient.NewClient(ctx, cli.TimelineConfig), nil
 		})
 		kctx.FatalIfErrorf(err)
 		err = kctx.BindToProvider(func() (adminpbconnect.AdminServiceClient, error) {

--- a/cmd/ftl/cmd_mcp.go
+++ b/cmd/ftl/cmd_mcp.go
@@ -20,7 +20,7 @@ type mcpCmd struct{}
 
 func (m mcpCmd) Run(ctx context.Context, k *kong.Kong, projectConfig projectconfig.Config, buildEngineClient buildenginepbconnect.BuildEngineServiceClient,
 	adminClient adminpbconnect.AdminServiceClient, bindContext KongContextBinder) error {
-	timelineClient := rpc.Dial(timelinepbconnect.NewTimelineServiceClient, cli.TimelineEndpoint.String(), log.Error)
+	timelineClient := rpc.Dial(timelinepbconnect.NewTimelineServiceClient, cli.TimelineConfig.TimelineEndpoint.String(), log.Error)
 
 	s := newMCPServer(ctx, k, projectConfig, buildEngineClient, adminClient, timelineClient, bindContext)
 	k.FatalIfErrorf(s.Serve(), "failed to serve MCP")

--- a/cmd/ftl/cmd_serve.go
+++ b/cmd/ftl/cmd_serve.go
@@ -111,7 +111,7 @@ func (s *serveCommonConfig) run(
 	logger := log.FromContext(ctx)
 	services := additionalServices
 
-	timelineClient := timelineclient.NewClient(ctx, s.Bind)
+	timelineClient := timelineclient.NewClient(ctx, timelineclient.Config{TimelineEndpoint: s.Bind})
 	adminClient := rpc.Dial(adminpbconnect.NewAdminServiceClient, s.Bind.String(), log.Error)
 	buildEngineClient := rpc.Dial(buildenginepbconnect.NewBuildEngineServiceClient, s.Bind.String(), log.Error)
 	schemaClient := rpc.Dial(ftlv1connect.NewSchemaServiceClient, s.Bind.String(), log.Error)
@@ -305,7 +305,7 @@ func (s *serveCommonConfig) run(
 		ctx := log.ContextWithLogger(ctx, log.FromContext(ctx).Scope("cron"))
 		c := cron.Config{
 			SchemaServiceEndpoint: s.Bind,
-			TimelineEndpoint:      s.Bind,
+			TimelineConfig:        timelineclient.Config{TimelineEndpoint: s.Bind},
 		}
 		err := cron.Start(ctx, c, schemaEventSource, router, timelineClient)
 		if err != nil {


### PR DESCRIPTION
Set `FTL_TIMELINE_ENDPOINT=discard://` to create a no-op timeline client.

Also DRY timeline config so we get consistent help/envars/etc.