### PR TITLE
chore: don't retry integration tests

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -283,8 +283,7 @@ test-integration *test:
 # Run integration test(s)
 integration-tests *test:
   #!/bin/bash
-  test -z "$CI" && retries=1 || retries=3
-  retry "$retries" /bin/bash -c "go test -vet=off -fullpath -count 1 -v -tags integration -run '^({{test}})$' -p 1 $(git ls-files | grep '_test\.go$' | xargs grep -r -l {{test}} | xargs grep -l '//go:build integration' | xargs -I {} dirname './{}' | tr '\n' ' ')"
+  go test -vet=off -fullpath -count 1 -v -tags integration -run '^({{test}})$' -p 1 $(git ls-files | grep '_test\.go$' | xargs grep -r -l {{test}} | xargs grep -l '//go:build integration' | xargs -I {} dirname './{}' | tr '\n' ' ')
 
 # Alias for infrastructure-tests
 test-infrastructure *test:


### PR DESCRIPTION
We initially did this because dependencies (eg. NPM, Go) would often fail. We're caching basically everything now, so this should be much less frequent.

This still might be a problem for Docker though :(